### PR TITLE
Add optional write access mode with DROP protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ An MCP server for ClickHouse.
 
 ### ClickHouse Tools
 
-* `run_select_query`
+* `run_query`
   * Execute SQL queries on your ClickHouse cluster.
-  * Input: `sql` (string): The SQL query to execute.
-  * All ClickHouse queries are run with `readonly = 1` to ensure they are safe.
+  * Input: `query` (string): The SQL query to execute.
+  * Queries run in read-only mode by default (`CLICKHOUSE_READ_ONLY=true`), but writes can be enabled explicitly if needed.
 
 * `list_databases`
   * List all databases on your ClickHouse cluster.
@@ -26,7 +26,7 @@ An MCP server for ClickHouse.
 
 * `run_chdb_select_query`
   * Execute SQL queries using [chDB](https://github.com/chdb-io/chdb)'s embedded ClickHouse engine.
-  * Input: `sql` (string): The SQL query to execute.
+  * Input: `query` (string): The SQL query to execute.
   * Query data directly from various sources (files, URLs, databases) without ETL processes.
 
 ### Health Check Endpoint
@@ -171,6 +171,26 @@ You can also enable both ClickHouse and chDB simultaneously:
 3. Locate the command entry for `uv` and replace it with the absolute path to the `uv` executable. This ensures that the correct version of `uv` is used when starting the server. On a mac, you can find this path using `which uv`.
 
 4. Restart Claude Desktop to apply the changes.
+
+### Optional Write Access
+
+By default, this MCP enforces read-only queries so that accidental mutations cannot happen during exploration. To allow DDL or INSERT/UPDATE statements, set the `CLICKHOUSE_READ_ONLY` environment variable to `false`. The server keeps enforcing read-only mode if the ClickHouse instance itself disallows writes.
+
+### DROP Operation Protection
+
+Even when write access is enabled (`CLICKHOUSE_READ_ONLY=false`), DROP operations (DROP TABLE, DROP DATABASE, DROP VIEW, DROP DICTIONARY) require an additional opt-in flag for safety. This prevents accidental data deletion during AI exploration.
+
+To enable DROP operations, set both flags:
+```json
+"env": {
+  "CLICKHOUSE_READ_ONLY": "false",
+  "CLICKHOUSE_ALLOW_DROP": "true"
+}
+```
+
+This two-tier approach ensures that accidental drops are very difficult:
+- **Write operations** (INSERT, UPDATE, CREATE) require `CLICKHOUSE_READ_ONLY=false`
+- **Destructive operations** (DROP) additionally require `CLICKHOUSE_ALLOW_DROP=true`
 
 ### Running Without uv (Using System Python)
 
@@ -321,6 +341,15 @@ The following environment variables are used to configure the ClickHouse and chD
 * `CLICKHOUSE_ENABLED`: Enable/disable ClickHouse functionality
   * Default: `"true"`
   * Set to `"false"` to disable ClickHouse tools when using chDB only
+* `CLICKHOUSE_READ_ONLY`: Force read-only query mode
+  * Default: `"true"`
+  * Set to `"false"` to allow DDL (CREATE, ALTER, DROP) and DML (INSERT, UPDATE, DELETE) operations
+  * When enabled, queries run with `readonly=1` setting to prevent data modifications
+* `CLICKHOUSE_ALLOW_DROP`: Allow DROP operations (DROP TABLE, DROP DATABASE, DROP VIEW, DROP DICTIONARY)
+  * Default: `"false"`
+  * Only takes effect when `CLICKHOUSE_READ_ONLY=false`
+  * Set to `"true"` to explicitly allow destructive DROP operations
+  * This is a safety feature to prevent accidental data deletion during AI exploration
 
 #### chDB Variables
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An MCP server for ClickHouse.
 * `run_query`
   * Execute SQL queries on your ClickHouse cluster.
   * Input: `query` (string): The SQL query to execute.
-  * Queries run in read-only mode by default (`CLICKHOUSE_READ_ONLY=true`), but writes can be enabled explicitly if needed.
+  * Queries run in read-only mode by default (`CLICKHOUSE_ALLOW_WRITE_ACCESS=false`), but writes can be enabled explicitly if needed.
 
 * `list_databases`
   * List all databases on your ClickHouse cluster.
@@ -174,22 +174,22 @@ You can also enable both ClickHouse and chDB simultaneously:
 
 ### Optional Write Access
 
-By default, this MCP enforces read-only queries so that accidental mutations cannot happen during exploration. To allow DDL or INSERT/UPDATE statements, set the `CLICKHOUSE_READ_ONLY` environment variable to `false`. The server keeps enforcing read-only mode if the ClickHouse instance itself disallows writes.
+By default, this MCP enforces read-only queries so that accidental mutations cannot happen during exploration. To allow DDL or INSERT/UPDATE statements, set the `CLICKHOUSE_ALLOW_WRITE_ACCESS` environment variable to `true`. The server keeps enforcing read-only mode if the ClickHouse instance itself disallows writes.
 
 ### DROP Operation Protection
 
-Even when write access is enabled (`CLICKHOUSE_READ_ONLY=false`), DROP operations (DROP TABLE, DROP DATABASE, DROP VIEW, DROP DICTIONARY) require an additional opt-in flag for safety. This prevents accidental data deletion during AI exploration.
+Even when write access is enabled (`CLICKHOUSE_ALLOW_WRITE_ACCESS=true`), DROP operations (DROP TABLE, DROP DATABASE, DROP VIEW, DROP DICTIONARY) require an additional opt-in flag for safety. This prevents accidental data deletion during AI exploration.
 
 To enable DROP operations, set both flags:
 ```json
 "env": {
-  "CLICKHOUSE_READ_ONLY": "false",
+  "CLICKHOUSE_ALLOW_WRITE_ACCESS": "true",
   "CLICKHOUSE_ALLOW_DROP": "true"
 }
 ```
 
 This two-tier approach ensures that accidental drops are very difficult:
-- **Write operations** (INSERT, UPDATE, CREATE) require `CLICKHOUSE_READ_ONLY=false`
+- **Write operations** (INSERT, UPDATE, CREATE) require `CLICKHOUSE_ALLOW_WRITE_ACCESS=true`
 - **Destructive operations** (DROP) additionally require `CLICKHOUSE_ALLOW_DROP=true`
 
 ### Running Without uv (Using System Python)
@@ -341,13 +341,13 @@ The following environment variables are used to configure the ClickHouse and chD
 * `CLICKHOUSE_ENABLED`: Enable/disable ClickHouse functionality
   * Default: `"true"`
   * Set to `"false"` to disable ClickHouse tools when using chDB only
-* `CLICKHOUSE_READ_ONLY`: Force read-only query mode
-  * Default: `"true"`
-  * Set to `"false"` to allow DDL (CREATE, ALTER, DROP) and DML (INSERT, UPDATE, DELETE) operations
-  * When enabled, queries run with `readonly=1` setting to prevent data modifications
+* `CLICKHOUSE_ALLOW_WRITE_ACCESS`: Allow write operations (DDL and DML)
+  * Default: `"false"`
+  * Set to `"true"` to allow DDL (CREATE, ALTER, DROP) and DML (INSERT, UPDATE, DELETE) operations
+  * When disabled (default), queries run with `readonly=1` setting to prevent data modifications
 * `CLICKHOUSE_ALLOW_DROP`: Allow DROP operations (DROP TABLE, DROP DATABASE, DROP VIEW, DROP DICTIONARY)
   * Default: `"false"`
-  * Only takes effect when `CLICKHOUSE_READ_ONLY=false`
+  * Only takes effect when `CLICKHOUSE_ALLOW_WRITE_ACCESS=true` is also set
   * Set to `"true"` to explicitly allow destructive DROP operations
   * This is a safety feature to prevent accidental data deletion during AI exploration
 

--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ You can also enable both ClickHouse and chDB simultaneously:
 
 By default, this MCP enforces read-only queries so that accidental mutations cannot happen during exploration. To allow DDL or INSERT/UPDATE statements, set the `CLICKHOUSE_ALLOW_WRITE_ACCESS` environment variable to `true`. The server keeps enforcing read-only mode if the ClickHouse instance itself disallows writes.
 
-### DROP Operation Protection
+### Destructive Operation Protection
 
-Even when write access is enabled (`CLICKHOUSE_ALLOW_WRITE_ACCESS=true`), DROP operations (DROP TABLE, DROP DATABASE, DROP VIEW, DROP DICTIONARY) require an additional opt-in flag for safety. This prevents accidental data deletion during AI exploration.
+Even when write access is enabled (`CLICKHOUSE_ALLOW_WRITE_ACCESS=true`), destructive operations (DROP TABLE, DROP DATABASE, DROP VIEW, DROP DICTIONARY, TRUNCATE TABLE) require an additional opt-in flag for safety. This prevents accidental data deletion during AI exploration.
 
-To enable DROP operations, set both flags:
+To enable destructive operations, set both flags:
 ```json
 "env": {
   "CLICKHOUSE_ALLOW_WRITE_ACCESS": "true",
@@ -252,7 +252,7 @@ To enable DROP operations, set both flags:
 
 This two-tier approach ensures that accidental drops are very difficult:
 - **Write operations** (INSERT, UPDATE, CREATE) require `CLICKHOUSE_ALLOW_WRITE_ACCESS=true`
-- **Destructive operations** (DROP) additionally require `CLICKHOUSE_ALLOW_DROP=true`
+- **Destructive operations** (DROP, TRUNCATE) additionally require `CLICKHOUSE_ALLOW_DROP=true`
 
 ### Running Without uv (Using System Python)
 
@@ -423,10 +423,10 @@ The following environment variables are used to configure the ClickHouse and chD
   * Default: `"false"`
   * Set to `"true"` to allow DDL (CREATE, ALTER, DROP) and DML (INSERT, UPDATE, DELETE) operations
   * When disabled (default), queries run with `readonly=1` setting to prevent data modifications
-* `CLICKHOUSE_ALLOW_DROP`: Allow DROP operations (DROP TABLE, DROP DATABASE, DROP VIEW, DROP DICTIONARY)
+* `CLICKHOUSE_ALLOW_DROP`: Allow destructive operations (DROP TABLE, DROP DATABASE, DROP VIEW, DROP DICTIONARY, TRUNCATE TABLE)
   * Default: `"false"`
   * Only takes effect when `CLICKHOUSE_ALLOW_WRITE_ACCESS=true` is also set
-  * Set to `"true"` to explicitly allow destructive DROP operations
+  * Set to `"true"` to explicitly allow destructive DROP and TRUNCATE operations
   * This is a safety feature to prevent accidental data deletion during AI exploration
 
 #### chDB Variables

--- a/mcp_clickhouse/__init__.py
+++ b/mcp_clickhouse/__init__.py
@@ -4,7 +4,7 @@ from .mcp_server import (
     create_clickhouse_client,
     list_databases,
     list_tables,
-    run_select_query,
+    run_query,
     create_chdb_client,
     run_chdb_select_query,
     chdb_initial_prompt,
@@ -21,7 +21,7 @@ if os.getenv("MCP_CLICKHOUSE_TRUSTSTORE_DISABLE", None) != "1":
 __all__ = [
     "list_databases",
     "list_tables",
-    "run_select_query",
+    "run_query",
     "create_clickhouse_client",
     "create_chdb_client",
     "run_chdb_select_query",

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -44,8 +44,8 @@ class ClickHouseConfig:
         CLICKHOUSE_DATABASE: Default database to use (default: None)
         CLICKHOUSE_PROXY_PATH: Path to be added to the host URL. For instance, for servers behind an HTTP proxy (default: None)
         CLICKHOUSE_ENABLED: Enable ClickHouse server (default: true)
-        CLICKHOUSE_READ_ONLY: Force read-only queries (default: true)
-        CLICKHOUSE_ALLOW_DROP: Allow DROP operations when writes are enabled (default: false)
+        CLICKHOUSE_ALLOW_WRITE_ACCESS: Allow write operations (DDL and DML) (default: false)
+        CLICKHOUSE_ALLOW_DROP: Allow DROP operations when writes are also enabled (default: false)
     """
 
     def __init__(self):
@@ -129,19 +129,19 @@ class ClickHouseConfig:
         return os.getenv("CLICKHOUSE_PROXY_PATH")
 
     @property
-    def read_only(self) -> bool:
-        """Get whether queries should be forced to read-only mode.
+    def allow_write_access(self) -> bool:
+        """Get whether write operations (DDL and DML) are allowed.
 
-        Default: True
+        Default: False
         """
-        return os.getenv("CLICKHOUSE_READ_ONLY", "true").lower() == "true"
+        return os.getenv("CLICKHOUSE_ALLOW_WRITE_ACCESS", "false").lower() == "true"
 
     @property
     def allow_drop(self) -> bool:
         """Get whether DROP operations (DROP TABLE, DROP DATABASE) are allowed.
 
         This setting provides an additional safety layer when write access is enabled.
-        Even with CLICKHOUSE_READ_ONLY=false, DROP operations require this flag.
+        Even with CLICKHOUSE_ALLOW_WRITE_ACCESS=true, DROP operations require this flag.
 
         Default: False
         """

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -44,6 +44,8 @@ class ClickHouseConfig:
         CLICKHOUSE_DATABASE: Default database to use (default: None)
         CLICKHOUSE_PROXY_PATH: Path to be added to the host URL. For instance, for servers behind an HTTP proxy (default: None)
         CLICKHOUSE_ENABLED: Enable ClickHouse server (default: true)
+        CLICKHOUSE_READ_ONLY: Force read-only queries (default: true)
+        CLICKHOUSE_ALLOW_DROP: Allow DROP operations when writes are enabled (default: false)
     """
 
     def __init__(self):
@@ -125,6 +127,25 @@ class ClickHouseConfig:
     @property
     def proxy_path(self) -> str:
         return os.getenv("CLICKHOUSE_PROXY_PATH")
+
+    @property
+    def read_only(self) -> bool:
+        """Get whether queries should be forced to read-only mode.
+
+        Default: True
+        """
+        return os.getenv("CLICKHOUSE_READ_ONLY", "true").lower() == "true"
+
+    @property
+    def allow_drop(self) -> bool:
+        """Get whether DROP operations (DROP TABLE, DROP DATABASE) are allowed.
+
+        This setting provides an additional safety layer when write access is enabled.
+        Even with CLICKHOUSE_READ_ONLY=false, DROP operations require this flag.
+
+        Default: False
+        """
+        return os.getenv("CLICKHOUSE_ALLOW_DROP", "false").lower() == "true"
 
     def get_client_config(self) -> dict:
         """Get the configuration dictionary for clickhouse_connect client.

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -46,7 +46,7 @@ class ClickHouseConfig:
         CLICKHOUSE_PROXY_PATH: Path to be added to the host URL. For instance, for servers behind an HTTP proxy (default: None)
         CLICKHOUSE_ENABLED: Enable ClickHouse server (default: true)
         CLICKHOUSE_ALLOW_WRITE_ACCESS: Allow write operations (DDL and DML) (default: false)
-        CLICKHOUSE_ALLOW_DROP: Allow DROP operations when writes are also enabled (default: false)
+        CLICKHOUSE_ALLOW_DROP: Allow destructive operations (DROP, TRUNCATE) when writes are also enabled (default: false)
     """
 
     def __init__(self):

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -188,10 +188,8 @@ def _validate_query_for_drop(query: str) -> None:
         return
 
     # Simple pattern matching for DROP operations
-    query_upper = query.upper()
-
     drop_pattern = r'\bDROP\s+(TABLE|DATABASE|VIEW|DICTIONARY)\b'
-    if re.search(drop_pattern, query_upper):
+    if re.search(drop_pattern, query, re.IGNORECASE):
         raise ToolError(
             "DROP operations are not allowed. "
             "Set CLICKHOUSE_ALLOW_DROP=true to enable DROP TABLE/DATABASE operations. "
@@ -343,6 +341,16 @@ def _normalize_readonly_value(value: Any) -> Optional[str]:
 
     The clickhouse_connect library represents settings as objects with a .value attribute.
     This function extracts the actual value for our logic.
+
+    Args:
+        value: The readonly setting value from ClickHouse server. Can be:
+            - None (server has no readonly restriction)
+            - A clickhouse_connect setting object with a .value attribute
+            - An int (0, 1, 2)
+            - A str ("0", "1", "2")
+
+    Returns:
+        Optional[str]: Normalized readonly value as string ("0", "1", "2") or None
     """
     if value is None:
         return None

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -457,6 +457,8 @@ def execute_query(query: str):
         res = client.query(query, settings=query_settings)
         logger.info(f"Query returned {len(res.result_rows)} rows")
         return {"columns": res.column_names, "rows": res.result_rows}
+    except ToolError:
+        raise
     except Exception as err:
         logger.error(f"Error executing query: {err}")
         raise ToolError(f"Query execution failed: {str(err)}")

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -419,14 +419,14 @@ def list_tables(
     }
 
 
-def _validate_query_for_drop(query: str) -> None:
-    """Validate that DROP operations are allowed.
+def _validate_query_for_destructive_ops(query: str) -> None:
+    """Validate that destructive operations (DROP, TRUNCATE) are allowed.
 
     Args:
         query: The SQL query to validate
 
     Raises:
-        ToolError: If the query contains DROP operations but CLICKHOUSE_ALLOW_DROP is not set
+        ToolError: If the query contains destructive operations but CLICKHOUSE_ALLOW_DROP is not set
     """
     config = get_config()
 
@@ -438,12 +438,12 @@ def _validate_query_for_drop(query: str) -> None:
     if config.allow_drop:
         return
 
-    # Simple pattern matching for DROP operations
-    drop_pattern = r'\bDROP\s+(TABLE|DATABASE|VIEW|DICTIONARY)\b'
-    if re.search(drop_pattern, query, re.IGNORECASE):
+    # Simple pattern matching for destructive operations
+    destructive_pattern = r'\b(DROP\s+(TABLE|DATABASE|VIEW|DICTIONARY)|TRUNCATE\s+TABLE)\b'
+    if re.search(destructive_pattern, query, re.IGNORECASE):
         raise ToolError(
-            "DROP operations are not allowed. "
-            "Set CLICKHOUSE_ALLOW_DROP=true to enable DROP TABLE/DATABASE operations. "
+            "Destructive operations (DROP, TRUNCATE) are not allowed. "
+            "Set CLICKHOUSE_ALLOW_DROP=true to enable these operations. "
             "This is a safety feature to prevent accidental data deletion."
         )
 
@@ -451,7 +451,7 @@ def _validate_query_for_drop(query: str) -> None:
 def execute_query(query: str):
     client = create_clickhouse_client()
     try:
-        _validate_query_for_drop(query)
+        _validate_query_for_destructive_ops(query)
 
         query_settings = build_query_settings(client)
         res = client.query(query, settings=query_settings)
@@ -691,7 +691,7 @@ if os.getenv("CLICKHOUSE_ENABLED", "true").lower() == "true":
         description=(
             "Execute SQL queries in ClickHouse. Queries run in read-only mode by default. "
             "Set CLICKHOUSE_ALLOW_WRITE_ACCESS=true to allow DDL and DML operations. "
-            "Set CLICKHOUSE_ALLOW_DROP=true to additionally allow DROP operations."
+            "Set CLICKHOUSE_ALLOW_DROP=true to additionally allow destructive operations (DROP, TRUNCATE)."
         )
     ))
     logger.info("ClickHouse tools registered")

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -439,7 +439,7 @@ def _validate_query_for_destructive_ops(query: str) -> None:
         return
 
     # Simple pattern matching for destructive operations
-    destructive_pattern = r'\b(DROP\s+(TABLE|DATABASE|VIEW|DICTIONARY)|TRUNCATE\s+TABLE)\b'
+    destructive_pattern = r'\b(DROP\s+(\S+\s+)*(TABLE|DATABASE|VIEW|DICTIONARY)|TRUNCATE\s+TABLE)\b'
     if re.search(destructive_pattern, query, re.IGNORECASE):
         raise ToolError(
             "Destructive operations (DROP, TRUNCATE) are not allowed. "

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -189,7 +189,7 @@ async def test_run_select_query_success(mcp_server, setup_test_database):
 
     async with Client(mcp_server) as client:
         query = f"SELECT id, name, age FROM {test_db}.{test_table} ORDER BY id"
-        result = await client.call_tool("run_select_query", {"query": query})
+        result = await client.call_tool("run_query", {"query": query})
 
         query_result = json.loads(result.content[0].text)
 
@@ -215,7 +215,7 @@ async def test_run_select_query_with_aggregation(mcp_server, setup_test_database
 
     async with Client(mcp_server) as client:
         query = f"SELECT COUNT(*) as count, AVG(age) as avg_age FROM {test_db}.{test_table}"
-        result = await client.call_tool("run_select_query", {"query": query})
+        result = await client.call_tool("run_query", {"query": query})
 
         query_result = json.loads(result.content[0].text)
 
@@ -243,7 +243,7 @@ async def test_run_select_query_with_join(mcp_server, setup_test_database):
             COUNT(DISTINCT event_type) as event_types_count
         FROM {test_db}.{test_table2}
         """
-        result = await client.call_tool("run_select_query", {"query": query})
+        result = await client.call_tool("run_query", {"query": query})
 
         query_result = json.loads(result.content[0].text)
         assert query_result["rows"][0][0] == 3  # login, logout, purchase
@@ -260,7 +260,7 @@ async def test_run_select_query_error(mcp_server, setup_test_database):
 
         # Should raise ToolError
         with pytest.raises(ToolError) as exc_info:
-            await client.call_tool("run_select_query", {"query": query})
+            await client.call_tool("run_query", {"query": query})
 
         assert "Query execution failed" in str(exc_info.value)
 
@@ -274,7 +274,7 @@ async def test_run_select_query_syntax_error(mcp_server):
 
         # Should raise ToolError
         with pytest.raises(ToolError) as exc_info:
-            await client.call_tool("run_select_query", {"query": query})
+            await client.call_tool("run_query", {"query": query})
 
         assert "Query execution failed" in str(exc_info.value)
 
@@ -352,7 +352,7 @@ async def test_concurrent_queries(mcp_server, setup_test_database):
 
         # Execute all queries concurrently
         results = await asyncio.gather(
-            *[client.call_tool("run_select_query", {"query": query}) for query in queries]
+            *[client.call_tool("run_query", {"query": query}) for query in queries]
         )
 
         # Verify all queries succeeded

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -195,8 +195,8 @@ class TestClickhouseWriteMode(unittest.TestCase):
         result = run_query(create_query)
         self.assertIsInstance(result, dict)
 
-        tables = list_tables(self.test_db)
-        table_names = [t["name"] for t in tables]
+        result = list_tables(self.test_db)
+        table_names = [t["name"] for t in result["tables"]]
         self.assertIn("ddl_test", table_names)
 
         self.client.command(f"DROP TABLE {self.test_db}.ddl_test")
@@ -217,9 +217,9 @@ class TestClickhouseWriteMode(unittest.TestCase):
         result = run_query(alter_query)
         self.assertIsInstance(result, dict)
 
-        tables = list_tables(self.test_db, like="alter_test")
-        self.assertEqual(len(tables), 1)
-        column_names = [col["name"] for col in tables[0]["columns"]]
+        result = list_tables(self.test_db, like="alter_test")
+        self.assertEqual(len(result["tables"]), 1)
+        column_names = [col["name"] for col in result["tables"][0]["columns"]]
         self.assertIn("name", column_names)
 
         self.client.command(f"DROP TABLE {self.test_db}.alter_test")
@@ -329,8 +329,8 @@ class TestClickhouseDropProtection(unittest.TestCase):
         result = run_query(create_query)
         self.assertIsInstance(result, dict)
 
-        tables = list_tables(self.test_db)
-        table_names = [t["name"] for t in tables]
+        result = list_tables(self.test_db)
+        table_names = [t["name"] for t in result["tables"]]
         self.assertIn("create_test", table_names)
 
         self.client.command(f"DROP TABLE {self.test_db}.create_test")

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -371,6 +371,7 @@ class TestClickhouseReadOnlyMode(unittest.TestCase):
         """Set up the environment before tests."""
         cls.env_patcher = patch.dict(os.environ, {"CLICKHOUSE_ALLOW_WRITE_ACCESS": "false"})
         cls.env_patcher.start()
+        cls.addClassCleanup(cls.env_patcher.stop)
 
         cls.client = create_clickhouse_client()
         cls.test_db = "test_readonly_db"
@@ -390,7 +391,6 @@ class TestClickhouseReadOnlyMode(unittest.TestCase):
     def tearDownClass(cls):
         """Clean up the environment after tests."""
         cls.client.command(f"DROP DATABASE IF EXISTS {cls.test_db}")
-        cls.env_patcher.stop()
 
     def test_insert_blocked_in_readonly_mode(self):
         """Test that INSERT queries fail when CLICKHOUSE_ALLOW_WRITE_ACCESS=false."""

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -266,7 +266,7 @@ class TestClickhouseDropProtection(unittest.TestCase):
             run_query(drop_query)
 
         error_msg = str(context.exception)
-        self.assertIn("DROP operations are not allowed", error_msg)
+        self.assertIn("Destructive operations (DROP, TRUNCATE) are not allowed", error_msg)
         self.assertIn("CLICKHOUSE_ALLOW_DROP=true", error_msg)
 
     @patch.dict(os.environ, {"CLICKHOUSE_ALLOW_WRITE_ACCESS": "true", "CLICKHOUSE_ALLOW_DROP": "false"})
@@ -282,7 +282,7 @@ class TestClickhouseDropProtection(unittest.TestCase):
             run_query(drop_query)
 
         error_msg = str(context.exception)
-        self.assertIn("DROP operations are not allowed", error_msg)
+        self.assertIn("Destructive operations (DROP, TRUNCATE) are not allowed", error_msg)
         self.assertIn("CLICKHOUSE_ALLOW_DROP=true", error_msg)
 
         self.client.command(f"DROP DATABASE IF EXISTS {temp_db}")
@@ -334,6 +334,29 @@ class TestClickhouseDropProtection(unittest.TestCase):
         self.assertIn("create_test", table_names)
 
         self.client.command(f"DROP TABLE {self.test_db}.create_test")
+
+    @patch.dict(os.environ, {"CLICKHOUSE_ALLOW_WRITE_ACCESS": "true", "CLICKHOUSE_ALLOW_DROP": "false"})
+    def test_truncate_blocked_when_drop_flag_not_set(self):
+        """Test that TRUNCATE TABLE is blocked when CLICKHOUSE_ALLOW_DROP=false."""
+        truncate_query = f"TRUNCATE TABLE {self.test_db}.{self.test_table}"
+
+        with self.assertRaises(ToolError) as context:
+            run_query(truncate_query)
+
+        error_msg = str(context.exception)
+        self.assertIn("Destructive operations (DROP, TRUNCATE) are not allowed", error_msg)
+        self.assertIn("CLICKHOUSE_ALLOW_DROP=true", error_msg)
+
+    def test_truncate_allowed_when_drop_flag_set(self):
+        """Test that TRUNCATE works when CLICKHOUSE_ALLOW_DROP=true."""
+        # Re-insert data so truncate has something to remove
+        self.client.command(
+            f"INSERT INTO {self.test_db}.{self.test_table} (id, value) VALUES (99, 'to_truncate')"
+        )
+
+        truncate_query = f"TRUNCATE TABLE {self.test_db}.{self.test_table}"
+        result = run_query(truncate_query)
+        self.assertIsInstance(result, dict)
 
 
 class TestClickhouseReadOnlyMode(unittest.TestCase):


### PR DESCRIPTION
# Summary
This PR enables LLMs to perform write operations on ClickHouse databases with built-in safety controls to prevent accidental data loss.

## Write Access Mode
- New `CLICKHOUSE_ALLOW_WRITE_ACCESS` flag (default: false) enables DDL and DML operations (INSERT, UPDATE, CREATE, ALTER, DROP)
- When enabled, queries run with `readonly=0` instead of the default `readonly=1`

## Two-Tier `DROP` Protection
- `CLICKHOUSE_ALLOW_DROP` (default: false) provides additional safety for destructive operations
- Both flags must be true to allow `DROP` operations
- Other write operations (`INSERT`, `CREATE`, etc.) only require `CLICKHOUSE_ALLOW_WRITE_ACCESS=true`

# Usage
Enable write access:
```json
"env": {
  "CLICKHOUSE_ALLOW_WRITE_ACCESS": "true"
}
```

Enable write access including `DROP`:
```json
"env": {
  "CLICKHOUSE_ALLOW_WRITE_ACCESS": "true",
  "CLICKHOUSE_ALLOW_DROP": "true"
}
```

Closes #24