### PR TITLE
Fix import order

### DIFF
--- a/mcp_clickhouse/__init__.py
+++ b/mcp_clickhouse/__init__.py
@@ -1,8 +1,8 @@
 from .mcp_server import (
+    create_clickhouse_client,
     list_databases,
     list_tables,
     run_select_query,
-    create_clickhouse_client,
 )
 
 __all__ = [

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -1,10 +1,10 @@
-from fastmcp import FastMCP
-from typing import Sequence
-from dotenv import load_dotenv
-import clickhouse_connect
-import os
 import logging
+import os
+from typing import Sequence
 
+import clickhouse_connect
+from dotenv import load_dotenv
+from fastmcp import FastMCP
 
 MCP_SERVER_NAME = "mcp-clickhouse"
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,6 +1,8 @@
 import unittest
+
 from dotenv import load_dotenv
-from mcp_clickhouse import list_databases, list_tables, run_select_query, create_clickhouse_client
+
+from mcp_clickhouse import create_clickhouse_client, list_databases, list_tables, run_select_query
 
 load_dotenv()
 


### PR DESCRIPTION
Fix import order in accordance with [PEP 8](https://peps.python.org/pep-0008/#imports) using `ruff check --select I --fix`.