### PR TITLE
Add ASGI app export for HTTP deployment

### DIFF
--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -579,3 +579,7 @@ if os.getenv("CHDB_ENABLED", "false").lower() == "true":
     )
     mcp.add_prompt(chdb_prompt)
     logger.info("chDB tools and prompts registered")
+
+
+# ASGI application for HTTP deployment (e.g., uvicorn mcp_clickhouse.mcp_server:app)
+app = mcp.http_app()


### PR DESCRIPTION
 Exposes the FastMCP application as an ASGI app, enabling HTTP-based deployment via uvicorn or other ASGI servers:

```bash
uvicorn mcp_clickhouse.mcp_server:app --host 0.0.0.0 --port 8000
```

This enables running the MCP server in containerized and cloud environments that require HTTP transport instead of stdio.

Changes

- Added single line: app = mcp.http_app() at the end of mcp_server.py

Test plan

- Verified server starts with uvicorn
- Verified MCP protocol handshake works over HTTP
- Existing stdio functionality unchanged
