### PR TITLE
Client config override support via MCP Context Session states

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ logger = logging.getLogger("my-middleware")
 
 class LoggingMiddleware(Middleware):
     """Log all tool calls."""
-
+    
     async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
         tool_name = context.message.name if hasattr(context.message, 'name') else 'unknown'
         logger.info(f"Calling tool: {tool_name}")

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ logger = logging.getLogger("my-middleware")
 
 class LoggingMiddleware(Middleware):
     """Log all tool calls."""
-    
+
     async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
         tool_name = context.message.name if hasattr(context.message, 'name') else 'unknown'
         logger.info(f"Calling tool: {tool_name}")
@@ -401,6 +401,22 @@ The `Middleware` base class provides hooks for different MCP operations:
 - `on_list_prompts(context, call_next)` - Called when listing prompts
 
 Each hook receives a `MiddlewareContext` object containing the message and metadata, and a `call_next` function to continue the pipeline.
+
+### Dynamic Client Configuration via Context State
+
+Middleware can override ClickHouse client configuration on a per-request basis by setting the `clickhouse_client_config_overrides` context state. The server merges these overrides with the base configuration from environment variables.
+
+```python
+from fastmcp.server.dependencies import get_context
+
+ctx = get_context()
+ctx.set_state("clickhouse_client_config_overrides", {
+    "connect_timeout": 60,
+    "send_receive_timeout": 120
+})
+```
+
+This enables advanced use cases like dynamic timeout adjustments, tenant-specific routing, or per-user connection settings.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -404,13 +404,14 @@ Each hook receives a `MiddlewareContext` object containing the message and metad
 
 ### Dynamic Client Configuration via Context State
 
