### PR TITLE
feat: add CLICKHOUSE_ROLE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This MCP server supports both ClickHouse and chDB. You can enable either or both
         "CLICKHOUSE_PORT": "<clickhouse-port>",
         "CLICKHOUSE_USER": "<clickhouse-user>",
         "CLICKHOUSE_PASSWORD": "<clickhouse-password>",
+        "CLICKHOUSE_ROLE": "<clickhouse-role>",
         "CLICKHOUSE_SECURE": "true",
         "CLICKHOUSE_VERIFY": "true",
         "CLICKHOUSE_CONNECT_TIMEOUT": "30",
@@ -298,6 +299,9 @@ The following environment variables are used to configure the ClickHouse and chD
 * `CLICKHOUSE_PORT`: The port number of your ClickHouse server
   * Default: `8443` if HTTPS is enabled, `8123` if disabled
   * Usually doesn't need to be set unless using a non-standard port
+* `CLICKHOUSE_ROLE`: The role to use for authentication
+  * Default: None
+  * Set this if your user requires a specific role
 * `CLICKHOUSE_SECURE`: Enable/disable HTTPS connection
   * Default: `"true"`
   * Set to `"false"` for non-secure connections

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -36,6 +36,7 @@ class ClickHouseConfig:
         CLICKHOUSE_PASSWORD: The password for authentication
 
     Optional environment variables (with defaults):
+        CLICKHOUSE_ROLE: The role to use for authentication (default: None)
         CLICKHOUSE_PORT: The port number (default: 8443 if secure=True, 8123 if secure=False)
         CLICKHOUSE_SECURE: Enable HTTPS (default: true)
         CLICKHOUSE_VERIFY: Verify SSL certificates (default: true)
@@ -84,6 +85,11 @@ class ClickHouseConfig:
     def password(self) -> str:
         """Get the ClickHouse password."""
         return os.environ["CLICKHOUSE_PASSWORD"]
+
+    @property
+    def role(self) -> Optional[str]:
+        """Get the ClickHouse role."""
+        return os.getenv("CLICKHOUSE_ROLE")
 
     @property
     def database(self) -> Optional[str]:
@@ -144,6 +150,10 @@ class ClickHouseConfig:
             "send_receive_timeout": self.send_receive_timeout,
             "client_name": "mcp_clickhouse",
         }
+
+        # Add optional role if set
+        if self.role:
+            config.setdefault("settings", {})["role"] = self.role
 
         # Add optional database if set
         if self.database:

--- a/tests/test_config_interface.py
+++ b/tests/test_config_interface.py
@@ -81,3 +81,16 @@ def test_interface_https_with_custom_port(monkeypatch: pytest.MonkeyPatch):
     assert client_config["interface"] == "https"
     assert client_config["secure"] is True
     assert client_config["port"] == 9443
+
+
+def test_role_configuration(monkeypatch: pytest.MonkeyPatch):
+    """Test that role is correctly configured when CLICKHOUSE_ROLE is set."""
+    monkeypatch.setenv("CLICKHOUSE_HOST", "localhost")
+    monkeypatch.setenv("CLICKHOUSE_USER", "test")
+    monkeypatch.setenv("CLICKHOUSE_PASSWORD", "test")
+    monkeypatch.setenv("CLICKHOUSE_ROLE", "analytics_reader")
+
+    config = ClickHouseConfig()
+    client_config = config.get_client_config()
+
+    assert client_config["settings"]["role"] == "analytics_reader"


### PR DESCRIPTION
# Add support for CLICKHOUSE_ROLE environment variable

## Summary
This PR adds support for the `CLICKHOUSE_ROLE` environment variable, allowing users to specify a role for auth when connecting to ClickHouse.

## Changes
- Added `CLICKHOUSE_ROLE` to the list of optional environment variables in `mcp_env.py`.
- Updated `ClickHouseConfig` to include a `role` property.
- Updated `get_client_config` to pass the `role` to the ClickHouse client settings.
- Added unit tests in `tests/test_config_interface.py` to verify the configuration.

## Usage
```json
"env": {
  "CLICKHOUSE_ROLE": "my_role"
}
```
