### PR TITLE
Add Multi-Tenancy Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # ClickHouse MCP Server
 
-TO-DO: Update README
-
-
 [![PyPI - Version](https://img.shields.io/pypi/v/mcp-clickhouse)](https://pypi.org/project/mcp-clickhouse)
 
 An MCP server for ClickHouse.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ An MCP server for ClickHouse.
 
 ### ClickHouse Tools
 
+* `list_clickhouse_tenants`
+  * List all clickhouse tenants.
+
 * `run_select_query`
   * Execute SQL queries on your ClickHouse cluster.
   * Input: `sql` (string): The SQL query to execute.
@@ -23,6 +26,9 @@ An MCP server for ClickHouse.
   * Input: `database` (string): The name of the database.
 
 ### chDB Tools
+
+* `list_chdb_tenants`
+  * List all chdb tenants.
 
 * `run_chdb_select_query`
   * Execute SQL queries using [chDB](https://github.com/chdb-io/chdb)'s embedded ClickHouse engine.
@@ -162,6 +168,132 @@ You can also enable both ClickHouse and chDB simultaneously:
         "CLICKHOUSE_SEND_RECEIVE_TIMEOUT": "30",
         "CHDB_ENABLED": "true",
         "CHDB_DATA_PATH": "/path/to/chdb/data"
+      }
+    }
+  }
+}
+```
+
+Multi-tenancy configuration is also supported. This is enabled by defining custom prefixes in front of the base environment variables. The below configuration creates two tenants: `cluster1` and `cluster2`.
+
+```json
+{
+  "mcpServers": {
+    "mcp-clickhouse": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "mcp-clickhouse",
+        "--python",
+        "3.10",
+        "mcp-clickhouse"
+      ],
+      "env": {
+        "cluster1_CLICKHOUSE_HOST": "<clickhouse-host>",
+        "cluster1_CLICKHOUSE_PORT": "<clickhouse-port>",
+        "cluster1_CLICKHOUSE_USER": "<clickhouse-user>",
+        "cluster1_CLICKHOUSE_PASSWORD": "<clickhouse-password>",
+        "cluster1_CLICKHOUSE_SECURE": "true",
+        "cluster1_CLICKHOUSE_VERIFY": "true",
+        "cluster1_CLICKHOUSE_CONNECT_TIMEOUT": "30",
+        "cluster1_CLICKHOUSE_SEND_RECEIVE_TIMEOUT": "30",
+        "cluster1_CHDB_ENABLED": "true",
+        "cluster1_CHDB_DATA_PATH": "/path/to/chdb/data",
+        "cluster2_CLICKHOUSE_HOST": "<clickhouse-host>",
+        "cluster2_CLICKHOUSE_PORT": "<clickhouse-port>",
+        "cluster2_CLICKHOUSE_USER": "<clickhouse-user>",
+        "cluster2_CLICKHOUSE_PASSWORD": "<clickhouse-password>",
+        "cluster2_CLICKHOUSE_SECURE": "true",
+        "cluster2_CLICKHOUSE_VERIFY": "true",
+        "cluster2_CLICKHOUSE_CONNECT_TIMEOUT": "30",
+        "cluster2_CLICKHOUSE_SEND_RECEIVE_TIMEOUT": "30",
+        "cluster2_CHDB_ENABLED": "true",
+        "cluster2_CHDB_DATA_PATH": "/path/to/chdb/data"
+      }
+    }
+  }
+}
+```
+
+If no custom prefix is defined, a `default` tenant is automatically assigned based on the original environment variables. Defining custom tenants using the reserved `default` prefix is not allowed. The below example creates two tenants: `default` and `custom`.
+
+```json
+{
+  "mcpServers": {
+    "mcp-clickhouse": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "mcp-clickhouse",
+        "--python",
+        "3.10",
+        "mcp-clickhouse"
+      ],
+      "env": {
+        "CLICKHOUSE_HOST": "<clickhouse-host>",
+        "CLICKHOUSE_PORT": "<clickhouse-port>",
+        "CLICKHOUSE_USER": "<clickhouse-user>",
+        "CLICKHOUSE_PASSWORD": "<clickhouse-password>",
+        "CLICKHOUSE_SECURE": "true",
+        "CLICKHOUSE_VERIFY": "true",
+        "CLICKHOUSE_CONNECT_TIMEOUT": "30",
+        "CLICKHOUSE_SEND_RECEIVE_TIMEOUT": "30",
+        "CHDB_ENABLED": "true",
+        "CHDB_DATA_PATH": "/path/to/chdb/data",
+        "custom_CLICKHOUSE_HOST": "<clickhouse-host>",
+        "custom_CLICKHOUSE_PORT": "<clickhouse-port>",
+        "custom_CLICKHOUSE_USER": "<clickhouse-user>",
+        "custom_CLICKHOUSE_PASSWORD": "<clickhouse-password>",
+        "custom_CLICKHOUSE_SECURE": "true",
+        "custom_CLICKHOUSE_VERIFY": "true",
+        "custom_CLICKHOUSE_CONNECT_TIMEOUT": "30",
+        "custom_CLICKHOUSE_SEND_RECEIVE_TIMEOUT": "30",
+        "custom_CHDB_ENABLED": "true",
+        "custom_CHDB_DATA_PATH": "/path/to/chdb/data"
+      }
+    }
+  }
+}
+```
+
+The below example will throw an error as `default` prefix is used.
+
+```json
+{
+  "mcpServers": {
+    "mcp-clickhouse": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "mcp-clickhouse",
+        "--python",
+        "3.10",
+        "mcp-clickhouse"
+      ],
+      "env": {
+        "CLICKHOUSE_HOST": "<clickhouse-host>",
+        "CLICKHOUSE_PORT": "<clickhouse-port>",
+        "CLICKHOUSE_USER": "<clickhouse-user>",
+        "CLICKHOUSE_PASSWORD": "<clickhouse-password>",
+        "CLICKHOUSE_SECURE": "true",
+        "CLICKHOUSE_VERIFY": "true",
+        "CLICKHOUSE_CONNECT_TIMEOUT": "30",
+        "CLICKHOUSE_SEND_RECEIVE_TIMEOUT": "30",
+        "CHDB_ENABLED": "true",
+        "CHDB_DATA_PATH": "/path/to/chdb/data",
+        "default_CLICKHOUSE_HOST": "<clickhouse-host>",
+        "default_CLICKHOUSE_PORT": "<clickhouse-port>",
+        "default_CLICKHOUSE_USER": "<clickhouse-user>",
+        "default_CLICKHOUSE_PASSWORD": "<clickhouse-password>",
+        "default_CLICKHOUSE_SECURE": "true",
+        "default_CLICKHOUSE_VERIFY": "true",
+        "default_CLICKHOUSE_CONNECT_TIMEOUT": "30",
+        "default_CLICKHOUSE_SEND_RECEIVE_TIMEOUT": "30",
+        "default_CHDB_ENABLED": "true",
+        "default_CHDB_DATA_PATH": "/path/to/chdb/data"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ClickHouse MCP Server
 
+TO-DO: Update README
+
+
 [![PyPI - Version](https://img.shields.io/pypi/v/mcp-clickhouse)](https://pypi.org/project/mcp-clickhouse)
 
 An MCP server for ClickHouse.

--- a/mcp_clickhouse/__init__.py
+++ b/mcp_clickhouse/__init__.py
@@ -1,4 +1,6 @@
 from .mcp_server import (
+    list_clickhouse_tenants,
+    list_chdb_tenants,
     create_clickhouse_client,
     list_databases,
     list_tables,
@@ -9,6 +11,8 @@ from .mcp_server import (
 )
 
 __all__ = [
+    "list_clickhouse_tenants",
+    "list_chdb_tenants",
     "list_databases",
     "list_tables",
     "run_select_query",

--- a/mcp_clickhouse/main.py
+++ b/mcp_clickhouse/main.py
@@ -1,9 +1,9 @@
 from .mcp_server import mcp
-from .mcp_env import get_config, TransportType
+from .mcp_env import get_mcp_config, TransportType
 
 
 def main():
-    config = get_config()
+    config = get_mcp_config()
     transport = config.mcp_server_transport
 
     # For HTTP and SSE transports, we need to specify host and port

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -50,7 +50,7 @@ class ClickHouseConfig:
     """
     tenant: str
 
-    def __init__(self):
+    def __post_init__(self):
         """Initialize the configuration from environment variables."""
         if self.enabled:
             self._validate_required_vars()
@@ -192,7 +192,7 @@ class ChDBConfig:
     """
     tenant: str
 
-    def __init__(self):
+    def __post_init__(self):
         """Initialize the configuration from environment variables."""
         if self.enabled:
             self._validate_required_vars()

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -242,7 +242,7 @@ def get_mcp_config() -> dict:
     """
     Get the MCP server configuration from environment variables.
     """
-    # Global MCP transport config (single for all tenants)
+    # Global MCP transport config
     MCP_TRANSPORT = os.getenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", TransportType.STDIO.value).lower()
     if MCP_TRANSPORT not in TransportType.values():
         raise ValueError(f"Invalid MCP transport '{MCP_TRANSPORT}'. Valid options: {TransportType.values()}")

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -302,6 +302,12 @@ def get_chdb_config(tenant: str = "default") -> ChDBConfig:
         raise ValueError(f"No ChDB config found for tenant '{tenant}'")
     return _CHDB_TENANTS[tenant]
 
-def list_tenants() -> List[str]:
-    """Get list of all tenant names."""
+def list_clickhouse_tenants() -> List[str]:
+    """Get list of all clickhouse tenant names."""
+    global _CLICKHOUSE_TENANTS
     return [tenant for tenant in _CLICKHOUSE_TENANTS.keys()]
+
+def list_chdb_tenants() -> List[str]:
+    """Get list of all chdb tenant names."""
+    global _CHDB_TENANTS
+    return [tenant for tenant in _CHDB_TENANTS.keys()]

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -215,6 +215,10 @@ def execute_query(query: str):
 def run_select_query(tenant: str, query: str):
     """Run a SELECT query in a ClickHouse database"""
     logger.info(f"Executing SELECT query for tenant '{tenant}': {query}")
+
+    if tenant not in TENANTS:
+        tenant = "default" # TO-DO: Should return some error since tenant does not exist
+        
     try:
         future = QUERY_EXECUTOR[tenant].submit(execute_query, query)
         try:
@@ -324,6 +328,10 @@ def execute_chdb_query(query: str):
 def run_chdb_select_query(tenant: str, query: str):
     """Run SQL in chDB, an in-process ClickHouse engine"""
     logger.info(f"Executing chDB SELECT query for tenant '{tenant}': {query}")
+
+    if tenant not in TENANTS:
+        tenant = "default" # TO-DO: Should return some error since tenant does not exist
+        
     try:
         future = QUERY_EXECUTOR[tenant].submit(execute_chdb_query, query)
         try:

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -255,7 +255,7 @@ def run_select_query(tenant: str, query: str):
         
     logger.info(f"Executing SELECT query for tenant - '{tenant}': {query}")
     try:
-        future = CLICKHOUSE_QUERY_EXECUTOR[tenant].submit(execute_query, {"tenant": tenant, "query": query})
+        future = CLICKHOUSE_QUERY_EXECUTOR[tenant].submit(execute_query, tenant, query)
         try:
             result = future.result(timeout=SELECT_QUERY_TIMEOUT_SECS)
             # Check if we received an error structure from execute_query
@@ -392,7 +392,7 @@ def run_chdb_select_query(tenant: str, query: str):
         
     logger.info(f"Executing chDB SELECT query for tenant - '{tenant}': {query}")
     try:
-        future = CHDB_QUERY_EXECUTOR[tenant].submit(execute_chdb_query, query)
+        future = CHDB_QUERY_EXECUTOR[tenant].submit(execute_chdb_query, tenant, query)
         try:
             result = future.result(timeout=SELECT_QUERY_TIMEOUT_SECS)
             # Check if we received an error structure from execute_chdb_query

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field, asdict, is_dataclass
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
-from mcp_clickhouse.mcp_env import load_clickhouse_configs, load_chdb_configs, list_clickhouse_tenants, list_chdb_tenants, get_config, get_chdb_config
+from mcp_clickhouse.mcp_env import load_clickhouse_configs, load_chdb_configs, get_clickhouse_tenants, get_chdb_tenants, get_config, get_chdb_config
 from mcp_clickhouse.chdb_prompt import CHDB_PROMPT
 
 
@@ -66,8 +66,8 @@ load_clickhouse_configs()
 load_chdb_configs()
 
 # List of Tenants
-CLICKHOUSE_TENANTS = list_clickhouse_tenants()
-CHDB_TENANTS = list_chdb_tenants()
+CLICKHOUSE_TENANTS = get_clickhouse_tenants()
+CHDB_TENANTS = get_chdb_tenants()
 
 # Create ThreadPoolExecutors for each tenant
 CLICKHOUSE_QUERY_EXECUTOR = {
@@ -168,15 +168,15 @@ def chdb_tenant_available(tenant: str):
         return True
     return False
 
-def list_chdb_tenants():
+def list_clickhouse_tenants():
     """List available Clickhouse tenants"""
     global CLICKHOUSE_TENANTS
-    return CLICKHOUSE_TENANTS
+    return json.dumps(CLICKHOUSE_TENANTS)
 
 def list_chdb_tenants():
     """List available chDB tenants"""
     global CHDB_TENANTS
-    return CHDB_TENANTS
+    return json.dumps(CHDB_TENANTS)
 
 def list_databases(tenant: str):
     """List available ClickHouse databases"""

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -170,15 +170,11 @@ def chdb_tenant_available(tenant: str):
 
 def list_databases(tenant: str):
     """List available ClickHouse databases"""
-    logger.info("Listing all databases")
-
     if not clickhouse_tenant_available(tenant):
-        logger.warning(f"List databases not performed for non-existent tenant - '{tenant}'")
-        return {
-            "status": "error",
-            "message": f"List databases not performed for non-existent tenant - '{tenant}'"
-        }
+        logger.warning(f"List databases not performed for invalid tenant - '{tenant}'")
+        raise ToolError(f"List databases not performed for invalid tenant - '{tenant}'")
 
+    logger.info("Listing all databases")
     client = create_clickhouse_client(tenant)
     result = client.command("SHOW DATABASES")
 
@@ -197,11 +193,8 @@ def list_tables(tenant: str, database: str, like: Optional[str] = None, not_like
     row count, and column count."""
 
     if not clickhouse_tenant_available(tenant):
-        logger.warning(f"List tables not performed for non-existent tenant - '{tenant}'")
-        return {
-            "status": "error",
-            "message": f"List tables not performed for non-existent tenant - '{tenant}'"
-        }
+        logger.warning(f"List tables not performed for invalid tenant - '{tenant}'")
+        raise ToolError(f"List tables not performed for invalid tenant - '{tenant}'")
 
     logger.info(f"Listing tables for tenant - '{tenant}' in database '{database}'")
     client = create_clickhouse_client(tenant)
@@ -233,6 +226,10 @@ def list_tables(tenant: str, database: str, like: Optional[str] = None, not_like
 
 
 def execute_query(tenant: str, query: str):
+    if not clickhouse_tenant_available(tenant):
+        logger.warning(f"Query not executed for invalid tenant - '{tenant}'")
+        raise ToolError(f"Query not executed for invalid tenant - '{tenant}'")
+    
     client = create_clickhouse_client(tenant)
     try:
         read_only = get_readonly_setting(client)
@@ -247,11 +244,8 @@ def execute_query(tenant: str, query: str):
 def run_select_query(tenant: str, query: str):
     """Run a SELECT query in a ClickHouse database"""
     if not clickhouse_tenant_available(tenant):
-        logger.warning(f"Query not performed for non-existent tenant - '{tenant}'")
-        return {
-            "status": "error",
-            "message": f"Query not performed for non-existent tenant - '{tenant}'"
-        }
+        logger.warning(f"Select Query not performed for invalid tenant - '{tenant}'")
+        raise ToolError(f"Select Query not performed for invalid tenant - '{tenant}'")
         
     logger.info(f"Executing SELECT query for tenant - '{tenant}': {query}")
     try:
@@ -281,11 +275,8 @@ def run_select_query(tenant: str, query: str):
 
 def create_clickhouse_client(tenant: str):
     if not clickhouse_tenant_available(tenant):
-        logger.warning(f"Clickhouse client not created for non-existent tenant - '{tenant}'")
-        return {
-            "status": "error",
-            "message": f"Clickhouse client not created for non-existent tenant - '{tenant}'"
-        }
+        logger.warning(f"Clickhouse client not created for invalid tenant - '{tenant}'")
+        raise ToolError(f"Clickhouse client not created for invalid tenant - '{tenant}'")
     
     client_config = get_config(tenant).get_client_config()
     logger.info(
@@ -340,11 +331,8 @@ def get_readonly_setting(client) -> str:
 def create_chdb_client(tenant: str):
     """Create a chDB client connection."""
     if not chdb_tenant_available(tenant):
-        logger.warning(f"chDB client not created for non-existent tenant - '{tenant}'")
-        return {
-            "status": "error",
-            "message": f"chDB client not created for non-existent tenant - '{tenant}'"
-        }
+        logger.warning(f"chDB client not created for invalid tenant - '{tenant}'")
+        raise ToolError(f"chDB client not created for invalid tenant - '{tenant}'")
     
     if not get_chdb_config(tenant).enabled:
         raise ValueError(f"chDB is not enabled for tenant - '{tenant}'. Set CHDB_ENABLED=true to enable it.")
@@ -354,11 +342,8 @@ def create_chdb_client(tenant: str):
 def execute_chdb_query(tenant: str, query: str):
     """Execute a query using chDB client."""
     if not chdb_tenant_available(tenant):
-        logger.warning(f"chDB Query not performed for non-existent tenant - '{tenant}'")
-        return {
-            "status": "error",
-            "message": f"chDB Query not performed for non-existent tenant - '{tenant}'"
-        }
+        logger.warning(f"chDB query not executed for invalid tenant - '{tenant}'")
+        raise ToolError(f"chDB query not executed for invalid tenant - '{tenant}'")
 
     client = create_chdb_client(tenant)
     try:
@@ -384,11 +369,8 @@ def execute_chdb_query(tenant: str, query: str):
 def run_chdb_select_query(tenant: str, query: str):
     """Run SQL in chDB, an in-process ClickHouse engine"""
     if not chdb_tenant_available(tenant):
-        logger.warning(f"chDB query not performed for non-existent tenant - '{tenant}'")
-        return {
-            "status": "error",
-            "message": f"chDB query not performed for non-existent tenant - '{tenant}'"
-        }
+        logger.warning(f"chDB query not performed for invalid tenant - '{tenant}'")
+        raise ToolError(f"chDB query not performed for invalid tenant - '{tenant}'")
         
     logger.info(f"Executing chDB SELECT query for tenant - '{tenant}': {query}")
     try:
@@ -425,11 +407,8 @@ def chdb_initial_prompt() -> str:
 def _init_chdb_client(tenant: str):
     """Initialize the global chDB client instance."""
     if not chdb_tenant_available(tenant):
-        logger.warning(f"chDB client not initialised for non-existent tenant - '{tenant}'")
-        return {
-            "status": "error",
-            "message": f"chDB client not initialised for non-existent tenant - '{tenant}'"
-        }
+        logger.warning(f"chDB client not initialised for invalid tenant - '{tenant}'")
+        raise ToolError(f"chDB client not initialised for invalid tenant - '{tenant}'")
     
     try:
         if not get_chdb_config(tenant).enabled:

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -3,7 +3,6 @@ import json
 from typing import Optional, List, Any
 import concurrent.futures
 import atexit
-import os
 
 import clickhouse_connect
 import chdb.session as chs

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -168,6 +168,16 @@ def chdb_tenant_available(tenant: str):
         return True
     return False
 
+def list_chdb_tenants():
+    """List available Clickhouse tenants"""
+    global CLICKHOUSE_TENANTS
+    return CLICKHOUSE_TENANTS
+
+def list_chdb_tenants():
+    """List available chDB tenants"""
+    global CHDB_TENANTS
+    return CHDB_TENANTS
+
 def list_databases(tenant: str):
     """List available ClickHouse databases"""
     if not clickhouse_tenant_available(tenant):
@@ -430,6 +440,7 @@ def _init_chdb_client(tenant: str):
 if not CLICKHOUSE_TENANTS:
     logger.info("ClickHouse tools not registered")
 else:
+    mcp.add_tool(Tool.from_function(list_clickhouse_tenants))
     mcp.add_tool(Tool.from_function(list_databases))
     mcp.add_tool(Tool.from_function(list_tables))
     mcp.add_tool(Tool.from_function(run_select_query))
@@ -443,6 +454,7 @@ else:
         if _chdb_client:
             atexit.register(lambda: _chdb_client.close())
 
+    mcp.add_tool(Tool.from_function(list_chdb_tenants))
     mcp.add_tool(Tool.from_function(run_chdb_select_query))
     chdb_prompt = Prompt.from_function(
         chdb_initial_prompt,

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field, asdict, is_dataclass
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
-from mcp_clickhouse.mcp_env import get_config, get_chdb_config
+from mcp_clickhouse.mcp_env import load_clickhouse_configs, load_chdb_configs, list_tenants, get_config, get_chdb_config
 from mcp_clickhouse.chdb_prompt import CHDB_PROMPT
 
 
@@ -61,11 +61,24 @@ logging.basicConfig(
 )
 logger = logging.getLogger(MCP_SERVER_NAME)
 
-QUERY_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=10)
-atexit.register(lambda: QUERY_EXECUTOR.shutdown(wait=True))
+# List of Tenants
+TENANTS = list_tenants()
+
+# Create a ThreadPoolExecutor per tenant
+QUERY_EXECUTOR = {
+    tenant: concurrent.futures.ThreadPoolExecutor(max_workers=10)
+    for tenant in TENANTS
+}
+
+# Ensure all executors are properly shutdown on exit
+atexit.register(lambda: [executor.shutdown(wait=True) for executor in QUERY_EXECUTOR.values()])
+
+# Default query timeout for selects
 SELECT_QUERY_TIMEOUT_SECS = 30
 
 load_dotenv()
+load_clickhouse_configs()
+load_chdb_configs()
 
 mcp = FastMCP(
     name=MCP_SERVER_NAME,
@@ -85,29 +98,40 @@ async def health_check(request: Request) -> PlainTextResponse:
     Returns OK if the server is running and can connect to ClickHouse.
     """
     try:
-        # Check if ClickHouse is enabled by trying to create config
-        # If ClickHouse is disabled, this will succeed but connection will fail
-        clickhouse_enabled = os.getenv("CLICKHOUSE_ENABLED", "true").lower() == "true"
+        reports = []
 
-        if not clickhouse_enabled:
-            # If ClickHouse is disabled, check chDB status
-            chdb_config = get_chdb_config()
-            if chdb_config.enabled:
-                return PlainTextResponse("OK - MCP server running with chDB enabled")
-            else:
-                # Both ClickHouse and chDB are disabled - this is an error
-                return PlainTextResponse(
-                    "ERROR - Both ClickHouse and chDB are disabled. At least one must be enabled.",
-                    status_code=503,
-                )
+        for tenant in TENANTS:
+            tenant_report = f"Tenant '{tenant}': "
 
-        # Try to create a client connection to verify ClickHouse connectivity
-        client = create_clickhouse_client()
-        version = client.server_version
-        return PlainTextResponse(f"OK - Connected to ClickHouse {version}")
+            # Check if ClickHouse is enabled by trying to create config 
+            # If ClickHouse is disabled, this will succeed but connection will fail
+            try:
+                clickhouse_config = get_config(tenant)
+                if clickhouse_config.enabled:
+                    client = create_clickhouse_client(tenant)
+                    version = client.server_version
+                    tenant_report += f"ClickHouse OK (v{version})"
+                else:
+                    tenant_report += "ClickHouse Disabled"
+            except Exception as e:
+                tenant_report += f"ClickHouse ERROR ({str(e)})"
+
+            # Check chDB status if enabled
+            try:
+                chdb_config = get_chdb_config(tenant)
+                if chdb_config.enabled:
+                    tenant_report += ", chDB OK"
+                else:
+                    tenant_report += ", chDB Disabled"
+            except Exception as e:
+                tenant_report += f", chDB ERROR ({str(e)})"
+
+            reports.append(tenant_report)
+
+        return PlainTextResponse("\n".join(reports))
+
     except Exception as e:
-        # Return 503 Service Unavailable if we can't connect to ClickHouse
-        return PlainTextResponse(f"ERROR - Cannot connect to ClickHouse: {str(e)}", status_code=503)
+        return PlainTextResponse(f"ERROR - Health check failed: {str(e)}", status_code=503)
 
 
 def result_to_table(query_columns, result) -> List[Table]:
@@ -128,10 +152,10 @@ def to_json(obj: Any) -> str:
     return obj
 
 
-def list_databases():
+def list_databases(tenant: str):
     """List available ClickHouse databases"""
     logger.info("Listing all databases")
-    client = create_clickhouse_client()
+    client = create_clickhouse_client(tenant)
     result = client.command("SHOW DATABASES")
 
     # Convert newline-separated string to list and trim whitespace
@@ -140,15 +164,15 @@ def list_databases():
     else:
         databases = [result]
 
-    logger.info(f"Found {len(databases)} databases")
+    logger.info(f"Found {len(databases)} databases for tenant '{tenant}'")
     return json.dumps(databases)
 
 
-def list_tables(database: str, like: Optional[str] = None, not_like: Optional[str] = None):
+def list_tables(tenant: str, database: str, like: Optional[str] = None, not_like: Optional[str] = None):
     """List available ClickHouse tables in a database, including schema, comment,
     row count, and column count."""
-    logger.info(f"Listing tables in database '{database}'")
-    client = create_clickhouse_client()
+    logger.info(f"Listing tables for tenant '{tenant}' in database '{database}'")
+    client = create_clickhouse_client(tenant)
     query = f"SELECT database, name, engine, create_table_query, dependencies_database, dependencies_table, engine_full, sorting_key, primary_key, total_rows, total_bytes, total_bytes_uncompressed, parts, active_parts, total_marks, comment FROM system.tables WHERE database = {format_query_value(database)}"
     if like:
         query += f" AND name LIKE {format_query_value(like)}"
@@ -172,7 +196,7 @@ def list_tables(database: str, like: Optional[str] = None, not_like: Optional[st
             )
         ]
 
-    logger.info(f"Found {len(tables)} tables")
+    logger.info(f"Found {len(tables)} tables for tenant '{tenant}'")
     return [asdict(table) for table in tables]
 
 
@@ -188,38 +212,38 @@ def execute_query(query: str):
         raise ToolError(f"Query execution failed: {str(err)}")
 
 
-def run_select_query(query: str):
+def run_select_query(tenant: str, query: str):
     """Run a SELECT query in a ClickHouse database"""
-    logger.info(f"Executing SELECT query: {query}")
+    logger.info(f"Executing SELECT query for tenant '{tenant}': {query}")
     try:
-        future = QUERY_EXECUTOR.submit(execute_query, query)
+        future = QUERY_EXECUTOR[tenant].submit(execute_query, query)
         try:
             result = future.result(timeout=SELECT_QUERY_TIMEOUT_SECS)
             # Check if we received an error structure from execute_query
             if isinstance(result, dict) and "error" in result:
-                logger.warning(f"Query failed: {result['error']}")
+                logger.warning(f"Query failed for tenant '{tenant}': {result['error']}")
                 # MCP requires structured responses; string error messages can cause
                 # serialization issues leading to BrokenResourceError
                 return {
                     "status": "error",
-                    "message": f"Query failed: {result['error']}",
+                    "message": f"Query failed for tenant '{tenant}': {result['error']}",
                 }
             return result
         except concurrent.futures.TimeoutError:
-            logger.warning(f"Query timed out after {SELECT_QUERY_TIMEOUT_SECS} seconds: {query}")
+            logger.warning(f"Query timed out after {SELECT_QUERY_TIMEOUT_SECS} seconds for tenant '{tenant}': {query}")
             future.cancel()
-            raise ToolError(f"Query timed out after {SELECT_QUERY_TIMEOUT_SECS} seconds")
+            raise ToolError(f"Query timed out after {SELECT_QUERY_TIMEOUT_SECS} seconds for tenant '{tenant}'")
     except ToolError:
         raise
     except Exception as e:
-        logger.error(f"Unexpected error in run_select_query: {str(e)}")
-        raise RuntimeError(f"Unexpected error during query execution: {str(e)}")
+        logger.error(f"Unexpected error in run_select_query for tenant '{tenant}': {str(e)}")
+        raise RuntimeError(f"Unexpected error during query execution for tenant '{tenant}': {str(e)}")
 
 
-def create_clickhouse_client():
-    client_config = get_config().get_client_config()
+def create_clickhouse_client(tenant: str):
+    client_config = get_config(tenant).get_client_config()
     logger.info(
-        f"Creating ClickHouse client connection to {client_config['host']}:{client_config['port']} "
+        f"Creating ClickHouse client connection for tenant '{tenant}', to {client_config['host']}:{client_config['port']} "
         f"as {client_config['username']} "
         f"(secure={client_config['secure']}, verify={client_config['verify']}, "
         f"connect_timeout={client_config['connect_timeout']}s, "
@@ -230,10 +254,10 @@ def create_clickhouse_client():
         client = clickhouse_connect.get_client(**client_config)
         # Test the connection
         version = client.server_version
-        logger.info(f"Successfully connected to ClickHouse server version {version}")
+        logger.info(f"Successfully connected to ClickHouse server version {version} for tenant '{tenant}'")
         return client
     except Exception as e:
-        logger.error(f"Failed to connect to ClickHouse: {str(e)}")
+        logger.error(f"Failed to connect to ClickHouse for tenant '{tenant}': {str(e)}")
         raise
 
 
@@ -267,10 +291,10 @@ def get_readonly_setting(client) -> str:
         return "1"  # Default to basic read-only mode if setting isn't present
 
 
-def create_chdb_client():
+def create_chdb_client(tenant: str):
     """Create a chDB client connection."""
     if not get_chdb_config().enabled:
-        raise ValueError("chDB is not enabled. Set CHDB_ENABLED=true to enable it.")
+        raise ValueError(f"chDB is not enabled for tenant '{tenant}'. Set CHDB_ENABLED=true to enable it.")
     return _chdb_client
 
 
@@ -297,33 +321,33 @@ def execute_chdb_query(query: str):
         return {"error": str(err)}
 
 
-def run_chdb_select_query(query: str):
+def run_chdb_select_query(tenant: str, query: str):
     """Run SQL in chDB, an in-process ClickHouse engine"""
-    logger.info(f"Executing chDB SELECT query: {query}")
+    logger.info(f"Executing chDB SELECT query for tenant '{tenant}': {query}")
     try:
-        future = QUERY_EXECUTOR.submit(execute_chdb_query, query)
+        future = QUERY_EXECUTOR[tenant].submit(execute_chdb_query, query)
         try:
             result = future.result(timeout=SELECT_QUERY_TIMEOUT_SECS)
             # Check if we received an error structure from execute_chdb_query
             if isinstance(result, dict) and "error" in result:
-                logger.warning(f"chDB query failed: {result['error']}")
+                logger.warning(f"chDB query failed for tenant '{tenant}': {result['error']}")
                 return {
                     "status": "error",
-                    "message": f"chDB query failed: {result['error']}",
+                    "message": f"chDB query failed for tenant '{tenant}': {result['error']}",
                 }
             return result
         except concurrent.futures.TimeoutError:
             logger.warning(
-                f"chDB query timed out after {SELECT_QUERY_TIMEOUT_SECS} seconds: {query}"
+                f"chDB query timed out after {SELECT_QUERY_TIMEOUT_SECS} seconds for tenant '{tenant}': {query}"
             )
             future.cancel()
             return {
                 "status": "error",
-                "message": f"chDB query timed out after {SELECT_QUERY_TIMEOUT_SECS} seconds",
+                "message": f"chDB query timed out after {SELECT_QUERY_TIMEOUT_SECS} seconds for tenant '{tenant}'",
             }
     except Exception as e:
-        logger.error(f"Unexpected error in run_chdb_select_query: {e}")
-        return {"status": "error", "message": f"Unexpected error: {e}"}
+        logger.error(f"Unexpected error in run_chdb_select_query for tenant '{tenant}': {e}")
+        return {"status": "error", "message": f"Unexpected error for tenant '{tenant}': {e}"}
 
 
 def chdb_initial_prompt() -> str:
@@ -331,25 +355,26 @@ def chdb_initial_prompt() -> str:
     return CHDB_PROMPT
 
 
-def _init_chdb_client():
+def _init_chdb_client(tenant: str):
     """Initialize the global chDB client instance."""
     try:
-        if not get_chdb_config().enabled:
-            logger.info("chDB is disabled, skipping client initialization")
+        if not get_chdb_config(tenant).enabled:
+            logger.info("chDB is disabled for tenant '{tenant}', skipping client initialization")
             return None
 
-        client_config = get_chdb_config().get_client_config()
+        client_config = get_chdb_config(tenant).get_client_config()
         data_path = client_config["data_path"]
-        logger.info(f"Creating chDB client with data_path={data_path}")
+        logger.info(f"Creating chDB client with data_path={data_path} for tenant '{tenant}'")
         client = chs.Session(path=data_path)
-        logger.info(f"Successfully connected to chDB with data_path={data_path}")
+        logger.info(f"Successfully connected to chDB with data_path={data_path} for tenant '{tenant}'")
         return client
     except Exception as e:
-        logger.error(f"Failed to initialize chDB client: {e}")
+        logger.error(f"Failed to initialize chDB client for tenant '{tenant}': {e}")
         return None
 
 
 # Register tools based on configuration
+# For multi-tenancy, we will use global flags to bypass this
 if os.getenv("CLICKHOUSE_ENABLED", "true").lower() == "true":
     mcp.add_tool(Tool.from_function(list_databases))
     mcp.add_tool(Tool.from_function(list_tables))

--- a/tests/test_chdb_tool.py
+++ b/tests/test_chdb_tool.py
@@ -1,7 +1,7 @@
 import unittest
 
 from dotenv import load_dotenv
-
+from fastmcp.exceptions import ToolError
 from mcp_clickhouse import create_chdb_client, run_chdb_select_query
 
 load_dotenv()
@@ -16,11 +16,13 @@ class TestChDBTools(unittest.TestCase):
         """Test running a simple SELECT query in chDB with wrong tenant."""
         tenant = "wrong_tenant"
         query = "SELECT 1 as test_value"
-        result = run_chdb_select_query(tenant, query)
-        self.assertEqual(result, {
-            "status": "error",
-            "message": f"chDB query not performed for non-existent tenant - '{tenant}'"
-        })
+        with self.assertRaises(ToolError) as cm:
+            run_chdb_select_query(tenant, query)
+
+        self.assertIn(
+            f"chDB query not performed for invalid tenant - '{tenant}'",
+            str(cm.exception)
+        )
 
     def test_run_chdb_select_query_simple(self):
         """Test running a simple SELECT query in chDB."""

--- a/tests/test_chdb_tool.py
+++ b/tests/test_chdb_tool.py
@@ -2,7 +2,7 @@ import unittest
 
 from dotenv import load_dotenv
 from fastmcp.exceptions import ToolError
-from mcp_clickhouse import create_chdb_client, run_chdb_select_query
+from mcp_clickhouse import list_chdb_tenants, create_chdb_client, run_chdb_select_query
 
 load_dotenv()
 
@@ -10,7 +10,12 @@ class TestChDBTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up the environment before chDB tests."""
-        cls.client = create_chdb_client(tenant="example")
+        cls.client = create_chdb_client(tenant="default")
+
+    def test_list_chdb_tenants(self):
+        tenants = list_chdb_tenants()
+        self.assertIn("default", tenants)
+        self.assertEqual(len(tenants), 1)
 
     def test_run_chdb_select_query_wrong_tenant(self):
         """Test running a simple SELECT query in chDB with wrong tenant."""
@@ -26,7 +31,7 @@ class TestChDBTools(unittest.TestCase):
 
     def test_run_chdb_select_query_simple(self):
         """Test running a simple SELECT query in chDB."""
-        tenant = "example"
+        tenant = "default"
         query = "SELECT 1 as test_value"
         result = run_chdb_select_query(tenant, query)
         self.assertIsInstance(result, list)
@@ -34,7 +39,7 @@ class TestChDBTools(unittest.TestCase):
 
     def test_run_chdb_select_query_with_url_table_function(self):
         """Test running a SELECT query with url table function in chDB."""
-        tenant = "example"
+        tenant = "default"
         query = "SELECT COUNT(1) FROM url('https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_0.parquet', 'Parquet')"
         result = run_chdb_select_query(tenant, query)
         print(result)
@@ -43,7 +48,7 @@ class TestChDBTools(unittest.TestCase):
 
     def test_run_chdb_select_query_failure(self):
         """Test running a SELECT query with an error in chDB."""
-        tenant = "example"
+        tenant = "default"
         query = "SELECT * FROM non_existent_table_chDB"
         result = run_chdb_select_query(tenant, query)
         print(result)
@@ -53,7 +58,7 @@ class TestChDBTools(unittest.TestCase):
 
     def test_run_chdb_select_query_empty_result(self):
         """Test running a SELECT query that returns empty result in chDB."""
-        tenant = "example"
+        tenant = "default"
         query = "SELECT 1 WHERE 1 = 0"
         result = run_chdb_select_query(tenant, query)
         print(result)

--- a/tests/test_chdb_tool.py
+++ b/tests/test_chdb_tool.py
@@ -6,18 +6,22 @@ from mcp_clickhouse import create_chdb_client, run_chdb_select_query
 
 load_dotenv()
 
-## TO-DO
-"""
-- Set up multiple tenants
-- Test with wrong tenant -> Should we execute default or not execute?
-"""
-
 class TestChDBTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up the environment before chDB tests."""
         tenant = "example"
         cls.client = create_chdb_client(tenant)
+
+    def test_run_chdb_select_query_wrong_tenant(self):
+        """Test running a simple SELECT query in chDB with wrong tenant."""
+        tenant = "wrong_tenant"
+        query = "SELECT 1 as test_value"
+        result = run_chdb_select_query(tenant, query)
+        self.assertEqual(result, {
+            "status": "error",
+            "message": f"chDB query not performed for non-existent tenant - '{tenant}'"
+        })
 
     def test_run_chdb_select_query_simple(self):
         """Test running a simple SELECT query in chDB."""

--- a/tests/test_chdb_tool.py
+++ b/tests/test_chdb_tool.py
@@ -6,6 +6,12 @@ from mcp_clickhouse import create_chdb_client, run_chdb_select_query
 
 load_dotenv()
 
+## TO-DO
+"""
+- Set up multiple tenants
+- Test with wrong tenant -> Should we execute default or not execute?
+"""
+
 class TestChDBTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_chdb_tool.py
+++ b/tests/test_chdb_tool.py
@@ -6,24 +6,25 @@ from mcp_clickhouse import create_chdb_client, run_chdb_select_query
 
 load_dotenv()
 
+tenant = "example"
 
 class TestChDBTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up the environment before chDB tests."""
-        cls.client = create_chdb_client()
+        cls.client = create_chdb_client(tenant)
 
     def test_run_chdb_select_query_simple(self):
         """Test running a simple SELECT query in chDB."""
         query = "SELECT 1 as test_value"
-        result = run_chdb_select_query(query)
+        result = run_chdb_select_query(tenant, query)
         self.assertIsInstance(result, list)
         self.assertIn("test_value", str(result))
 
     def test_run_chdb_select_query_with_url_table_function(self):
         """Test running a SELECT query with url table function in chDB."""
         query = "SELECT COUNT(1) FROM url('https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_0.parquet', 'Parquet')"
-        result = run_chdb_select_query(query)
+        result = run_chdb_select_query(tenant, query)
         print(result)
         self.assertIsInstance(result, list)
         self.assertIn("1000000", str(result))
@@ -31,7 +32,7 @@ class TestChDBTools(unittest.TestCase):
     def test_run_chdb_select_query_failure(self):
         """Test running a SELECT query with an error in chDB."""
         query = "SELECT * FROM non_existent_table_chDB"
-        result = run_chdb_select_query(query)
+        result = run_chdb_select_query(tenant, query)
         print(result)
         self.assertIsInstance(result, dict)
         self.assertEqual(result["status"], "error")
@@ -40,7 +41,7 @@ class TestChDBTools(unittest.TestCase):
     def test_run_chdb_select_query_empty_result(self):
         """Test running a SELECT query that returns empty result in chDB."""
         query = "SELECT 1 WHERE 1 = 0"
-        result = run_chdb_select_query(query)
+        result = run_chdb_select_query(tenant, query)
         print(result)
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 0)

--- a/tests/test_chdb_tool.py
+++ b/tests/test_chdb_tool.py
@@ -6,16 +6,16 @@ from mcp_clickhouse import create_chdb_client, run_chdb_select_query
 
 load_dotenv()
 
-tenant = "example"
-
 class TestChDBTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up the environment before chDB tests."""
+        tenant = "example"
         cls.client = create_chdb_client(tenant)
 
     def test_run_chdb_select_query_simple(self):
         """Test running a simple SELECT query in chDB."""
+        tenant = "example"
         query = "SELECT 1 as test_value"
         result = run_chdb_select_query(tenant, query)
         self.assertIsInstance(result, list)
@@ -23,6 +23,7 @@ class TestChDBTools(unittest.TestCase):
 
     def test_run_chdb_select_query_with_url_table_function(self):
         """Test running a SELECT query with url table function in chDB."""
+        tenant = "example"
         query = "SELECT COUNT(1) FROM url('https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_0.parquet', 'Parquet')"
         result = run_chdb_select_query(tenant, query)
         print(result)
@@ -31,6 +32,7 @@ class TestChDBTools(unittest.TestCase):
 
     def test_run_chdb_select_query_failure(self):
         """Test running a SELECT query with an error in chDB."""
+        tenant = "example"
         query = "SELECT * FROM non_existent_table_chDB"
         result = run_chdb_select_query(tenant, query)
         print(result)
@@ -40,6 +42,7 @@ class TestChDBTools(unittest.TestCase):
 
     def test_run_chdb_select_query_empty_result(self):
         """Test running a SELECT query that returns empty result in chDB."""
+        tenant = "example"
         query = "SELECT 1 WHERE 1 = 0"
         result = run_chdb_select_query(tenant, query)
         print(result)

--- a/tests/test_chdb_tool.py
+++ b/tests/test_chdb_tool.py
@@ -10,8 +10,7 @@ class TestChDBTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up the environment before chDB tests."""
-        tenant = "example"
-        cls.client = create_chdb_client(tenant)
+        cls.client = create_chdb_client(tenant="example")
 
     def test_run_chdb_select_query_wrong_tenant(self):
         """Test running a simple SELECT query in chDB with wrong tenant."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -91,33 +91,35 @@ def mcp_server():
 @pytest.mark.asyncio
 async def test_list_databases_wrong_tenant(mcp_server):
     """Test the list_databases tool with wrong tenant."""
+    tenant = "wrong_tenant"
     async with Client(mcp_server) as client:
-        result = await client.call_tool("list_databases", {"tenant": "wrong_tenant"})
-        assert result == {
-            "status": "error",
-            "message": "List databases not performed for non-existent tenant - 'wrong_tenant'"
-        }
+        with pytest.raises(ToolError) as exc_info:
+            await client.call_tool("list_databases", {"tenant": tenant})
+        
+        assert f"List databases not performed for invalid tenant - '{tenant}'" in str(exc_info.value)
 
 @pytest.mark.asyncio
-async def test_list_tables_wrong_tenant(mcp_server):
+async def test_list_tables_wrong_tenant(mcp_server, setup_test_database):
     """Test the list_tables tool with wrong tenant."""
+    _, test_db, test_table, _ = setup_test_database
+    tenant = "wrong_tenant"
     async with Client(mcp_server) as client:
-        result = await client.call_tool("list_databases", {"tenant": "wrong_tenant"})
-        assert result == {
-            "status": "error",
-            "message": "List tables not performed for non-existent tenant - 'wrong_tenant'"
-        }
+        with pytest.raises(ToolError) as exc_info:
+            await client.call_tool("list_tables", {"tenant": tenant, "database": test_db})
+        assert f"List tables not performed for invalid tenant - '{tenant}'" in str(exc_info.value)
 
 @pytest.mark.asyncio
-async def test_run_select_query_wrong_tenant(mcp_server):
+async def test_run_select_query_wrong_tenant(mcp_server, setup_test_database):
     """Test the run_select_query tool with wrong tenant."""
+    _, test_db, test_table, _ = setup_test_database
+    tenant = "wrong_tenant"
     async with Client(mcp_server) as client:
-        result = await client.call_tool("list_databases", {"tenant": "wrong_tenant"})
-        assert result == {
-            "status": "error",
-            "message": "Query not performed for non-existent tenant - 'wrong_tenant'"
-        }
+        with pytest.raises(ToolError) as exc_info:
+            await client.call_tool("run_select_query", {"tenant": tenant, "query": f"SELECT COUNT(*) FROM {test_db}.{test_table}",})
+        
+        assert f"Query not performed for invalid tenant - '{tenant}'" in str(exc_info.value)
 
+@pytest.mark.asyncio
 async def test_list_databases(mcp_server, setup_test_database):
     """Test the list_databases tool."""
     test_tenant, test_db, _, _ = setup_test_database

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,6 +17,11 @@ def event_loop():
     yield loop
     loop.close()
 
+## TO-DO
+"""
+- Set up multiple tenants
+- Test with wrong tenant -> Should we execute default or not execute?
+"""
 
 @pytest_asyncio.fixture(scope="module")
 async def setup_test_database():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -120,6 +120,34 @@ async def test_run_select_query_wrong_tenant(mcp_server, setup_test_database):
         assert f"Query not performed for invalid tenant - '{tenant}'" in str(exc_info.value)
 
 @pytest.mark.asyncio
+async def test_list_clickhouse_tenants(mcp_server):
+    """Test the list_clickhouse_tenants tool."""
+    async with Client(mcp_server) as client:
+        result = await client.call_tool("list_clickhouse_tenants")
+
+        # The result should be a list containing at least one item
+        assert len(result) >= 1
+        assert isinstance(result[0].text, str)
+        tenants = json.loads(result[0].text)
+
+        assert "default" in tenants  # default tenant is defined in .env (no prefix)
+        assert "example" in tenants  # example tenant is defined in .env (example prefix)
+
+@pytest.mark.asyncio
+async def test_list_chdb_tenants(mcp_server):
+    """Test the list_chdb_tenants tool."""
+    async with Client(mcp_server) as client:
+        result = await client.call_tool("list_chdb_tenants")
+
+        # The result should be a list containing at least one item
+        assert len(result) >= 1
+        assert isinstance(result[0].text, str)
+        tenants = json.loads(result[0].text)
+        
+        assert "default" in tenants  # default tenant is defined in .env (no prefix)
+        assert "example" in tenants  # example tenant is defined in .env (example prefix)
+
+@pytest.mark.asyncio
 async def test_list_databases(mcp_server, setup_test_database):
     """Test the list_databases tool."""
     test_tenant, test_db, _, _ = setup_test_database

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,7 +9,6 @@ import json
 
 # Load environment variables
 load_dotenv()
-tenant = "example"
 
 @pytest.fixture(scope="module")
 def event_loop():
@@ -22,7 +21,10 @@ def event_loop():
 @pytest_asyncio.fixture(scope="module")
 async def setup_test_database():
     """Set up test database and tables before running tests."""
-    client = create_clickhouse_client(tenant)
+    # Test tenant
+    test_tenant = "example"
+
+    client = create_clickhouse_client(test_tenant)
 
     # Test database and table names
     test_db = "test_mcp_db"
@@ -75,7 +77,7 @@ async def setup_test_database():
         (1003, 'login', '2024-01-01 12:00:00')
     """)
 
-    yield test_db, test_table, test_table2
+    yield test_tenant, test_db, test_table, test_table2
 
     # Cleanup after tests
     client.command(f"DROP DATABASE IF EXISTS {test_db}")
@@ -90,10 +92,10 @@ def mcp_server():
 @pytest.mark.asyncio
 async def test_list_databases(mcp_server, setup_test_database):
     """Test the list_databases tool."""
-    test_db, _, _ = setup_test_database
+    test_tenant, test_db, _, _ = setup_test_database
 
     async with Client(mcp_server) as client:
-        result = await client.call_tool("list_databases", {"tenant": tenant})
+        result = await client.call_tool("list_databases", {"tenant": test_tenant})
 
         # The result should be a list containing at least one item
         assert len(result) >= 1
@@ -108,10 +110,10 @@ async def test_list_databases(mcp_server, setup_test_database):
 @pytest.mark.asyncio
 async def test_list_tables_basic(mcp_server, setup_test_database):
     """Test the list_tables tool without filters."""
-    test_db, test_table, test_table2 = setup_test_database
+    test_tenant, test_db, test_table, test_table2 = setup_test_database
 
     async with Client(mcp_server) as client:
-        result = await client.call_tool("list_tables", {"tenant": tenant, "database": test_db})
+        result = await client.call_tool("list_tables", {"tenant": test_tenant, "database": test_db})
 
         assert len(result) >= 1
         tables = json.loads(result[0].text)
@@ -143,11 +145,11 @@ async def test_list_tables_basic(mcp_server, setup_test_database):
 @pytest.mark.asyncio
 async def test_list_tables_with_like_filter(mcp_server, setup_test_database):
     """Test the list_tables tool with LIKE filter."""
-    test_db, test_table, _ = setup_test_database
+    test_tenant, test_db, test_table, _ = setup_test_database
 
     async with Client(mcp_server) as client:
         # Test with LIKE filter
-        result = await client.call_tool("list_tables", {"tenant": tenant, "database": test_db, "like": "test_%"})
+        result = await client.call_tool("list_tables", {"tenant": test_tenant, "database": test_db, "like": "test_%"})
 
         tables_data = json.loads(result[0].text)
 
@@ -164,11 +166,11 @@ async def test_list_tables_with_like_filter(mcp_server, setup_test_database):
 @pytest.mark.asyncio
 async def test_list_tables_with_not_like_filter(mcp_server, setup_test_database):
     """Test the list_tables tool with NOT LIKE filter."""
-    test_db, _, test_table2 = setup_test_database
+    test_tenant, test_db, _, test_table2 = setup_test_database
 
     async with Client(mcp_server) as client:
         # Test with NOT LIKE filter
-        result = await client.call_tool("list_tables", {"tenant": tenant, "database": test_db, "not_like": "test_%"})
+        result = await client.call_tool("list_tables", {"tenant": test_tenant, "database": test_db, "not_like": "test_%"})
 
         tables_data = json.loads(result[0].text)
 
@@ -185,11 +187,11 @@ async def test_list_tables_with_not_like_filter(mcp_server, setup_test_database)
 @pytest.mark.asyncio
 async def test_run_select_query_success(mcp_server, setup_test_database):
     """Test running a successful SELECT query."""
-    test_db, test_table, _ = setup_test_database
+    test_tenant, test_db, test_table, _ = setup_test_database
 
     async with Client(mcp_server) as client:
         query = f"SELECT id, name, age FROM {test_db}.{test_table} ORDER BY id"
-        result = await client.call_tool("run_select_query", {"tenant": tenant, "query": query})
+        result = await client.call_tool("run_select_query", {"tenant": test_tenant, "query": query})
 
         query_result = json.loads(result[0].text)
 
@@ -211,11 +213,11 @@ async def test_run_select_query_success(mcp_server, setup_test_database):
 @pytest.mark.asyncio
 async def test_run_select_query_with_aggregation(mcp_server, setup_test_database):
     """Test running a SELECT query with aggregation."""
-    test_db, test_table, _ = setup_test_database
+    test_tenant, test_db, test_table, _ = setup_test_database
 
     async with Client(mcp_server) as client:
         query = f"SELECT COUNT(*) as count, AVG(age) as avg_age FROM {test_db}.{test_table}"
-        result = await client.call_tool("run_select_query", {"tenant": tenant, "query": query})
+        result = await client.call_tool("run_select_query", {"tenant": test_tenant, "query": query})
 
         query_result = json.loads(result[0].text)
 
@@ -228,11 +230,11 @@ async def test_run_select_query_with_aggregation(mcp_server, setup_test_database
 @pytest.mark.asyncio
 async def test_run_select_query_with_join(mcp_server, setup_test_database):
     """Test running a SELECT query with JOIN."""
-    test_db, test_table, test_table2 = setup_test_database
+    test_tenant, test_db, test_table, test_table2 = setup_test_database
 
     async with Client(mcp_server) as client:
         # Insert related data for join
-        client_direct = create_clickhouse_client(tenant)
+        client_direct = create_clickhouse_client(test_tenant)
         client_direct.command(f"""
             INSERT INTO {test_db}.{test_table2} (event_id, event_type, timestamp) VALUES
             (2001, 'purchase', '2024-01-01 14:00:00')
@@ -243,7 +245,7 @@ async def test_run_select_query_with_join(mcp_server, setup_test_database):
             COUNT(DISTINCT event_type) as event_types_count
         FROM {test_db}.{test_table2}
         """
-        result = await client.call_tool("run_select_query", {"tenant": tenant, "query": query})
+        result = await client.call_tool("run_select_query", {"tenant": test_tenant, "query": query})
 
         query_result = json.loads(result[0].text)
         assert query_result["rows"][0][0] == 3  # login, logout, purchase
@@ -252,7 +254,7 @@ async def test_run_select_query_with_join(mcp_server, setup_test_database):
 @pytest.mark.asyncio
 async def test_run_select_query_error(mcp_server, setup_test_database):
     """Test running a SELECT query that results in an error."""
-    test_db, _, _ = setup_test_database
+    test_tenant, test_db, _, _ = setup_test_database
 
     async with Client(mcp_server) as client:
         # Query non-existent table
@@ -260,13 +262,15 @@ async def test_run_select_query_error(mcp_server, setup_test_database):
 
         # Should raise ToolError
         with pytest.raises(ToolError) as exc_info:
-            await client.call_tool("run_select_query", {"tenant": tenant, "query": query})
+            await client.call_tool("run_select_query", {"tenant": test_tenant, "query": query})
 
         assert "Query execution failed" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
-async def test_run_select_query_syntax_error(mcp_server):
+async def test_run_select_query_syntax_error(mcp_server, setup_test_database):
+    test_tenant, _, _, _ = setup_test_database
+
     """Test running a SELECT query with syntax error."""
     async with Client(mcp_server) as client:
         # Invalid SQL syntax
@@ -274,7 +278,7 @@ async def test_run_select_query_syntax_error(mcp_server):
 
         # Should raise ToolError
         with pytest.raises(ToolError) as exc_info:
-            await client.call_tool("run_select_query", {"tenant": tenant, "query": query})
+            await client.call_tool("run_select_query", {"tenant": test_tenant, "query": query})
 
         assert "Query execution failed" in str(exc_info.value)
 
@@ -282,10 +286,10 @@ async def test_run_select_query_syntax_error(mcp_server):
 @pytest.mark.asyncio
 async def test_table_metadata_details(mcp_server, setup_test_database):
     """Test that table metadata is correctly retrieved."""
-    test_db, test_table, _ = setup_test_database
+    test_tenant, test_db, test_table, _ = setup_test_database
 
     async with Client(mcp_server) as client:
-        result = await client.call_tool("list_tables", {"tenant": tenant, "database": test_db})
+        result = await client.call_tool("list_tables", {"tenant": test_tenant, "database": test_db})
         tables = json.loads(result[0].text)
 
         # Find our test table
@@ -319,11 +323,12 @@ async def test_table_metadata_details(mcp_server, setup_test_database):
 
 
 @pytest.mark.asyncio
-async def test_system_database_access(mcp_server):
+async def test_system_database_access(mcp_server, setup_test_database):
     """Test that we can access system databases."""
+    test_tenant, _, _, _ = setup_test_database
     async with Client(mcp_server) as client:
         # List tables in system database
-        result = await client.call_tool("list_tables", {"tenant": tenant, "database": "system"})
+        result = await client.call_tool("list_tables", {"tenant": test_tenant, "database": "system"})
         tables = json.loads(result[0].text)
 
         # System database should have many tables
@@ -339,7 +344,7 @@ async def test_system_database_access(mcp_server):
 @pytest.mark.asyncio
 async def test_concurrent_queries(mcp_server, setup_test_database):
     """Test running multiple queries concurrently."""
-    test_db, test_table, test_table2 = setup_test_database
+    test_tenant, test_db, test_table, test_table2 = setup_test_database
 
     async with Client(mcp_server) as client:
         # Run multiple queries concurrently
@@ -352,7 +357,7 @@ async def test_concurrent_queries(mcp_server, setup_test_database):
 
         # Execute all queries concurrently
         results = await asyncio.gather(
-            *[client.call_tool("run_select_query", {"tenant": tenant, "query": query}) for query in queries]
+            *[client.call_tool("run_select_query", {"tenant": test_tenant, "query": query}) for query in queries]
         )
 
         # Verify all queries succeeded

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,12 +17,6 @@ def event_loop():
     yield loop
     loop.close()
 
-## TO-DO
-"""
-- Set up multiple tenants
-- Test with wrong tenant -> Should we execute default or not execute?
-"""
-
 @pytest_asyncio.fixture(scope="module")
 async def setup_test_database():
     """Set up test database and tables before running tests."""
@@ -95,6 +89,35 @@ def mcp_server():
 
 
 @pytest.mark.asyncio
+async def test_list_databases_wrong_tenant(mcp_server):
+    """Test the list_databases tool with wrong tenant."""
+    async with Client(mcp_server) as client:
+        result = await client.call_tool("list_databases", {"tenant": "wrong_tenant"})
+        assert result == {
+            "status": "error",
+            "message": "List databases not performed for non-existent tenant - 'wrong_tenant'"
+        }
+
+@pytest.mark.asyncio
+async def test_list_tables_wrong_tenant(mcp_server):
+    """Test the list_tables tool with wrong tenant."""
+    async with Client(mcp_server) as client:
+        result = await client.call_tool("list_databases", {"tenant": "wrong_tenant"})
+        assert result == {
+            "status": "error",
+            "message": "List tables not performed for non-existent tenant - 'wrong_tenant'"
+        }
+
+@pytest.mark.asyncio
+async def test_run_select_query_wrong_tenant(mcp_server):
+    """Test the run_select_query tool with wrong tenant."""
+    async with Client(mcp_server) as client:
+        result = await client.call_tool("list_databases", {"tenant": "wrong_tenant"})
+        assert result == {
+            "status": "error",
+            "message": "Query not performed for non-existent tenant - 'wrong_tenant'"
+        }
+
 async def test_list_databases(mcp_server, setup_test_database):
     """Test the list_databases tool."""
     test_tenant, test_db, _, _ = setup_test_database

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -4,7 +4,7 @@ import json
 from dotenv import load_dotenv
 from fastmcp.exceptions import ToolError
 
-from mcp_clickhouse import create_clickhouse_client, list_databases, list_tables, run_select_query
+from mcp_clickhouse import create_clickhouse_client, list_clickhouse_tenants, list_chdb_tenants, list_databases, list_tables, run_select_query 
 
 load_dotenv()
 
@@ -39,6 +39,18 @@ class TestClickhouseTools(unittest.TestCase):
     def tearDownClass(cls):
         """Clean up the environment after tests."""
         cls.client.command(f"DROP DATABASE IF EXISTS {cls.test_db}")
+
+    def test_list_clickhouse_tenants(self):
+        tenants = list_clickhouse_tenants()
+        self.assertIn("example", tenants)
+        self.assertIn("default", tenants)
+        self.assertEqual(len(tenants), 2)
+
+    def test_list_chdb_tenants(self):
+        tenants = list_chdb_tenants()
+        self.assertIn("example", tenants)
+        self.assertIn("default", tenants)
+        self.assertEqual(len(tenants), 2)
 
     def test_list_databases_wrong_tenant(self):
         """Test listing tables with wrong tenant."""

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -8,12 +8,17 @@ from mcp_clickhouse import create_clickhouse_client, list_databases, list_tables
 
 load_dotenv()
 
+## TO-DO
+"""
+- Set up multiple tenants
+- Test with wrong tenant -> Should we execute default or not execute?
+"""
 
 class TestClickhouseTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up the environment before tests."""
-        cls.client = create_clickhouse_client()
+        cls.client = create_clickhouse_client("example")
 
         # Prepare test database and table
         cls.test_db = "test_tool_db"
@@ -43,21 +48,21 @@ class TestClickhouseTools(unittest.TestCase):
 
     def test_list_databases(self):
         """Test listing databases."""
-        result = list_databases()
+        result = list_databases("example")
         # Parse JSON response
         databases = json.loads(result)
         self.assertIn(self.test_db, databases)
 
     def test_list_tables_without_like(self):
         """Test listing tables without a 'LIKE' filter."""
-        result = list_tables(self.test_db)
+        result = list_tables("example", self.test_db)
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], self.test_table)
 
     def test_list_tables_with_like(self):
         """Test listing tables with a 'LIKE' filter."""
-        result = list_tables(self.test_db, like=f"{self.test_table}%")
+        result = list_tables("example", self.test_db, like=f"{self.test_table}%")
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], self.test_table)
@@ -65,7 +70,7 @@ class TestClickhouseTools(unittest.TestCase):
     def test_run_select_query_success(self):
         """Test running a SELECT query successfully."""
         query = f"SELECT * FROM {self.test_db}.{self.test_table}"
-        result = run_select_query(query)
+        result = run_select_query("example", query)
         self.assertIsInstance(result, dict)
         self.assertEqual(len(result["rows"]), 2)
         self.assertEqual(result["rows"][0][0], 1)
@@ -77,13 +82,13 @@ class TestClickhouseTools(unittest.TestCase):
 
         # Should raise ToolError
         with self.assertRaises(ToolError) as context:
-            run_select_query(query)
+            run_select_query("example", query)
 
         self.assertIn("Query execution failed", str(context.exception))
 
     def test_table_and_column_comments(self):
         """Test that table and column comments are correctly retrieved."""
-        result = list_tables(self.test_db)
+        result = list_tables("example", self.test_db)
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -4,7 +4,7 @@ import json
 from dotenv import load_dotenv
 from fastmcp.exceptions import ToolError
 
-from mcp_clickhouse import create_clickhouse_client, list_clickhouse_tenants, list_chdb_tenants, list_databases, list_tables, run_select_query 
+from mcp_clickhouse import create_clickhouse_client, list_clickhouse_tenants, list_databases, list_tables, run_select_query 
 
 load_dotenv()
 
@@ -12,7 +12,7 @@ class TestClickhouseTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up the environment before tests."""
-        cls.client = create_clickhouse_client("example")
+        cls.client = create_clickhouse_client(tenant="default")
 
         # Prepare test database and table
         cls.test_db = "test_tool_db"
@@ -42,15 +42,8 @@ class TestClickhouseTools(unittest.TestCase):
 
     def test_list_clickhouse_tenants(self):
         tenants = list_clickhouse_tenants()
-        self.assertIn("example", tenants)
         self.assertIn("default", tenants)
-        self.assertEqual(len(tenants), 2)
-
-    def test_list_chdb_tenants(self):
-        tenants = list_chdb_tenants()
-        self.assertIn("example", tenants)
-        self.assertIn("default", tenants)
-        self.assertEqual(len(tenants), 2)
+        self.assertEqual(len(tenants), 1)
 
     def test_list_databases_wrong_tenant(self):
         """Test listing tables with wrong tenant."""
@@ -88,21 +81,21 @@ class TestClickhouseTools(unittest.TestCase):
 
     def test_list_databases(self):
         """Test listing databases."""
-        result = list_databases("example")
+        result = list_databases("default")
         # Parse JSON response
         databases = json.loads(result)
         self.assertIn(self.test_db, databases)
 
     def test_list_tables_without_like(self):
         """Test listing tables without a 'LIKE' filter."""
-        result = list_tables("example", self.test_db)
+        result = list_tables("default", self.test_db)
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], self.test_table)
 
     def test_list_tables_with_like(self):
         """Test listing tables with a 'LIKE' filter."""
-        result = list_tables("example", self.test_db, like=f"{self.test_table}%")
+        result = list_tables("default", self.test_db, like=f"{self.test_table}%")
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], self.test_table)
@@ -110,7 +103,7 @@ class TestClickhouseTools(unittest.TestCase):
     def test_run_select_query_success(self):
         """Test running a SELECT query successfully."""
         query = f"SELECT * FROM {self.test_db}.{self.test_table}"
-        result = run_select_query("example", query)
+        result = run_select_query("default", query)
         self.assertIsInstance(result, dict)
         self.assertEqual(len(result["rows"]), 2)
         self.assertEqual(result["rows"][0][0], 1)
@@ -122,13 +115,13 @@ class TestClickhouseTools(unittest.TestCase):
 
         # Should raise ToolError
         with self.assertRaises(ToolError) as context:
-            run_select_query("example", query)
+            run_select_query("default", query)
 
         self.assertIn("Query execution failed", str(context.exception))
 
     def test_table_and_column_comments(self):
         """Test that table and column comments are correctly retrieved."""
-        result = list_tables("example", self.test_db)
+        result = list_tables("default", self.test_db)
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -8,12 +8,6 @@ from mcp_clickhouse import create_clickhouse_client, list_databases, list_tables
 
 load_dotenv()
 
-## TO-DO
-"""
-- Set up multiple tenants
-- Test with wrong tenant -> Should we execute default or not execute?
-"""
-
 class TestClickhouseTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -45,6 +39,30 @@ class TestClickhouseTools(unittest.TestCase):
     def tearDownClass(cls):
         """Clean up the environment after tests."""
         cls.client.command(f"DROP DATABASE IF EXISTS {cls.test_db}")
+
+    def test_list_databases_wrong_tenant(self):
+        """Test listing databases with wrong tenant."""
+        result = list_databases("wrong_tenant")
+        self.assertEqual(result, {
+            "status": "error",
+            "message": "List databases not performed for non-existent tenant - 'wrong_tenant'"
+        })
+
+    def test_list_tables_wrong_tenant(self):
+        """Test listing tables with wrong tenant."""
+        result = list_tables("wrong_tenant")
+        self.assertEqual(result, {
+            "status": "error",
+            "message": "List tables not performed for non-existent tenant - 'wrong_tenant'"
+        })
+
+    def test_run_select_query_wrong_tenant(self):
+        """Test run select query with wrong tenant."""
+        result = list_databases("wrong_tenant")
+        self.assertEqual(result, {
+            "status": "error",
+            "message": "Query not performed for non-existent tenant - 'wrong_tenant'"
+        })
 
     def test_list_databases(self):
         """Test listing databases."""

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -41,28 +41,38 @@ class TestClickhouseTools(unittest.TestCase):
         cls.client.command(f"DROP DATABASE IF EXISTS {cls.test_db}")
 
     def test_list_databases_wrong_tenant(self):
-        """Test listing databases with wrong tenant."""
-        result = list_databases("wrong_tenant")
-        self.assertEqual(result, {
-            "status": "error",
-            "message": "List databases not performed for non-existent tenant - 'wrong_tenant'"
-        })
+        """Test listing tables with wrong tenant."""
+        tenant = "wrong_tenant"
+        with self.assertRaises(ToolError) as cm:
+            list_databases(tenant)
+
+        self.assertIn(
+            f"List databases not performed for invalid tenant - '{tenant}'",
+            str(cm.exception)
+        )
 
     def test_list_tables_wrong_tenant(self):
         """Test listing tables with wrong tenant."""
-        result = list_tables("wrong_tenant")
-        self.assertEqual(result, {
-            "status": "error",
-            "message": "List tables not performed for non-existent tenant - 'wrong_tenant'"
-        })
+        tenant = "wrong_tenant"
+        with self.assertRaises(ToolError) as cm:
+            list_tables(tenant, self.test_db)
+
+        self.assertIn(
+            f"List tables not performed for invalid tenant - '{tenant}'",
+            str(cm.exception)
+        )
 
     def test_run_select_query_wrong_tenant(self):
         """Test run select query with wrong tenant."""
-        result = list_databases("wrong_tenant")
-        self.assertEqual(result, {
-            "status": "error",
-            "message": "Query not performed for non-existent tenant - 'wrong_tenant'"
-        })
+        tenant = "wrong_tenant"
+        query = f"SELECT * FROM {self.test_db}.{self.test_table}"
+        with self.assertRaises(ToolError) as cm:
+            run_select_query(tenant, query)
+
+        self.assertIn(
+            f"Query not performed for invalid tenant - '{tenant}'",
+            str(cm.exception)
+        )
 
     def test_list_databases(self):
         """Test listing databases."""


### PR DESCRIPTION
This PR is similar to #48. The intention is provide multi-tenancy in a single MCP server but in a more flexible manner. If no custom prefix is defined, we assign a "default" tenant, otherwise we create tenant IDs based on the prefix used. To prevent any confusion, "default" is not allowed as a prefix.

For my team's usecases, we are planning to have a single MCP server to intelligently communicate with more than 5 clusters so this implementation provides that flexibility for us.

README and unit tests have been updated accordingly. Am welcome to any feedback.