-Middleware can override ClickHouse client configuration on a per-request basis by setting the `clickhouse_client_config_overrides` context state. The server merges these overrides with the base configuration from environment variables.
+Middleware can override ClickHouse client configuration on a per-request basis using the `CLIENT_CONFIG_OVERRIDES_KEY` context state key. The server merges these overrides with the base configuration from environment variables.
 
 ```python
 from fastmcp.server.dependencies import get_context
+from mcp_clickhouse.mcp_server import CLIENT_CONFIG_OVERRIDES_KEY
 
 ctx = get_context()
-ctx.set_state("clickhouse_client_config_overrides", {
+ctx.set_state(CLIENT_CONFIG_OVERRIDES_KEY, {
     "connect_timeout": 60,
     "send_receive_timeout": 120
 })

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -59,6 +59,7 @@ class Table:
 
 
 MCP_SERVER_NAME = "mcp-clickhouse"
+CLIENT_CONFIG_OVERRIDES_KEY = "clickhouse_client_config_overrides"
 
 # Configure logging
 logging.basicConfig(
@@ -503,9 +504,9 @@ def create_clickhouse_client():
 
     try:
         ctx = get_context()
-        session_config_overrides = ctx.get_state("clickhouse_client_config_overrides")
+        session_config_overrides = ctx.get_state(CLIENT_CONFIG_OVERRIDES_KEY)
         if session_config_overrides:
-            logger.info(f"Applying session-specific ClickHouse client config overrides {session_config_overrides}")
+            logger.debug(f"Applying session-specific ClickHouse client config overrides: {list(session_config_overrides.keys())}")
             client_config.update(session_config_overrides)
     except RuntimeError:
         # If we're outside a request context, just proceed with the default config

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -505,7 +505,9 @@ def create_clickhouse_client():
     try:
         ctx = get_context()
         session_config_overrides = ctx.get_state(CLIENT_CONFIG_OVERRIDES_KEY)
-        if session_config_overrides:
+        if session_config_overrides and not isinstance(session_config_overrides, dict):
+            logger.warning(f"{CLIENT_CONFIG_OVERRIDES_KEY} must be a dict, got {type(session_config_overrides).__name__}. Ignoring.")
+        elif session_config_overrides:
             logger.debug(f"Applying session-specific ClickHouse client config overrides: {list(session_config_overrides.keys())}")
             client_config.update(session_config_overrides)
     except RuntimeError:

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -16,6 +16,7 @@ from cachetools import TTLCache
 from fastmcp.tools import Tool
 from fastmcp.prompts import Prompt
 from fastmcp.exceptions import ToolError
+from fastmcp.server.dependencies import get_context
 from dataclasses import dataclass, field, asdict, is_dataclass
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
@@ -499,6 +500,13 @@ def run_query(query: str):
 
 def create_clickhouse_client():
     client_config = get_config().get_client_config()
+
+    ctx = get_context()
+    session_config_overrides = ctx.get_state("clickhouse_client_config_overrides")
+    if session_config_overrides:
+        logger.info(f"Applying session-specific ClickHouse client config overrides {session_config_overrides}")
+        client_config.update(session_config_overrides)
+
     logger.info(
         f"Creating ClickHouse client connection to {client_config['host']}:{client_config['port']} "
         f"as {client_config['username']} "

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -501,11 +501,15 @@ def run_query(query: str):
 def create_clickhouse_client():
     client_config = get_config().get_client_config()
 
-    ctx = get_context()
-    session_config_overrides = ctx.get_state("clickhouse_client_config_overrides")
-    if session_config_overrides:
-        logger.info(f"Applying session-specific ClickHouse client config overrides {session_config_overrides}")
-        client_config.update(session_config_overrides)
+    try:
+        ctx = get_context()
+        session_config_overrides = ctx.get_state("clickhouse_client_config_overrides")
+        if session_config_overrides:
+            logger.info(f"Applying session-specific ClickHouse client config overrides {session_config_overrides}")
+            client_config.update(session_config_overrides)
+    except RuntimeError:
+        # If we're outside a request context, just proceed with the default config
+        pass
 
     logger.info(
         f"Creating ClickHouse client connection to {client_config['host']}:{client_config['port']} "

--- a/tests/test_context_config_override.py
+++ b/tests/test_context_config_override.py
@@ -1,0 +1,159 @@
+"""Tests for context state-based ClickHouse client configuration overrides."""
+
+import pytest
+import pytest_asyncio
+from fastmcp import Client
+from fastmcp.server.middleware import Middleware, MiddlewareContext, CallNext
+from fastmcp.server.dependencies import get_context
+from mcp_clickhouse.mcp_server import mcp, create_clickhouse_client
+from dotenv import load_dotenv
+import asyncio
+import os
+
+load_dotenv()
+
+# Skip all tests if ClickHouse is not configured
+pytestmark = pytest.mark.skipif(
+    not all([
+        os.getenv("CLICKHOUSE_HOST"),
+        os.getenv("CLICKHOUSE_USER"),
+        os.getenv("CLICKHOUSE_PASSWORD")
+    ]),
+    reason="ClickHouse environment variables not set"
+)
+
+
+class ConfigOverrideMiddleware(Middleware):
+    """Test middleware that sets ClickHouse client config overrides."""
+
+    def __init__(self, overrides: dict):
+        self.overrides = overrides
+
+    async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
+        """Set config overrides in context state before tool execution."""
+        ctx = get_context()
+        ctx.set_state("clickhouse_client_config_overrides", self.overrides)
+        return await call_next(context)
+
+
+@pytest.fixture(scope="module")
+def event_loop():
+    """Create an instance of the default event loop for the test session."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture
+def mcp_server():
+    """Return the MCP server instance for testing."""
+    return mcp
+
+
+@pytest.mark.asyncio
+async def test_context_state_config_override(mcp_server):
+    """Test that config overrides from context state are applied."""
+    # Add middleware with custom timeout overrides
+    test_overrides = {
+        "connect_timeout": 99,
+        "send_receive_timeout": 199,
+    }
+    
+    middleware = ConfigOverrideMiddleware(test_overrides)
+    mcp_server.add_middleware(middleware)
+
+    try:
+        async with Client(mcp_server) as client:
+            # Call any tool - the middleware should inject config overrides
+            result = await client.call_tool("list_databases", {})
+            
+            # If we got here without errors, the client was created successfully
+            # with the overridden configuration
+            assert len(result.content) >= 1
+    finally:
+        # Clean up middleware
+        if middleware in mcp_server.middleware:
+            mcp_server.middleware.remove(middleware)
+
+
+@pytest.mark.asyncio
+async def test_context_state_empty_override(mcp_server):
+    """Test that empty config overrides don't break client creation."""
+    middleware = ConfigOverrideMiddleware({})
+    mcp_server.add_middleware(middleware)
+
+    try:
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("list_databases", {})
+            assert len(result.content) >= 1
+    finally:
+        if middleware in mcp_server.middleware:
+            mcp_server.middleware.remove(middleware)
+
+
+@pytest.mark.asyncio
+async def test_context_state_no_override(mcp_server):
+    """Test that client creation works without any config overrides."""
+    # Don't add any middleware - context state should be empty
+    async with Client(mcp_server) as client:
+        result = await client.call_tool("list_databases", {})
+        assert len(result.content) >= 1
+
+
+def test_create_client_with_context_override():
+    """Test create_clickhouse_client with context state override."""
+    # This test runs synchronously to verify the client creation logic
+    # Note: This requires an active context, which is set up by FastMCP
+    # during actual request handling
+    
+    # We can't easily test this without the full FastMCP request context,
+    # so this is a placeholder for documentation purposes.
+    # The real testing happens in the async tests above where FastMCP
+    # provides the proper context.
+    pass
+
+
+@pytest.mark.asyncio
+async def test_multiple_tools_with_override(mcp_server):
+    """Test that config overrides work across multiple tool calls."""
+    test_overrides = {
+        "connect_timeout": 88,
+    }
+    
+    middleware = ConfigOverrideMiddleware(test_overrides)
+    mcp_server.add_middleware(middleware)
+
+    try:
+        async with Client(mcp_server) as client:
+            # Call multiple tools
+            result1 = await client.call_tool("list_databases", {})
+            assert len(result1.content) >= 1
+            
+            # The override should still be active for subsequent calls
+            result2 = await client.call_tool("list_databases", {})
+            assert len(result2.content) >= 1
+    finally:
+        if middleware in mcp_server.middleware:
+            mcp_server.middleware.remove(middleware)
+
+
+@pytest.mark.asyncio
+async def test_override_inherits_from_env(mcp_server):
+    """Test that overrides merge with base config from environment."""
+    # Override only timeout, other settings should come from env
+    test_overrides = {
+        "connect_timeout": 77,
+    }
+    
+    middleware = ConfigOverrideMiddleware(test_overrides)
+    mcp_server.add_middleware(middleware)
+
+    try:
+        async with Client(mcp_server) as client:
+            # This should work because host, user, password, etc.
+            # still come from environment variables
+            result = await client.call_tool("list_databases", {})
+            assert len(result.content) >= 1
+    finally:
+        if middleware in mcp_server.middleware:
+            mcp_server.middleware.remove(middleware)

--- a/tests/test_context_config_override.py
+++ b/tests/test_context_config_override.py
@@ -1,25 +1,16 @@
 """Tests for context state-based ClickHouse client configuration overrides."""
 
 import pytest
-import pytest_asyncio
+from unittest.mock import patch, MagicMock
+
 from fastmcp import Client
 from fastmcp.server.middleware import Middleware, MiddlewareContext, CallNext
 from fastmcp.server.dependencies import get_context
-from mcp_clickhouse.mcp_server import mcp, create_clickhouse_client
-from dotenv import load_dotenv
-import asyncio
-import os
 
-load_dotenv()
-
-# Skip all tests if ClickHouse is not configured
-pytestmark = pytest.mark.skipif(
-    not all([
-        os.getenv("CLICKHOUSE_HOST"),
-        os.getenv("CLICKHOUSE_USER"),
-        os.getenv("CLICKHOUSE_PASSWORD")
-    ]),
-    reason="ClickHouse environment variables not set"
+from mcp_clickhouse.mcp_server import (
+    mcp,
+    create_clickhouse_client,
+    CLIENT_CONFIG_OVERRIDES_KEY,
 )
 
 
@@ -30,18 +21,70 @@ class ConfigOverrideMiddleware(Middleware):
         self.overrides = overrides
 
     async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
-        """Set config overrides in context state before tool execution."""
         ctx = get_context()
-        ctx.set_state("clickhouse_client_config_overrides", self.overrides)
+        ctx.set_state(CLIENT_CONFIG_OVERRIDES_KEY, self.overrides)
         return await call_next(context)
 
 
-@pytest.fixture(scope="module")
-def event_loop():
-    """Create an instance of the default event loop for the test session."""
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    yield loop
-    loop.close()
+class TestConfigOverrideUnit:
+    """Unit tests for the config override merge logic in create_clickhouse_client."""
+
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    @patch("mcp_clickhouse.mcp_server.get_context")
+    def test_overrides_merged_into_client_config(self, mock_get_context, mock_cc):
+        """Verify overrides from context state are merged into the client config."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = {"connect_timeout": 99, "send_receive_timeout": 199}
+        mock_get_context.return_value = mock_ctx
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client()
+
+        call_kwargs = mock_cc.get_client.call_args[1]
+        assert call_kwargs["connect_timeout"] == 99
+        assert call_kwargs["send_receive_timeout"] == 199
+
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    @patch("mcp_clickhouse.mcp_server.get_context")
+    def test_empty_overrides_no_change(self, mock_get_context, mock_cc):
+        """Empty overrides dict should not alter the base config."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = {}
+        mock_get_context.return_value = mock_ctx
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client()
+
+        call_kwargs = mock_cc.get_client.call_args[1]
+        # Base config values from env should pass through unchanged
+        assert "host" in call_kwargs
+        assert "username" in call_kwargs
+
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    @patch("mcp_clickhouse.mcp_server.get_context")
+    def test_no_overrides_in_context(self, mock_get_context, mock_cc):
+        """When context state has no overrides, base config is used as-is."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = None
+        mock_get_context.return_value = mock_ctx
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client()
+
+        call_kwargs = mock_cc.get_client.call_args[1]
+        assert "host" in call_kwargs
+
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_no_request_context_falls_back_to_defaults(self, mock_cc):
+        """Outside a request context (RuntimeError), base config is used."""
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        # get_context is NOT mocked, so it will raise RuntimeError
+        # since there's no active FastMCP request context
+        create_clickhouse_client()
+
+        call_kwargs = mock_cc.get_client.call_args[1]
+        assert "host" in call_kwargs
 
 
 @pytest.fixture
@@ -50,110 +93,29 @@ def mcp_server():
     return mcp
 
 
-@pytest.mark.asyncio
-async def test_context_state_config_override(mcp_server):
-    """Test that config overrides from context state are applied."""
-    # Add middleware with custom timeout overrides
-    test_overrides = {
-        "connect_timeout": 99,
-        "send_receive_timeout": 199,
-    }
-    
-    middleware = ConfigOverrideMiddleware(test_overrides)
-    mcp_server.add_middleware(middleware)
+@pytest.mark.skipif(
+    not __import__("os").getenv("CLICKHOUSE_HOST"),
+    reason="ClickHouse environment variables not set",
+)
+class TestConfigOverrideIntegration:
+    """Integration tests that verify overrides work end-to-end with a real ClickHouse."""
 
-    try:
-        async with Client(mcp_server) as client:
-            # Call any tool - the middleware should inject config overrides
-            result = await client.call_tool("list_databases", {})
-            
-            # If we got here without errors, the client was created successfully
-            # with the overridden configuration
-            assert len(result.content) >= 1
-    finally:
-        # Clean up middleware
-        if middleware in mcp_server.middleware:
-            mcp_server.middleware.remove(middleware)
+    @pytest.mark.asyncio
+    async def test_tool_call_with_overrides(self, mcp_server):
+        """Config overrides from middleware are applied during tool execution."""
+        middleware = ConfigOverrideMiddleware({"connect_timeout": 99})
+        mcp_server.add_middleware(middleware)
+        try:
+            async with Client(mcp_server) as client:
+                result = await client.call_tool("list_databases", {})
+                assert len(result.content) >= 1
+        finally:
+            if middleware in mcp_server.middleware:
+                mcp_server.middleware.remove(middleware)
 
-
-@pytest.mark.asyncio
-async def test_context_state_empty_override(mcp_server):
-    """Test that empty config overrides don't break client creation."""
-    middleware = ConfigOverrideMiddleware({})
-    mcp_server.add_middleware(middleware)
-
-    try:
+    @pytest.mark.asyncio
+    async def test_tool_call_without_overrides(self, mcp_server):
+        """Client creation works normally without any override middleware."""
         async with Client(mcp_server) as client:
             result = await client.call_tool("list_databases", {})
             assert len(result.content) >= 1
-    finally:
-        if middleware in mcp_server.middleware:
-            mcp_server.middleware.remove(middleware)
-
-
-@pytest.mark.asyncio
-async def test_context_state_no_override(mcp_server):
-    """Test that client creation works without any config overrides."""
-    # Don't add any middleware - context state should be empty
-    async with Client(mcp_server) as client:
-        result = await client.call_tool("list_databases", {})
-        assert len(result.content) >= 1
-
-
-def test_create_client_with_context_override():
-    """Test create_clickhouse_client with context state override."""
-    # This test runs synchronously to verify the client creation logic
-    # Note: This requires an active context, which is set up by FastMCP
-    # during actual request handling
-    
-    # We can't easily test this without the full FastMCP request context,
-    # so this is a placeholder for documentation purposes.
-    # The real testing happens in the async tests above where FastMCP
-    # provides the proper context.
-    pass
-
-
-@pytest.mark.asyncio
-async def test_multiple_tools_with_override(mcp_server):
-    """Test that config overrides work across multiple tool calls."""
-    test_overrides = {
-        "connect_timeout": 88,
-    }
-    
-    middleware = ConfigOverrideMiddleware(test_overrides)
-    mcp_server.add_middleware(middleware)
-
-    try:
-        async with Client(mcp_server) as client:
-            # Call multiple tools
-            result1 = await client.call_tool("list_databases", {})
-            assert len(result1.content) >= 1
-            
-            # The override should still be active for subsequent calls
-            result2 = await client.call_tool("list_databases", {})
-            assert len(result2.content) >= 1
-    finally:
-        if middleware in mcp_server.middleware:
-            mcp_server.middleware.remove(middleware)
-
-
-@pytest.mark.asyncio
-async def test_override_inherits_from_env(mcp_server):
-    """Test that overrides merge with base config from environment."""
-    # Override only timeout, other settings should come from env
-    test_overrides = {
-        "connect_timeout": 77,
-    }
-    
-    middleware = ConfigOverrideMiddleware(test_overrides)
-    mcp_server.add_middleware(middleware)
-
-    try:
-        async with Client(mcp_server) as client:
-            # This should work because host, user, password, etc.
-            # still come from environment variables
-            result = await client.call_tool("list_databases", {})
-            assert len(result.content) >= 1
-    finally:
-        if middleware in mcp_server.middleware:
-            mcp_server.middleware.remove(middleware)


### PR DESCRIPTION
Adds support for middleware-driven ClickHouse client configuration overrides using FastMCP's context state management. This enables per-request customization of connection parameters without modifying environment variables.
