### PR TITLE
[DRAFT] Add a memory mode backed by ClickHouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,39 @@ An MCP server for ClickHouse.
   * Input: `sql` (string): The SQL query to execute.
   * Query data directly from various sources (files, URLs, databases) without ETL processes.
 
+### Memory Tools (Experimental)
+
+> [!WARNING]
+> Memory tools are an experimental feature and may change in future versions.
+
+When enabled via the `CLICKHOUSE_MEMORY=true` environment variable, the following memory management tools become available:
+
+* `save_memory`
+  * Store user-provided information as key-value pairs for later retrieval and reference.
+  * Input: `key` (string): A concise, descriptive key that summarizes the content.
+  * Input: `value` (string): The information to store.
+
+* `get_memories_titles`
+  * Retrieve all memory keys/titles to see what information has been stored.
+  * Returns a list of all stored memory keys with timestamps.
+
+* `get_memory`
+  * Retrieve all memory entries matching a specific key.
+  * Input: `key` (string): The key to search for.
+  * Returns all memories associated with that key, ordered by most recent first.
+
+* `get_all_memories`
+  * Retrieve all saved memories from the memory table.
+  * Input: None
+  * **Warning**: Should only be used when explicitly requested, as it may return large amounts of data.
+
+* `delete_memory`
+  * Delete all memory entries matching a specific key.
+  * Input: `key` (string): The key of memories to delete.
+  * **Warning**: Should only be used when explicitly requested by the user.
+
+These tools use ClickHouse to store memories in a `user_memory` table, allowing information to persist across sessions.
+
 ### Health Check Endpoint
 
 When running with HTTP or SSE transport, a health check endpoint is available at `/health`. This endpoint:
@@ -317,6 +350,9 @@ The following environment variables are used to configure the ClickHouse and chD
 * `CLICKHOUSE_ENABLED`: Enable/disable ClickHouse functionality
   * Default: `"true"`
   * Set to `"false"` to disable ClickHouse tools when using chDB only
+* `CLICKHOUSE_MEMORY`: Enable/disable memory tools (experimental)
+  * Default: `"false"`
+  * Set to `"true"` to enable memory management tools for storing key-value data
 
 #### chDB Variables
 

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -162,6 +162,14 @@ class ClickHouseConfig:
         """
         return int(os.getenv("CLICKHOUSE_MCP_BIND_PORT", "8000"))
 
+    @property
+    def memory_enabled(self) -> bool:
+        """Get whether memory tools are enabled.
+
+        Default: False
+        """
+        return os.getenv("CLICKHOUSE_MEMORY", "false").lower() == "true"
+
     def get_client_config(self) -> dict:
         """Get the configuration dictionary for clickhouse_connect client.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,8 @@ line-length = 100
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.1",
+]

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from fastmcp.exceptions import ToolError
 
 from mcp_clickhouse import create_clickhouse_client, list_databases, list_tables, run_select_query
+from mcp_clickhouse.mcp_server import save_memory, get_memories_titles, get_memory, get_all_memories, delete_memory
 
 load_dotenv()
 
