### PR TITLE
[WIP] adding docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+# Build stage
+FROM debian:bookworm-slim AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    wget \
+    gcc \
+    g++ \
+    make \
+    zlib1g-dev \
+    libffi-dev \
+    libssl-dev \
+    libbz2-dev \
+    liblzma-dev \
+    clang \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download and install Python from source
+ENV PYTHON_VERSION=3.13.2
+RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
+    && tar -xf Python-${PYTHON_VERSION}.tgz \
+    && cd Python-${PYTHON_VERSION} \
+    && ./configure --enable-optimizations \
+    && make -j$(nproc) \
+    && make install \
+    && cd .. \
+    && rm -rf Python-${PYTHON_VERSION} \
+    && rm Python-${PYTHON_VERSION}.tgz
+
+# Create and activate virtual environment
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Install UV package manager
+RUN pip install uv
+
+# Set working directory
+WORKDIR /app
+
+# Copy application files
+COPY . .
+
+# Install dependencies
+RUN uv sync
+
+# Runtime stage
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    zlib1g \
+    libffi8 \
+    libssl3 \
+    libbz2-1.0 \
+    liblzma5 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python from builder
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/lib /usr/local/lib
+COPY --from=builder /usr/local/include /usr/local/include
+
+# Copy virtual environment from builder
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Set working directory
+WORKDIR /app
+
+# Copy application files
+COPY . .
+
+# Expose port
+EXPOSE 18123
+
+# Run the application
+CMD ["python3", "server.py"]

