### PR TITLE
make `list_tables` works with parameterized views, use system tables for metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ClickHouse MCP Server
+
 [![PyPI - Version](https://img.shields.io/pypi/v/mcp-clickhouse)](https://pypi.org/project/mcp-clickhouse)
 
 An MCP server for ClickHouse.
@@ -10,22 +11,22 @@ An MCP server for ClickHouse.
 ### Tools
 
 * `run_select_query`
-  - Execute SQL queries on your ClickHouse cluster.
-  - Input: `sql` (string): The SQL query to execute.
-  - All ClickHouse queries are run with `readonly = 1` to ensure they are safe.
+  * Execute SQL queries on your ClickHouse cluster.
+  * Input: `sql` (string): The SQL query to execute.
+  * All ClickHouse queries are run with `readonly = 1` to ensure they are safe.
 
 * `list_databases`
-  - List all databases on your ClickHouse cluster.
+  * List all databases on your ClickHouse cluster.
 
 * `list_tables`
-  - List all tables in a database.
-  - Input: `database` (string): The name of the database.
+  * List all tables in a database.
+  * Input: `database` (string): The name of the database.
 
 ## Configuration
 
 1. Open the Claude Desktop configuration file located at:
-   - On macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-   - On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
+   * On macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   * On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
 2. Add the following:
 
@@ -89,7 +90,6 @@ Or, if you'd like to try it out with the [ClickHouse SQL Playground](https://sql
 }
 ```
 
-
 3. Locate the command entry for `uv` and replace it with the absolute path to the `uv` executable. This ensures that the correct version of `uv` is used when starting the server. On a mac, you can find this path using `which uv`.
 
 4. Restart Claude Desktop to apply the changes.
@@ -102,7 +102,7 @@ Or, if you'd like to try it out with the [ClickHouse SQL Playground](https://sql
 
 *Note: The use of the `default` user in this context is intended solely for local development purposes.*
 
-```
+```bash
 CLICKHOUSE_HOST=localhost
 CLICKHOUSE_PORT=8123
 CLICKHOUSE_USER=default
@@ -118,36 +118,39 @@ CLICKHOUSE_PASSWORD=clickhouse
 The following environment variables are used to configure the ClickHouse connection:
 
 #### Required Variables
+
 * `CLICKHOUSE_HOST`: The hostname of your ClickHouse server
 * `CLICKHOUSE_USER`: The username for authentication
 * `CLICKHOUSE_PASSWORD`: The password for authentication
 
-> [!CAUTION]  
+> [!CAUTION]
 > It is important to treat your MCP database user as you would any external client connecting to your database, granting only the minimum necessary privileges required for its operation. The use of default or administrative users should be strictly avoided at all times.
 
 #### Optional Variables
+
 * `CLICKHOUSE_PORT`: The port number of your ClickHouse server
-  - Default: `8443` if HTTPS is enabled, `8123` if disabled
-  - Usually doesn't need to be set unless using a non-standard port
+  * Default: `8443` if HTTPS is enabled, `8123` if disabled
+  * Usually doesn't need to be set unless using a non-standard port
 * `CLICKHOUSE_SECURE`: Enable/disable HTTPS connection
-  - Default: `"true"`
-  - Set to `"false"` for non-secure connections
+  * Default: `"true"`
+  * Set to `"false"` for non-secure connections
 * `CLICKHOUSE_VERIFY`: Enable/disable SSL certificate verification
-  - Default: `"true"`
-  - Set to `"false"` to disable certificate verification (not recommended for production)
+  * Default: `"true"`
+  * Set to `"false"` to disable certificate verification (not recommended for production)
 * `CLICKHOUSE_CONNECT_TIMEOUT`: Connection timeout in seconds
-  - Default: `"30"`
-  - Increase this value if you experience connection timeouts
+  * Default: `"30"`
+  * Increase this value if you experience connection timeouts
 * `CLICKHOUSE_SEND_RECEIVE_TIMEOUT`: Send/receive timeout in seconds
-  - Default: `"300"`
-  - Increase this value for long-running queries
+  * Default: `"300"`
+  * Increase this value for long-running queries
 * `CLICKHOUSE_DATABASE`: Default database to use
-  - Default: None (uses server default)
-  - Set this to automatically connect to a specific database
+  * Default: None (uses server default)
+  * Set this to automatically connect to a specific database
 
 #### Example Configurations
 
 For local development with Docker:
+
 ```env
 # Required variables
 CLICKHOUSE_HOST=localhost
@@ -160,6 +163,7 @@ CLICKHOUSE_VERIFY=false
 ```
 
 For ClickHouse Cloud:
+
 ```env
 # Required variables
 CLICKHOUSE_HOST=your-instance.clickhouse.cloud
@@ -172,6 +176,7 @@ CLICKHOUSE_PASSWORD=your-password
 ```
 
 For ClickHouse SQL Playground:
+
 ```env
 CLICKHOUSE_HOST=sql-clickhouse.clickhouse.com
 CLICKHOUSE_USER=demo
@@ -204,6 +209,17 @@ You can set these variables in your environment, in a `.env` file, or in the Cla
   }
 }
 ```
+
+### Running tests
+
+```bash
+uv sync --all-extras --dev # install dev dependencies
+uv run ruff check . # run linting
+
+docker compose up -d test_services # start ClickHouse
+uv run pytest tests
+```
+
 ## YouTube Overview
 
 [![YouTube](http://i.ytimg.com/vi/y9biAm_Fkqw/hqdefault.jpg)](https://www.youtube.com/watch?v=y9biAm_Fkqw)


### PR DESCRIPTION
* make `list_tables` work with parameterized views. You can't run `select *` on parameterized views.
* don't run count(), use the system schema to get row counts. Running count for large tables can be prohibitively expensive.
* add steps for running tests and lints to the README.md
* get the README.md to pass the markdown lints.