@@ -36,10 +37,34 @@ class TestClickhouseTools(unittest.TestCase):
             INSERT INTO {cls.test_db}.{cls.test_table} (id, name) VALUES (1, 'Alice'), (2, 'Bob')
         """)
 
+        # Set up memory table for memory tests
+        cls.client.command(f"DROP TABLE IF EXISTS {cls.test_db}.user_memory")
+        cls.client.command(f"""
+            CREATE TABLE {cls.test_db}.user_memory (
+                key String,
+                value String,
+                created_at DateTime DEFAULT now(),
+                updated_at DateTime DEFAULT now()
+            ) ENGINE = MergeTree()
+            ORDER BY key
+        """)
+
     @classmethod
     def tearDownClass(cls):
         """Clean up the environment after tests."""
         cls.client.command(f"DROP DATABASE IF EXISTS {cls.test_db}")
+
+    def setUp(self):
+        """Set up clean state before each memory test."""
+        # Clear memory table before each test - need to delete from default database too
+        try:
+            self.client.command("TRUNCATE TABLE user_memory")
+        except Exception:
+            pass  # Table may not exist in default database
+        try:
+            self.client.command(f"TRUNCATE TABLE {self.test_db}.user_memory")
+        except Exception:
+            pass  # Table may not exist in test database
 
     def test_list_databases(self):
         """Test listing databases."""
@@ -97,6 +122,153 @@ class TestClickhouseTools(unittest.TestCase):
         # Verify column comments
         self.assertEqual(columns["id"]["comment"], "Primary identifier")
         self.assertEqual(columns["name"]["comment"], "User name field")
+
+    def test_save_memory_success(self):
+        """Test saving memory successfully."""
+        result = save_memory("Test Key", "Test Value")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["key"], "Test Key")
+        self.assertIn("saved successfully", result["message"])
+
+    def test_save_memory_multiple_same_key(self):
+        """Test saving multiple memories with the same key."""
+        save_memory("Duplicate Key", "First Value")
+        result = save_memory("Duplicate Key", "Second Value")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["key"], "Duplicate Key")
+
+    def test_get_memories_titles_empty(self):
+        """Test getting titles from empty memory table."""
+        result = get_memories_titles()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 0)
+        self.assertEqual(result["titles"], [])
+
+    def test_get_memories_titles_with_data(self):
+        """Test getting titles with data in memory table."""
+        save_memory("Key 1", "Value 1")
+        save_memory("Key 2", "Value 2")
+        
+        result = get_memories_titles()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 2)
+        self.assertIn("Key 1", result["titles"])
+        self.assertIn("Key 2", result["titles"])
+
+    def test_get_memory_success(self):
+        """Test retrieving an existing memory."""
+        save_memory("Retrieve Key", "Retrieve Value")
+        
+        result = get_memory("Retrieve Key")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["key"], "Retrieve Key")
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["memories"][0]["value"], "Retrieve Value")
+
+    def test_get_memory_not_found(self):
+        """Test retrieving a non-existent memory."""
+        result = get_memory("Non-existent Key")
+        self.assertEqual(result["status"], "not_found")
+        self.assertEqual(result["key"], "Non-existent Key")
+
+    def test_get_memory_multiple_entries(self):
+        """Test retrieving multiple memories with the same key."""
+        save_memory("Multi Key", "First Value")
+        save_memory("Multi Key", "Second Value")
+        
+        result = get_memory("Multi Key")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 2)
+        self.assertEqual(len(result["memories"]), 2)
+
+    def test_get_all_memories_empty(self):
+        """Test getting all memories from empty table."""
+        result = get_all_memories()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 0)
+
+    def test_get_all_memories_with_data(self):
+        """Test getting all memories with data."""
+        save_memory("All Key 1", "All Value 1")
+        save_memory("All Key 2", "All Value 2")
+        
+        result = get_all_memories()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 2)
+        self.assertEqual(len(result["memories"]), 2)
+
+    def test_delete_memory_success(self):
+        """Test deleting an existing memory."""
+        save_memory("Delete Key", "Delete Value")
+        
+        result = delete_memory("Delete Key")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["key"], "Delete Key")
+        self.assertEqual(result["deleted_count"], 1)
+        
+        # Verify it's actually deleted
+        get_result = get_memory("Delete Key")
+        self.assertEqual(get_result["status"], "not_found")
+
+    def test_delete_memory_not_found(self):
+        """Test deleting a non-existent memory."""
+        result = delete_memory("Non-existent Delete Key")
+        self.assertEqual(result["status"], "not_found")
+        self.assertEqual(result["key"], "Non-existent Delete Key")
+
+    def test_memory_workflow_integration(self):
+        """Test complete memory workflow integration."""
+        # Save memory
+        save_result = save_memory("Workflow Key", "Workflow Value")
+        self.assertEqual(save_result["status"], "success")
+        
+        # Check it appears in titles
+        titles_result = get_memories_titles()
+        self.assertIn("Workflow Key", titles_result["titles"])
+        
+        # Retrieve it
+        get_result = get_memory("Workflow Key")
+        self.assertEqual(get_result["status"], "success")
+        self.assertEqual(get_result["memories"][0]["value"], "Workflow Value")
+        
+        # Update it (save again)
+        update_result = save_memory("Workflow Key", "Updated Value")
+        self.assertEqual(update_result["status"], "success")
+        
+        # Verify update
+        get_updated = get_memory("Workflow Key")
+        self.assertEqual(get_updated["count"], 2)  # Now has 2 entries
+        
+        # Delete it
+        delete_result = delete_memory("Workflow Key")
+        self.assertEqual(delete_result["status"], "success")
+        self.assertEqual(delete_result["deleted_count"], 2)
+        
+        # Verify deletion
+        final_get = get_memory("Workflow Key")
+        self.assertEqual(final_get["status"], "not_found")
+
+
+class TestMemoryFlag(unittest.TestCase):
+    """Test CLICKHOUSE_MEMORY flag functionality."""
+    
+    def test_memory_flag_controls_tool_availability(self):
+        """Test that CLICKHOUSE_MEMORY flag controls whether memory tools are available."""
+        # This test documents the expected behavior but cannot directly test
+        # the conditional registration since it happens at module import time
+        # In practice, this would be tested by running the server with different
+        # CLICKHOUSE_MEMORY flag values and checking available tools
+        
+        # For now, we just verify the memory functions exist and work when flag is enabled
+        # (which it must be for this test to run)
+        from mcp_clickhouse.mcp_server import save_memory, get_memories_titles, get_memory, get_all_memories, delete_memory
+        
+        # These should be callable functions when CLICKHOUSE_MEMORY=true
+        self.assertTrue(callable(save_memory))
+        self.assertTrue(callable(get_memories_titles))
+        self.assertTrue(callable(get_memory))
+        self.assertTrue(callable(get_all_memories))
+        self.assertTrue(callable(delete_memory))
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -450,6 +451,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "chdb", specifier = ">=3.3.0" },
@@ -461,6 +467,10 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "ruff", marker = "extra == 'dev'" },
 ]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.4.1" }]
 
 [[package]]
 name = "mdurl"


### PR DESCRIPTION
⚠️ This is an experiment and not ready to be merged.

 This PR introduces experimental memory management tools that allow storing and retrieving key-value data using ClickHouse as the backend storage.

  New Tools Added

  - save_memory: Store user-provided information as key-value pairs
  - get_memories_titles: Retrieve all memory keys/titles with timestamps
  - get_memory: Retrieve all memory entries matching a specific key
  - get_all_memories: Retrieve all saved memories (use with caution for large datasets)
  - delete_memory: Delete all memory entries matching a specific key

  Implementation Details

  - Memory data is stored in a user_memory table with automatic timestamps
  - Tools are conditionally registered based on CLICKHOUSE_MEMORY environment variable
  - Uses existing ClickHouse write query functionality for persistence
  - Includes comprehensive test coverage for all memory operations
  - Follows existing error handling patterns with structured responses
  

https://github.com/user-attachments/assets/26887bf7-37cb-4f23-8fb9-409bda3512ab


  
