### PR TITLE
Add MCPB bundle support for HTTP deployment

### DIFF
--- a/.github/workflows/build-bundle.yml
+++ b/.github/workflows/build-bundle.yml
@@ -1,0 +1,67 @@
+name: Build MCPB Bundle
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g., 0.1.13)'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update manifest version
+        run: |
+          jq --arg v "${{ steps.version.outputs.version }}" '.version = $v' manifest.json > manifest.tmp.json
+          mv manifest.tmp.json manifest.json
+
+      - uses: NimbleBrainInc/mcpb-pack@v1
+        id: pack
+        with:
+          python-version: '3.14'
+          output: mcp-clickhouse-v${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}.mcpb
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bundle-${{ matrix.arch }}
+          path: ${{ steps.pack.outputs.bundle-path }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.mcpb
+          generate_release_notes: true

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,0 +1,38 @@
+# Development environment
+.venv/
+.git/
+.github/
+.pytest_cache/
+__pycache__/
+*.pyc
+.mypy_cache/
+.ruff_cache/
+.coverage
+
+# Test files
+tests/
+test-services/
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+*.mcpb
+
+# Dev config
+Makefile
+pytest.ini
+.env
+.env.*
+.editorconfig
+
+# Lock files
+uv.lock
+
+# IDE
+.vscode/
+.idea/
+
+# Docker (not needed in bundle)
+Dockerfile
+.dockerignore

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": "0.3",
+  "name": "ai.nimbletools/clickhouse",
+  "version": "0.1.13",
+  "description": "ClickHouse database connectivity with read-only SQL queries, schema exploration, and chDB support",
+  "author": {
+    "name": "ClickHouse Inc"
+  },
+  "server": {
+    "type": "python",
+    "entry_point": "mcp_clickhouse/mcp_server.py",
+    "mcp_config": {
+      "command": "python",
+      "args": [
+        "${__dirname}/mcp_clickhouse/mcp_server.py"
+      ]
+    }
+  }
+}

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -579,3 +579,7 @@ if os.getenv("CHDB_ENABLED", "false").lower() == "true":
     )
     mcp.add_prompt(chdb_prompt)
     logger.info("chDB tools and prompts registered")
+
+
+# ASGI application for HTTP deployment (e.g., uvicorn mcp_clickhouse.mcp_server:app)
+app = mcp.http_app()


### PR DESCRIPTION
- Export ASGI app for uvicorn (mcp_clickhouse.mcp_server:app)
- Add manifest.json for MCPB packaging
- Add .mcpbignore to exclude dev files from bundle
- Add build-bundle.yml workflow for CI/CD

This enables deployment via MCPB bundles while preserving all existing functionality (stdio, HTTP, SSE transports).