### PR TITLE
Refactor chDB prompt to avoid context too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An MCP server for ClickHouse.
 ### chDB Tools
 
 * `run_chdb_select_query`
-  * Execute SQL queries using chDB's embedded OLAP engine.
+  * Execute SQL queries using chDB's embedded ClickHouse engine.
   * Input: `sql` (string): The SQL query to execute.
   * Query data directly from various sources (files, URLs, databases) without ETL processes.
 
@@ -111,7 +111,7 @@ Or, if you'd like to try it out with the [ClickHouse SQL Playground](https://sql
 }
 ```
 
-For chDB (embedded OLAP engine), add the following configuration:
+For chDB (embedded ClickHouse engine), add the following configuration:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An MCP server for ClickHouse.
 ### chDB Tools
 
 * `run_chdb_select_query`
-  * Execute SQL queries using chDB's embedded ClickHouse engine.
+  * Execute SQL queries using [chDB](https://github.com/chdb-io/chdb)'s embedded ClickHouse engine.
   * Input: `sql` (string): The SQL query to execute.
   * Query data directly from various sources (files, URLs, databases) without ETL processes.
 

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -30,7 +30,7 @@ class ClickHouseConfig:
     This class handles all environment variable configuration with sensible defaults
     and type conversion. It provides typed methods for accessing each configuration value.
 
-    Required environment variables:
+    Required environment variables (only when CLICKHOUSE_ENABLED=true):
         CLICKHOUSE_HOST: The hostname of the ClickHouse server
         CLICKHOUSE_USER: The username for authentication
         CLICKHOUSE_PASSWORD: The password for authentication


### PR DESCRIPTION
- Refactor chDB prompt to avoid context too large
- Fix health check error when only chDB enabled
- Explain chDB as "embedded ClickHouse engine" in README