--- a/README.md
+++ b/README.md
@@ -210,6 +210,50 @@ You can set these variables in your environment, in a `.env` file, or in the Cla
 }
 ```
 
+## Running with Docker Compose
+
+You can run the MCP server using Docker Compose with SSE mode. Create a `docker-compose.yml` file with the following configuration:
+
+```yaml
+version: '3.8'
+services:
+  mcp-clickhouse:
+    build: .
+    environment:
+      - CLICKHOUSE_HOST=your-clickhouse-host
+      - CLICKHOUSE_PORT=8443
+      - CLICKHOUSE_USER=your-user
+      - CLICKHOUSE_PASSWORD=your-password
+      - CLICKHOUSE_DATABASE=your-database
+      - CLICKHOUSE_SECURE=true
+      - CLICKHOUSE_VERIFY=true
+    ports:
+      - "28123:28123"
+```
+
+Then run:
+```bash
+docker compose up -d
+```
+
+### MCP Configuration for Docker
+
+When running the MCP server in Docker in SSE, you'll need to configure your MCP client to use `host.docker.internal` when running on the same machine. Update your MCP configuration to use the following URI:
+
+```json
+{
+  "mcpServers": {
+    "mcp-clickhouse": {
+      "type": "sse",
+      "uri": "http://host.docker.internal:28123/sse",
+      "timeout": 60000
+    }
+  }
+}
+```
+
+If you're using Claude Desktop, add this configuration to your `claude_desktop_config.json` file along with the existing configuration.
+
 ### Running tests
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  mcp-clickhouse:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "28123:28123"
+    environment:
+      - CLICKHOUSE_HOST=sql-clickhouse.clickhouse.com
+      - CLICKHOUSE_PORT=8443
+      - CLICKHOUSE_USER=demo
+      - CLICKHOUSE_PASSWORD=
+      - CLICKHOUSE_SECURE=true
+      - CLICKHOUSE_VERIFY=true
+      - CLICKHOUSE_CONNECT_TIMEOUT=30
+      - CLICKHOUSE_SEND_RECEIVE_TIMEOUT=30

--- a/mcp_clickhouse/main.py
+++ b/mcp_clickhouse/main.py
@@ -1,8 +1,15 @@
+import asyncio
+import argparse
+
 from .mcp_server import mcp
 
 
 def main():
     mcp.run()
+
+
+def main_sse():
+    mcp.run(transport="sse")
 
 
 if __name__ == "__main__":

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -46,6 +46,7 @@ class Table:
 
 
 MCP_SERVER_NAME = "mcp-clickhouse"
+SERVER_PORT = 28123
 
 # Configure logging
 logging.basicConfig(
@@ -66,7 +67,7 @@ deps = [
     "pip-system-certs",
 ]
 
-mcp = FastMCP(MCP_SERVER_NAME, dependencies=deps)
+mcp = FastMCP(MCP_SERVER_NAME, dependencies=deps, port=SERVER_PORT)
 
 
 def result_to_table(query_columns, result) -> List[Table]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-clickhouse"
-version = "0.1.7"
+version = "0.1.8"
 description = "An MCP server for ClickHouse."
 readme = "README.md"
 license = "Apache-2.0"
@@ -10,6 +10,7 @@ dependencies = [
      "mcp[cli]>=1.3.0",
      "python-dotenv>=1.0.1",
      "uvicorn>=0.34.0",
+     "uvicorn[standard]>=0.34.0",
      "clickhouse-connect>=0.8.16",
      "pip-system-certs>=4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 
 [project.scripts]
 mcp-clickhouse = "mcp_clickhouse.main:main"
-
+mcp-clickhouse-sse = "mcp_clickhouse.main:main_sse"
 [project.urls]
 Home = "https://github.com/ClickHouse/mcp-clickhouse"
 

--- a/server.py
+++ b/server.py
@@ -1,0 +1,5 @@
+import uvicorn
+from mcp_clickhouse.mcp_server import app
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/server.py
+++ b/server.py
@@ -2,4 +2,4 @@ import uvicorn
 from mcp_clickhouse.mcp_server import app
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8080)
+    uvicorn.run(app, host="0.0.0.0", port=18213)


### PR DESCRIPTION
This pull request introduces Docker support for the MCP ClickHouse server, adds a new SSE (Server-Sent Events) transport mode, and updates the project configuration. Key changes include the addition of a `Dockerfile` and `docker-compose.yml`, updates to the server code for SSE support, and enhancements to the documentation for Docker usage.

### Docker Support
* Added a `Dockerfile` to build a Docker image for the MCP ClickHouse server, including environment variable configuration and dependency installation.
* Introduced a `docker-compose.yml` file for easier deployment, specifying service configuration, ports, and environment variables.

### SSE Transport Mode
* Added an `mcp-clickhouse-sse` script entry point in `pyproject.toml` to run the server with SSE transport.
* Implemented the `main_sse` function in `mcp_clickhouse/main.py` to enable SSE transport.
* Updated `mcp_server.py` to configure the server port and support SSE. [[1]](diffhunk://#diff-23a8211a3be8c450e70035da878eefba8666df8885722cc5d19627d3c38d90b1R49) [[2]](diffhunk://#diff-23a8211a3be8c450e70035da878eefba8666df8885722cc5d19627d3c38d90b1L69-R70)

### Documentation Enhancements
* Updated `README.md` with instructions for running the MCP server using Docker Compose and configuring the MCP client for Docker environments.

### Miscellaneous
* Updated the project version in `pyproject.toml` to `0.1.8` and added `uvicorn[standard]` as a dependency. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R13-R20)
* Added a new `server.py` file to run the server with `uvicorn`.This pull request introduces Docker support for the MCP ClickHouse server and enhances its functionality with a new SSE mode. The changes include creating a Dockerfile, adding Docker Compose support, updating the server to support SSE, and modifying configuration files to reflect these updates.

### Docker Support

* **`Dockerfile`**: Added a multi-stage Dockerfile to build and run the MCP ClickHouse server with dependencies installed in a Python virtual environment. It also configures environment variables for ClickHouse and exposes port 28123 for the server.
* **`docker-compose.yml`**: Introduced a Docker Compose file to simplify running the MCP ClickHouse server with pre-configured environment variables and port mappings.

### SSE Mode Enhancements

* **`mcp_clickhouse/main.py`**: Added a new `main_sse` function to run the server in SSE mode.
* **`mcp_clickhouse/mcp_server.py`**: Updated the server to accept a `port` parameter and set the default port to 28123. [[1]](diffhunk://#diff-23a8211a3be8c450e70035da878eefba8666df8885722cc5d19627d3c38d90b1R49) [[2]](diffhunk://#diff-23a8211a3be8c450e70035da878eefba8666df8885722cc5d19627d3c38d90b1L69-R70)

### Documentation and Configuration Updates

* **`README.md`**: Added instructions for running the MCP server using Docker Compose and configuring the MCP client for SSE mode.
* **`pyproject.toml`**: Updated the version to `0.1.8`, added a new script entry for the SSE mode, and included `uvicorn[standard]` as a dependency. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R13-R20)

### Additional Changes

* **`server.py`**: Added a standalone script to run the server using `uvicorn`.