### PR TITLE
Support outbound ClickHouse client certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+- Outbound ClickHouse HTTPS support for private CA bundles and client certificates through `CLICKHOUSE_CA_CERT`, `CLICKHOUSE_CLIENT_CERT`, `CLICKHOUSE_CLIENT_CERT_KEY`, and `CLICKHOUSE_TLS_MODE`. Mutual mode uses the certificate for ClickHouse user authentication without sending a password. Strict and proxy modes present the certificate while retaining Basic authentication. A custom `pool_mgr` override cannot be combined with these certificate settings. ([#116](https://github.com/ClickHouse/mcp-clickhouse/pull/116))
+
 ### Changed
 - The minimum clickhouse-connect version is now 1.0.0. Locked development and container environments now use clickhouse-connect 1.8.0 and cryptography 50.0.1.
 - Local development and README launcher examples now use Python 3.12. CI covers Python 3.10 through 3.14, with Python 3.10 retained as the supported minimum.
+- Request-scoped client overrides are now validated for TLS consistency before client creation. `verify`, `ca_cert`, `client_cert`, `client_cert_key`, `tls_mode`, `server_host_name`, and `pool_mgr` must be top-level overrides and are rejected under `generic_args` and as DSN query parameters. Previously `generic_args.verify` and a DSN `verify` parameter reached clickhouse-connect. DSN overrides cannot select the chdb backend.
+- A `secure` override now switches the client interface between `https` and `http`, and an explicit `interface` override must be `http` or `https` and agree with `secure`. Previously a `secure` override alone left the base interface in place. `secure` and `verify` override values must be booleans or the strings `true` or `false`. `verify` also accepts `proxy`.
 
 ## 0.6.0 - 2026-09-03
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ The following environment variables are used to configure the ClickHouse and chD
 * `CLICKHOUSE_VERIFY`: Enable/disable SSL certificate verification
   * Default: `"true"`
   * Set to `"false"` to disable certificate verification (not recommended for production)
-  * TLS certificates: The package uses your operating system trust store for TLS certificate verification via `truststore`. We call `truststore.inject_into_ssl()` at startup to ensure proper certificate handling. Python’s default SSL behavior is used as a fallback only if an unexpected error occurs.
+  * TLS certificates: The package uses your operating system trust store for TLS certificate verification via `truststore`. We call `truststore.inject_into_ssl()` at startup to ensure proper certificate handling. Python's default SSL behavior is used as a fallback only if an unexpected error occurs.
 * `CLICKHOUSE_CONNECT_TIMEOUT`: Connection timeout in seconds
   * Default: `"30"`
   * Increase this value if you experience connection timeouts
@@ -334,6 +334,30 @@ The following environment variables are used to configure the ClickHouse and chD
 * `CLICKHOUSE_ENABLED`: Enable/disable ClickHouse functionality
   * Default: `"true"`
   * Set to `"false"` to disable ClickHouse tools when using chDB only
+
+##### mTLS (Mutual TLS) Variables
+
+These variables enable client certificate authentication for ClickHouse servers that require mutual TLS:
+
+* `CLICKHOUSE_CA_CERT`: Path to CA certificate file
+  * Default: None
+  * Set this to specify a custom CA certificate for SSL verification
+  * Example: `/path/to/ca.crt`
+* `CLICKHOUSE_CLIENT_CERT`: Path to client certificate file
+  * Default: None
+  * Required for mTLS authentication
+  * Can be a `.pem` file containing both the certificate and private key
+  * Example: `/path/to/client.crt` or `/path/to/client.pem`
+* `CLICKHOUSE_CLIENT_CERT_KEY`: Path to client private key file
+  * Default: None
+  * Optional if `CLICKHOUSE_CLIENT_CERT` is a `.pem` file containing both the certificate and private key
+  * Example: `/path/to/client.key`
+* `CLICKHOUSE_TLS_MODE`: TLS mode for client certificate authentication
+  * Default: None (auto-detected based on `CLICKHOUSE_CLIENT_CERT`)
+  * Valid options:
+    * `"mutual"` - Use client certificate for authentication (default when `CLICKHOUSE_CLIENT_CERT` is set)
+    * `"proxy"` - TLS termination at proxy, use Basic Auth with client certs for TLS only
+    * `"strict"` - Strict TLS mode with Basic Auth
 
 #### chDB Variables
 
@@ -380,6 +404,55 @@ CLICKHOUSE_HOST=sql-clickhouse.clickhouse.com
 CLICKHOUSE_USER=demo
 CLICKHOUSE_PASSWORD=
 # Uses secure defaults (HTTPS on port 8443)
+```
+
+For ClickHouse with mTLS (Mutual TLS):
+
+```env
+# Required variables
+CLICKHOUSE_HOST=your-secure-clickhouse.example.com
+CLICKHOUSE_PORT=8443
+CLICKHOUSE_USER=your-user
+CLICKHOUSE_PASSWORD=your-password
+
+# mTLS configuration
+CLICKHOUSE_SECURE=true
+CLICKHOUSE_CA_CERT=/path/to/ca.crt
+CLICKHOUSE_CLIENT_CERT=/path/to/client.crt
+CLICKHOUSE_CLIENT_CERT_KEY=/path/to/client.key
+
+# Or if using a combined .pem file:
+# CLICKHOUSE_CLIENT_CERT=/path/to/client.pem
+```
+
+Example Claude Desktop configuration with mTLS:
+
+```json
+{
+  "mcpServers": {
+    "mcp-clickhouse": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "mcp-clickhouse",
+        "--python",
+        "3.10",
+        "mcp-clickhouse"
+      ],
+      "env": {
+        "CLICKHOUSE_HOST": "your-secure-clickhouse.example.com",
+        "CLICKHOUSE_PORT": "8443",
+        "CLICKHOUSE_USER": "your-user",
+        "CLICKHOUSE_PASSWORD": "your-password",
+        "CLICKHOUSE_SECURE": "true",
+        "CLICKHOUSE_CA_CERT": "/path/to/ca.crt",
+        "CLICKHOUSE_CLIENT_CERT": "/path/to/client.crt",
+        "CLICKHOUSE_CLIENT_CERT_KEY": "/path/to/client.key"
+      }
+    }
+  }
+}
 ```
 
 For chDB only (in-memory):

--- a/README.md
+++ b/README.md
@@ -547,9 +547,12 @@ supplies `settings.role`. Top-level `role` and `ch_role` keys, plus the same key
 Set `verify`, `ca_cert`, `client_cert`, `client_cert_key`, `tls_mode`, `server_host_name`,
 and `pool_mgr` only as top-level overrides. They cannot be nested under `generic_args`. A
 custom `pool_mgr` cannot be combined with managed CA or client certificate settings. DSN query
-parameters cannot set these keys, and a DSN cannot select the chdb backend. Ordinary DSN
-routing and query settings remain supported. `secure` and `verify` overrides accept booleans
-or the strings `true` and `false`. `verify` also accepts `proxy`, which behaves as
+parameters cannot set these keys, and a DSN cannot select the chdb backend. Use explicit
+top-level `host`, `port`, `username`, `password`, `database`, and `secure` overrides to change
+the connection. A forwarded DSN does not replace populated base connection fields or select
+TLS. It can fill empty fields and supply supported query parameters such as `query_limit`.
+`secure` and `verify` overrides accept booleans or the strings `true` and `false`.
+`verify` also accepts `proxy`, which behaves as
 `tls_mode: proxy` when `tls_mode` is unset and therefore uses Basic authentication with the
 environment password. A `secure` override selects the matching `https` or `http` interface and
 does not change the port. An explicit `interface` override must be `http` or `https` and agree

--- a/README.md
+++ b/README.md
@@ -781,6 +781,30 @@ On an IPv6 or dual-stack bind, IPv4 proxies may appear as IPv4-mapped addresses 
   * The module must provide a `setup_middleware(mcp)` function
   * See [Custom Middleware](#custom-middleware) for details and examples
 
+##### mTLS (Mutual TLS) Variables
+
+These variables enable client certificate authentication for ClickHouse servers that require mutual TLS:
+
+* `CLICKHOUSE_CA_CERT`: Path to CA certificate file
+  * Default: None
+  * Set this to specify a custom CA certificate for SSL verification
+  * Example: `/path/to/ca.crt`
+* `CLICKHOUSE_CLIENT_CERT`: Path to client certificate file
+  * Default: None
+  * Required for mTLS authentication
+  * Can be a `.pem` file containing both the certificate and private key
+  * Example: `/path/to/client.crt` or `/path/to/client.pem`
+* `CLICKHOUSE_CLIENT_CERT_KEY`: Path to client private key file
+  * Default: None
+  * Optional if `CLICKHOUSE_CLIENT_CERT` is a `.pem` file containing both the certificate and private key
+  * Example: `/path/to/client.key`
+* `CLICKHOUSE_TLS_MODE`: TLS mode for client certificate authentication
+  * Default: None (auto-detected based on `CLICKHOUSE_CLIENT_CERT`)
+  * Valid options:
+    * `"mutual"` - Use client certificate for authentication (default when `CLICKHOUSE_CLIENT_CERT` is set)
+    * `"proxy"` - TLS termination at proxy, use Basic Auth with client certs for TLS only
+    * `"strict"` - Strict TLS mode with Basic Auth
+
 #### chDB Variables
 
 * `CHDB_ENABLED`: Enable/disable chDB functionality
@@ -833,6 +857,55 @@ CLICKHOUSE_HOST=sql-clickhouse.clickhouse.com
 CLICKHOUSE_USER=demo
 CLICKHOUSE_PASSWORD=
 # Uses secure defaults (HTTPS on port 8443)
+```
+
+For ClickHouse with mTLS (Mutual TLS):
+
+```env
+# Required variables
+CLICKHOUSE_HOST=your-secure-clickhouse.example.com
+CLICKHOUSE_PORT=8443
+CLICKHOUSE_USER=your-user
+CLICKHOUSE_PASSWORD=your-password
+
+# mTLS configuration
+CLICKHOUSE_SECURE=true
+CLICKHOUSE_CA_CERT=/path/to/ca.crt
+CLICKHOUSE_CLIENT_CERT=/path/to/client.crt
+CLICKHOUSE_CLIENT_CERT_KEY=/path/to/client.key
+
+# Or if using a combined .pem file:
+# CLICKHOUSE_CLIENT_CERT=/path/to/client.pem
+```
+
+Example Claude Desktop configuration with mTLS:
+
+```json
+{
+  "mcpServers": {
+    "mcp-clickhouse": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "mcp-clickhouse",
+        "--python",
+        "3.10",
+        "mcp-clickhouse"
+      ],
+      "env": {
+        "CLICKHOUSE_HOST": "your-secure-clickhouse.example.com",
+        "CLICKHOUSE_PORT": "8443",
+        "CLICKHOUSE_USER": "your-user",
+        "CLICKHOUSE_PASSWORD": "your-password",
+        "CLICKHOUSE_SECURE": "true",
+        "CLICKHOUSE_CA_CERT": "/path/to/ca.crt",
+        "CLICKHOUSE_CLIENT_CERT": "/path/to/client.crt",
+        "CLICKHOUSE_CLIENT_CERT_KEY": "/path/to/client.key"
+      }
+    }
+  }
+}
 ```
 
 For chDB only (in-memory):

--- a/README.md
+++ b/README.md
@@ -544,6 +544,19 @@ a ClickHouse client is created. `CLICKHOUSE_ROLE` remains active unless the over
 supplies `settings.role`. Top-level `role` and `ch_role` keys, plus the same keys under
 `generic_args`, are rejected.
 
+Set `verify`, `ca_cert`, `client_cert`, `client_cert_key`, `tls_mode`, `server_host_name`,
+and `pool_mgr` only as top-level overrides. They cannot be nested under `generic_args`. A
+custom `pool_mgr` cannot be combined with managed CA or client certificate settings. DSN query
+parameters cannot set these keys, and a DSN cannot select the chdb backend. Ordinary DSN
+routing and query settings remain supported. `secure` and `verify` overrides accept booleans
+or the strings `true` and `false`. `verify` also accepts `proxy`, which behaves as
+`tls_mode: proxy` when `tls_mode` is unset and therefore uses Basic authentication with the
+environment password. A `secure` override selects the matching `https` or `http` interface and
+does not change the port. An explicit `interface` override must be `http` or `https` and agree
+with `secure`. After merging overrides, default and `mutual` client certificate modes omit the
+password. `proxy` and `strict` modes use Basic authentication with the environment password
+unless the override supplies its own credentials.
+
 Treat these overrides as trusted middleware input. Middleware must authenticate and authorize
 request-derived values before setting them. Use `serializable=False` so FastMCP keeps the
 value in request-local state. The default `serializable=True` stores session state and is
@@ -591,12 +604,12 @@ Configuration is split into **independent** groups. Mixing them up is a common c
 
 | Group | Variables | Controls |
 |-------|-----------|----------|
-| **ClickHouse database connection** | `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_SECURE`, `CLICKHOUSE_VERIFY`, … | How **this MCP server** connects to your ClickHouse cluster over the **HTTP interface** |
+| **ClickHouse database connection** | `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_SECURE`, `CLICKHOUSE_VERIFY`, certificate variables | How **this MCP server** connects to your ClickHouse cluster over the **HTTP interface** |
 | **MCP server / transport** | `CLICKHOUSE_MCP_*`, `FASTMCP_SERVER_AUTH`, `FASTMCP_SERVER_AUTH_*`, `FASTMCP_ENV_FILE` | MCP transport, authentication, and query-tool execution limits |
 | **Middleware / chDB** | `MCP_MIDDLEWARE_MODULE`, `CHDB_*` | Optional extensions |
 
 > [!IMPORTANT]
-> Variables such as `CLICKHOUSE_SECURE`, `CLICKHOUSE_VERIFY`, and `CLICKHOUSE_PORT` apply to the **ClickHouse database** connection only. They do **not** configure TLS, ports, or auth for the MCP protocol endpoint.
+> `CLICKHOUSE_SECURE`, `CLICKHOUSE_VERIFY`, `CLICKHOUSE_CA_CERT`, `CLICKHOUSE_CLIENT_CERT`, `CLICKHOUSE_CLIENT_CERT_KEY`, `CLICKHOUSE_TLS_MODE`, and `CLICKHOUSE_PORT` apply to the outbound **ClickHouse database** connection only. They do **not** configure TLS, client certificates, ports, or authentication for the inbound MCP HTTP/SSE endpoint.
 >
 > Example: if the MCP server runs in Kubernetes behind an ingress that terminates TLS, that is an **MCP transport** concern. Keep `CLICKHOUSE_SECURE` aligned with how the pod reaches ClickHouse itself (HTTPS → `true`, plain HTTP → `false`). Setting `CLICKHOUSE_SECURE=false` because the MCP server is behind an ingress will make the server dial ClickHouse over HTTP—often against an HTTPS-only port—and produce opaque HTTP/TLS errors in the server logs.
 
@@ -610,6 +623,8 @@ mcp-clickhouse requires clickhouse-connect 1.0.0 or newer.
 * `CLICKHOUSE_HOST`: The hostname of your ClickHouse server (database endpoint, not the MCP server bind address)
 * `CLICKHOUSE_USER`: The username for **ClickHouse** authentication
 * `CLICKHOUSE_PASSWORD`: The password for **ClickHouse** authentication
+  * Required unless `CLICKHOUSE_CLIENT_CERT` uses the default or `"mutual"` TLS mode
+  * In default or `"mutual"` mode, certificate authentication is used and the password is not sent
 
 > [!CAUTION]
 > It is important to treat your MCP database user as you would any external client connecting to your database, granting only the minimum necessary privileges required for its operation. The use of default or administrative users should be strictly avoided at all times.
@@ -636,6 +651,26 @@ mcp-clickhouse requires clickhouse-connect 1.0.0 or newer.
   * Default: `"true"`
   * Set to `"false"` to disable certificate verification (not recommended for production)
   * TLS certificates: The package uses your operating system trust store for TLS certificate verification via `truststore`. We call `truststore.inject_into_ssl()` at startup to ensure proper certificate handling. Python’s default SSL behavior is used as a fallback only if an unexpected error occurs.
+* `CLICKHOUSE_CA_CERT`: Path to a PEM CA certificate bundle for the **ClickHouse** HTTPS connection
+  * Default: None (uses the operating system trust store)
+  * Use this by itself when a ClickHouse server or private proxy presents a certificate signed by a private CA. This changes server certificate verification and does not enable client certificate authentication.
+  * Requires `CLICKHOUSE_SECURE=true` and `CLICKHOUSE_VERIFY=true`
+* `CLICKHOUSE_CLIENT_CERT`: Path to a PEM client certificate for the **ClickHouse** HTTPS connection
+  * Default: None
+  * The file may also contain the private key. Otherwise set `CLICKHOUSE_CLIENT_CERT_KEY`.
+  * The ClickHouse user still comes from `CLICKHOUSE_USER`.
+* `CLICKHOUSE_CLIENT_CERT_KEY`: Path to the PEM private key for `CLICKHOUSE_CLIENT_CERT`
+  * Default: None
+  * Optional when the private key is included in the client certificate file
+  * Cannot be used without `CLICKHOUSE_CLIENT_CERT`
+* `CLICKHOUSE_TLS_MODE`: How clickhouse-connect uses `CLICKHOUSE_CLIENT_CERT`
+  * Default: None, which behaves as `"mutual"` when a client certificate is set
+  * `"mutual"`: Use the client certificate for ClickHouse X.509 user authentication. `CLICKHOUSE_PASSWORD` is optional and is not sent.
+  * `"proxy"`: Present the client certificate to a TLS-terminating proxy, then use ClickHouse Basic authentication. `CLICKHOUSE_PASSWORD` is required.
+  * `"strict"`: Present the client certificate because the ClickHouse server requires one at the TLS layer, then use ClickHouse Basic authentication. `CLICKHOUSE_PASSWORD` is required. This mode does not strengthen server certificate verification. `CLICKHOUSE_VERIFY` controls that verification.
+  * clickhouse-connect treats `"proxy"` and `"strict"` identically. The two names document intent.
+  * Values are trimmed and case-insensitive. A blank value is treated as unset. Other values are rejected before a ClickHouse client is created, on the first ClickHouse tool call or `/health` probe.
+  * Requires `CLICKHOUSE_CLIENT_CERT`. All client certificate options require `CLICKHOUSE_SECURE=true`.
 * `CLICKHOUSE_SERVER_HOST_NAME`: Server hostname for SNI override and certificate validation on the **ClickHouse** connection
   * Default: None (uses the connection hostname)
   * This is useful when connecting through proxies or load balancers where the certificate hostname differs from the connection hostname. When set, this hostname will be used for both SNI (Server Name Indication) during the TLS handshake and for certificate hostname validation.
@@ -662,6 +697,26 @@ mcp-clickhouse requires clickhouse-connect 1.0.0 or newer.
   * Default: `"false"`
   * Only takes effect when `CLICKHOUSE_ALLOW_WRITE_ACCESS=true` is also set
   * This gate is a best-effort accident guard in the MCP server, not a security boundary. Restrict the ClickHouse user's grants for real enforcement (see [Destructive Operation Protection](#destructive-operation-protection))
+
+##### ClickHouse TLS certificate files
+
+The certificate variables contain file paths, not PEM contents. mcp-clickhouse passes these
+paths to clickhouse-connect. For Docker or Kubernetes, mount the certificate and private key
+as read-only files and use their paths inside the container. Do not bake a private key into an
+image, commit it to source control, or put its contents in an environment variable.
+
+In `mutual` mode, the configured client certificate identifies this mcp-clickhouse process as
+`CLICKHOUSE_USER`. It does not authenticate inbound MCP clients or pass their identities to
+ClickHouse. Configure MCP transport authentication separately.
+
+Restart mcp-clickhouse after replacing a certificate or key at the same path when immediate
+rotation or revocation is required. Cached clients can retain existing TLS connections, and
+the cache does not track file contents or modification times.
+
+ClickHouse Cloud does not support X.509 client certificate authentication for database users.
+Use `CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD` for ClickHouse Cloud. A CA certificate can
+still be useful when a private proxy in front of an endpoint presents a certificate signed by
+a private CA.
 
 #### MCP server and transport
 
@@ -781,30 +836,6 @@ On an IPv6 or dual-stack bind, IPv4 proxies may appear as IPv4-mapped addresses 
   * The module must provide a `setup_middleware(mcp)` function
   * See [Custom Middleware](#custom-middleware) for details and examples
 
-##### mTLS (Mutual TLS) Variables
-
-These variables enable client certificate authentication for ClickHouse servers that require mutual TLS:
-
-* `CLICKHOUSE_CA_CERT`: Path to CA certificate file
-  * Default: None
-  * Set this to specify a custom CA certificate for SSL verification
-  * Example: `/path/to/ca.crt`
-* `CLICKHOUSE_CLIENT_CERT`: Path to client certificate file
-  * Default: None
-  * Required for mTLS authentication
-  * Can be a `.pem` file containing both the certificate and private key
-  * Example: `/path/to/client.crt` or `/path/to/client.pem`
-* `CLICKHOUSE_CLIENT_CERT_KEY`: Path to client private key file
-  * Default: None
-  * Optional if `CLICKHOUSE_CLIENT_CERT` is a `.pem` file containing both the certificate and private key
-  * Example: `/path/to/client.key`
-* `CLICKHOUSE_TLS_MODE`: TLS mode for client certificate authentication
-  * Default: None (auto-detected based on `CLICKHOUSE_CLIENT_CERT`)
-  * Valid options:
-    * `"mutual"` - Use client certificate for authentication (default when `CLICKHOUSE_CLIENT_CERT` is set)
-    * `"proxy"` - TLS termination at proxy, use Basic Auth with client certs for TLS only
-    * `"strict"` - Strict TLS mode with Basic Auth
-
 #### chDB Variables
 
 * `CHDB_ENABLED`: Enable/disable chDB functionality
@@ -859,54 +890,44 @@ CLICKHOUSE_PASSWORD=
 # Uses secure defaults (HTTPS on port 8443)
 ```
 
-For ClickHouse with mTLS (Mutual TLS):
+For a private server CA without client certificate authentication:
 
 ```env
-# Required variables
 CLICKHOUSE_HOST=your-secure-clickhouse.example.com
-CLICKHOUSE_PORT=8443
 CLICKHOUSE_USER=your-user
 CLICKHOUSE_PASSWORD=your-password
-
-# mTLS configuration
 CLICKHOUSE_SECURE=true
-CLICKHOUSE_CA_CERT=/path/to/ca.crt
-CLICKHOUSE_CLIENT_CERT=/path/to/client.crt
-CLICKHOUSE_CLIENT_CERT_KEY=/path/to/client.key
-
-# Or if using a combined .pem file:
-# CLICKHOUSE_CLIENT_CERT=/path/to/client.pem
+CLICKHOUSE_VERIFY=true
+CLICKHOUSE_CA_CERT=/run/secrets/clickhouse-ca.pem
 ```
 
-Example Claude Desktop configuration with mTLS:
+For ClickHouse X.509 client certificate authentication:
 
-```json
-{
-  "mcpServers": {
-    "mcp-clickhouse": {
-      "command": "uv",
-      "args": [
-        "run",
-        "--with",
-        "mcp-clickhouse",
-        "--python",
-        "3.10",
-        "mcp-clickhouse"
-      ],
-      "env": {
-        "CLICKHOUSE_HOST": "your-secure-clickhouse.example.com",
-        "CLICKHOUSE_PORT": "8443",
-        "CLICKHOUSE_USER": "your-user",
-        "CLICKHOUSE_PASSWORD": "your-password",
-        "CLICKHOUSE_SECURE": "true",
-        "CLICKHOUSE_CA_CERT": "/path/to/ca.crt",
-        "CLICKHOUSE_CLIENT_CERT": "/path/to/client.crt",
-        "CLICKHOUSE_CLIENT_CERT_KEY": "/path/to/client.key"
-      }
-    }
-  }
-}
+```env
+CLICKHOUSE_HOST=your-secure-clickhouse.example.com
+CLICKHOUSE_USER=your-certificate-user
+CLICKHOUSE_SECURE=true
+CLICKHOUSE_CLIENT_CERT=/run/secrets/clickhouse-client.pem
+CLICKHOUSE_CLIENT_CERT_KEY=/run/secrets/clickhouse-client-key.pem
+# CLICKHOUSE_CA_CERT=/run/secrets/clickhouse-ca.pem  # Only for a private server CA
+# CLICKHOUSE_TLS_MODE=mutual  # Optional. This is the default with a client certificate.
 ```
+
+For a client certificate required by a strict TLS server while ClickHouse uses Basic
+authentication:
+
+```env
+CLICKHOUSE_HOST=your-secure-clickhouse.example.com
+CLICKHOUSE_USER=your-user
+CLICKHOUSE_PASSWORD=your-password
+CLICKHOUSE_SECURE=true
+CLICKHOUSE_CLIENT_CERT=/run/secrets/clickhouse-client.pem
+CLICKHOUSE_CLIENT_CERT_KEY=/run/secrets/clickhouse-client-key.pem
+CLICKHOUSE_TLS_MODE=strict
+```
+
+Use `CLICKHOUSE_TLS_MODE=proxy` instead when a TLS-terminating proxy requires the client
+certificate and ClickHouse still uses Basic authentication.
 
 For chDB only (in-memory):
 

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -45,6 +45,10 @@ class ClickHouseConfig:
         CLICKHOUSE_DATABASE: Default database to use (default: None)
         CLICKHOUSE_PROXY_PATH: Path to be added to the host URL. For instance, for servers behind an HTTP proxy (default: None)
         CLICKHOUSE_ENABLED: Enable ClickHouse server (default: true)
+        CLICKHOUSE_CA_CERT: Path to CA certificate file for SSL verification (default: None)
+        CLICKHOUSE_CLIENT_CERT: Path to client certificate file for mTLS authentication (default: None)
+        CLICKHOUSE_CLIENT_CERT_KEY: Path to client private key file for mTLS authentication (default: None)
+        CLICKHOUSE_TLS_MODE: TLS mode for client certificate usage - "mutual", "proxy", or "strict" (default: None)
     """
 
     def __init__(self):
@@ -132,6 +136,46 @@ class ClickHouseConfig:
     def proxy_path(self) -> str:
         return os.getenv("CLICKHOUSE_PROXY_PATH")
 
+    @property
+    def ca_cert(self) -> Optional[str]:
+        """Get the path to CA certificate file for SSL verification.
+
+        Default: None
+        """
+        return os.getenv("CLICKHOUSE_CA_CERT")
+
+    @property
+    def client_cert(self) -> Optional[str]:
+        """Get the path to client certificate file for mTLS authentication.
+
+        Default: None
+        """
+        return os.getenv("CLICKHOUSE_CLIENT_CERT")
+
+    @property
+    def client_cert_key(self) -> Optional[str]:
+        """Get the path to client private key file for mTLS authentication.
+
+        This is optional if the client_cert file contains both the certificate
+        and the private key (e.g., a combined .pem file).
+
+        Default: None
+        """
+        return os.getenv("CLICKHOUSE_CLIENT_CERT_KEY")
+
+    @property
+    def tls_mode(self) -> Optional[str]:
+        """Get the TLS mode for client certificate usage.
+
+        Valid values:
+        - 'mutual': Use client certificate for authentication (default when client_cert is set)
+        - 'proxy': TLS termination at proxy, use Basic Auth with client certs for TLS only
+        - 'strict': Strict TLS mode, use Basic Auth with client certs for TLS only
+
+        Default: None (auto-detected by clickhouse-connect)
+        """
+        return os.getenv("CLICKHOUSE_TLS_MODE")
+
     def get_client_config(self) -> dict:
         """Get the configuration dictionary for clickhouse_connect client.
 
@@ -161,6 +205,19 @@ class ClickHouseConfig:
 
         if self.proxy_path:
             config["proxy_path"] = self.proxy_path
+
+        # Add mTLS configuration if set
+        if self.ca_cert:
+            config["ca_cert"] = self.ca_cert
+
+        if self.client_cert:
+            config["client_cert"] = self.client_cert
+
+        if self.client_cert_key:
+            config["client_cert_key"] = self.client_cert_key
+
+        if self.tls_mode:
+            config["tls_mode"] = self.tls_mode
 
         return config
 

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -52,6 +52,10 @@ class ClickHouseConfig:
         CLICKHOUSE_ENABLED: Enable ClickHouse server (default: true)
         CLICKHOUSE_ALLOW_WRITE_ACCESS: Allow write operations (DDL and DML) (default: false)
         CLICKHOUSE_ALLOW_DROP: Allow destructive operations (DROP, TRUNCATE) when writes are also enabled (default: false)
+        CLICKHOUSE_CA_CERT: Path to CA certificate file for SSL verification (default: None)
+        CLICKHOUSE_CLIENT_CERT: Path to client certificate file for mTLS authentication (default: None)
+        CLICKHOUSE_CLIENT_CERT_KEY: Path to client private key file for mTLS authentication (default: None)
+        CLICKHOUSE_TLS_MODE: TLS mode for client certificate usage - "mutual", "proxy", or "strict" (default: None)
     """
 
     def __init__(self):
@@ -163,6 +167,46 @@ class ClickHouseConfig:
         """
         return os.getenv("CLICKHOUSE_ALLOW_DROP", "false").lower() == "true"
 
+    @property
+    def ca_cert(self) -> Optional[str]:
+        """Get the path to CA certificate file for SSL verification.
+
+        Default: None
+        """
+        return os.getenv("CLICKHOUSE_CA_CERT")
+
+    @property
+    def client_cert(self) -> Optional[str]:
+        """Get the path to client certificate file for mTLS authentication.
+
+        Default: None
+        """
+        return os.getenv("CLICKHOUSE_CLIENT_CERT")
+
+    @property
+    def client_cert_key(self) -> Optional[str]:
+        """Get the path to client private key file for mTLS authentication.
+
+        This is optional if the client_cert file contains both the certificate
+        and the private key (e.g., a combined .pem file).
+
+        Default: None
+        """
+        return os.getenv("CLICKHOUSE_CLIENT_CERT_KEY")
+
+    @property
+    def tls_mode(self) -> Optional[str]:
+        """Get the TLS mode for client certificate usage.
+
+        Valid values:
+        - 'mutual': Use client certificate for authentication (default when client_cert is set)
+        - 'proxy': TLS termination at proxy, use Basic Auth with client certs for TLS only
+        - 'strict': Strict TLS mode, use Basic Auth with client certs for TLS only
+
+        Default: None (auto-detected by clickhouse-connect)
+        """
+        return os.getenv("CLICKHOUSE_TLS_MODE")
+
     def get_client_config(self) -> dict:
         """Get the configuration dictionary for clickhouse_connect client.
 
@@ -195,6 +239,19 @@ class ClickHouseConfig:
 
         if self.server_host_name:
             config["server_host_name"] = self.server_host_name
+
+        # Add mTLS configuration if set
+        if self.ca_cert:
+            config["ca_cert"] = self.ca_cert
+
+        if self.client_cert:
+            config["client_cert"] = self.client_cert
+
+        if self.client_cert_key:
+            config["client_cert_key"] = self.client_cert_key
+
+        if self.tls_mode:
+            config["tls_mode"] = self.tls_mode
 
         return config
 

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -9,9 +9,151 @@ from ipaddress import IPv4Network, IPv6Network, ip_network
 import os
 from typing import List, Optional
 from enum import Enum
+from urllib.parse import parse_qs, urlparse
 
 
 _IPV4_MAPPED_IPV6 = ip_network("::ffff:0:0/96")
+_TLS_MODES = frozenset({"mutual", "proxy", "strict"})
+TLS_TOP_LEVEL_ONLY_KEYS = frozenset(
+    {
+        "verify",
+        "ca_cert",
+        "client_cert",
+        "client_cert_key",
+        "tls_mode",
+        "server_host_name",
+        "pool_mgr",
+    }
+)
+
+
+def _normalize_tls_mode(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("CLICKHOUSE_TLS_MODE must be one of: mutual, proxy, strict")
+    value = value.strip().lower()
+    if not value:
+        return None
+    if value not in _TLS_MODES:
+        raise ValueError("CLICKHOUSE_TLS_MODE must be one of: mutual, proxy, strict")
+    return value
+
+
+def normalize_secure_flag(value: object) -> bool:
+    """Return the ClickHouse secure flag as a bool."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    raise ValueError("CLICKHOUSE_SECURE must be true or false")
+
+
+def _normalize_verify_flag(value: object) -> bool | str:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+        if normalized == "proxy":
+            return normalized
+    raise ValueError("CLICKHOUSE_VERIFY must be true, false, or proxy")
+
+
+def _effective_tls_mode(client_config: dict) -> Optional[str]:
+    tls_mode = _normalize_tls_mode(client_config.get("tls_mode"))
+    if tls_mode is not None:
+        return tls_mode
+    verify = client_config.get("verify")
+    if verify is not None and _normalize_verify_flag(verify) == "proxy":
+        return "proxy"
+    return None
+
+
+def _effective_interface(client_config: dict, secure: bool) -> str:
+    interface = client_config.get("interface")
+    if interface:
+        return interface
+    if secure or str(client_config.get("port")) in {"443", "8443"}:
+        return "https"
+    return "http"
+
+
+def _dsn_tls_query_keys(dsn: object) -> list[str]:
+    if not isinstance(dsn, str) or not dsn:
+        return []
+    try:
+        query = urlparse(dsn).query
+    except ValueError as exc:
+        raise ValueError("ClickHouse DSN override is not a valid URL") from exc
+    return sorted(TLS_TOP_LEVEL_ONLY_KEYS.intersection(parse_qs(query)))
+
+
+def uses_mutual_tls_auth(client_config: dict) -> bool:
+    """Return whether a client config selects ClickHouse certificate authentication."""
+    return bool(
+        client_config.get("client_cert") and _effective_tls_mode(client_config) in (None, "mutual")
+    )
+
+
+def validate_client_tls_config(client_config: dict) -> None:
+    """Validate and normalize ClickHouse TLS client settings."""
+    tls_mode = _normalize_tls_mode(client_config.get("tls_mode"))
+    if tls_mode is None:
+        client_config.pop("tls_mode", None)
+    else:
+        client_config["tls_mode"] = tls_mode
+
+    secure = False
+    if "secure" in client_config:
+        secure = normalize_secure_flag(client_config["secure"])
+        client_config["secure"] = secure
+
+    verify = None
+    if "verify" in client_config:
+        verify = _normalize_verify_flag(client_config["verify"])
+        client_config["verify"] = verify
+
+    dsn = client_config.get("dsn")
+    if isinstance(dsn, str) and dsn.startswith("chdb:"):
+        raise ValueError("ClickHouse DSN overrides cannot select the chdb backend")
+    dsn_tls_keys = _dsn_tls_query_keys(dsn)
+    if dsn_tls_keys:
+        raise ValueError(
+            "ClickHouse DSN query parameters cannot set managed TLS keys: "
+            f"{', '.join(dsn_tls_keys)}"
+        )
+
+    tls_options = {
+        "CLICKHOUSE_CA_CERT": client_config.get("ca_cert"),
+        "CLICKHOUSE_CLIENT_CERT": client_config.get("client_cert"),
+        "CLICKHOUSE_CLIENT_CERT_KEY": client_config.get("client_cert_key"),
+        "CLICKHOUSE_TLS_MODE": tls_mode,
+    }
+    configured_tls_options = ", ".join(name for name, value in tls_options.items() if value)
+    if configured_tls_options and not secure:
+        raise ValueError(f"{configured_tls_options} can only be used with CLICKHOUSE_SECURE=true")
+    if configured_tls_options and _effective_interface(client_config, secure) != "https":
+        raise ValueError(f"{configured_tls_options} can only be used with interface=https")
+    if configured_tls_options and client_config.get("pool_mgr") is not None:
+        raise ValueError(f"pool_mgr cannot be combined with {configured_tls_options}")
+
+    if client_config.get("client_cert_key") and not client_config.get("client_cert"):
+        raise ValueError("CLICKHOUSE_CLIENT_CERT_KEY requires CLICKHOUSE_CLIENT_CERT")
+    if tls_mode and not client_config.get("client_cert"):
+        raise ValueError("CLICKHOUSE_TLS_MODE requires CLICKHOUSE_CLIENT_CERT")
+    if client_config.get("ca_cert") and verify not in (True, "proxy"):
+        raise ValueError("CLICKHOUSE_CA_CERT requires CLICKHOUSE_VERIFY=true")
+
+    if uses_mutual_tls_auth(client_config):
+        client_config["password"] = ""
 
 
 class TransportType(str, Enum):
@@ -37,7 +179,7 @@ class ClickHouseConfig:
     Required environment variables (only when CLICKHOUSE_ENABLED=true):
         CLICKHOUSE_HOST: The hostname of the ClickHouse server
         CLICKHOUSE_USER: The username for authentication
-        CLICKHOUSE_PASSWORD: The password for authentication
+        CLICKHOUSE_PASSWORD: The password for authentication, except with mutual TLS
 
     Optional environment variables (with defaults):
         CLICKHOUSE_ROLE: The role to use for authentication (default: None)
@@ -95,7 +237,7 @@ class ClickHouseConfig:
     @property
     def password(self) -> str:
         """Get the ClickHouse password."""
-        return os.environ["CLICKHOUSE_PASSWORD"]
+        return os.getenv("CLICKHOUSE_PASSWORD", "")
 
     @property
     def role(self) -> Optional[str]:
@@ -199,13 +341,13 @@ class ClickHouseConfig:
         """Get the TLS mode for client certificate usage.
 
         Valid values:
-        - 'mutual': Use client certificate for authentication (default when client_cert is set)
-        - 'proxy': TLS termination at proxy, use Basic Auth with client certs for TLS only
-        - 'strict': Strict TLS mode, use Basic Auth with client certs for TLS only
+        - "mutual": Use client certificate authentication
+        - "proxy": Present a client certificate to a TLS proxy and use Basic authentication
+        - "strict": Present a client certificate and use Basic authentication
 
-        Default: None (auto-detected by clickhouse-connect)
+        Default: None (clickhouse-connect uses mutual when client_cert is set)
         """
-        return os.getenv("CLICKHOUSE_TLS_MODE")
+        return _normalize_tls_mode(os.getenv("CLICKHOUSE_TLS_MODE"))
 
     def get_client_config(self) -> dict:
         """Get the configuration dictionary for clickhouse_connect client.
@@ -253,6 +395,8 @@ class ClickHouseConfig:
         if self.tls_mode:
             config["tls_mode"] = self.tls_mode
 
+        validate_client_tls_config(config)
+
         return config
 
     def _validate_required_vars(self) -> None:
@@ -261,8 +405,21 @@ class ClickHouseConfig:
         Raises:
             ValueError: If any required environment variable is missing.
         """
+        tls_config = {
+            "secure": self.secure,
+            "verify": self.verify,
+            "ca_cert": self.ca_cert,
+            "client_cert": self.client_cert,
+            "client_cert_key": self.client_cert_key,
+            "tls_mode": self.tls_mode,
+        }
+        validate_client_tls_config(tls_config)
+
         missing_vars = []
-        for var in ["CLICKHOUSE_HOST", "CLICKHOUSE_USER", "CLICKHOUSE_PASSWORD"]:
+        required_vars = ["CLICKHOUSE_HOST", "CLICKHOUSE_USER"]
+        if not uses_mutual_tls_auth(tls_config):
+            required_vars.append("CLICKHOUSE_PASSWORD")
+        for var in required_vars:
             if var not in os.environ:
                 missing_vars.append(var)
 

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -42,7 +42,16 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from mcp_clickhouse.chdb_prompt import CHDB_PROMPT
 from mcp_clickhouse.http_security import transport_security_middleware
-from mcp_clickhouse.mcp_env import TransportType, get_chdb_config, get_config, get_mcp_config
+from mcp_clickhouse.mcp_env import (
+    TLS_TOP_LEVEL_ONLY_KEYS,
+    TransportType,
+    get_chdb_config,
+    get_config,
+    get_mcp_config,
+    normalize_secure_flag,
+    uses_mutual_tls_auth,
+    validate_client_tls_config,
+)
 from mcp_clickhouse.skills_advisor import CLICKHOUSE_SERVER_INSTRUCTIONS
 
 
@@ -2051,6 +2060,12 @@ def _snapshot_client_config_overrides(overrides: Any) -> Optional[dict[str, Any]
         if not isinstance(value, Mapping):
             raise ToolError(f"{CLIENT_CONFIG_OVERRIDES_KEY}.{key} must be a mapping")
         if key == "generic_args":
+            rejected_tls_keys = sorted(TLS_TOP_LEVEL_ONLY_KEYS.intersection(value))
+            if rejected_tls_keys:
+                raise ToolError(
+                    f"{CLIENT_CONFIG_OVERRIDES_KEY}.generic_args cannot set TLS client keys: "
+                    f"{', '.join(rejected_tls_keys)}"
+                )
             for role_key in _REJECTED_ROLE_OVERRIDE_KEYS:
                 if role_key in value:
                     raise ToolError(
@@ -2144,8 +2159,34 @@ def _resolve_client_config(
     else:
         overrides = _snapshot_client_config_overrides(client_config_overrides)
 
-    client_config = get_config().get_client_config()
-    _apply_client_config_overrides(client_config, overrides)
+    try:
+        client_config = get_config().get_client_config()
+        _apply_client_config_overrides(client_config, overrides)
+
+        if overrides is not None:
+            secure = normalize_secure_flag(client_config.get("secure"))
+            client_config["secure"] = secure
+            expected_interface = "https" if secure else "http"
+            if "interface" in overrides:
+                if client_config.get("interface") != expected_interface:
+                    raise ValueError(
+                        "ClickHouse client interface override must be http or https "
+                        "and match the secure setting"
+                    )
+            elif "secure" in overrides:
+                client_config["interface"] = expected_interface
+
+        password_overridden = bool(overrides is not None and "password" in overrides)
+        if (
+            not uses_mutual_tls_auth(client_config)
+            and not password_overridden
+            and client_config.get("password") in (None, "")
+            and "CLICKHOUSE_PASSWORD" in os.environ
+        ):
+            client_config["password"] = os.environ["CLICKHOUSE_PASSWORD"]
+        validate_client_tls_config(client_config)
+    except ValueError as exc:
+        raise ToolError(str(exc)) from exc
 
     timeout_overridden = bool(overrides and "send_receive_timeout" in overrides)
     if "CLICKHOUSE_SEND_RECEIVE_TIMEOUT" not in os.environ and not timeout_overridden:

--- a/server.json
+++ b/server.json
@@ -31,8 +31,8 @@
         },
         {
           "name": "CLICKHOUSE_PASSWORD",
-          "description": "Password for ClickHouse authentication",
-          "isRequired": true,
+          "description": "Password for ClickHouse authentication. Required unless a client certificate uses the default or mutual TLS mode",
+          "isRequired": false,
           "isSecret": true
         },
         {
@@ -52,6 +52,30 @@
           "description": "Verify SSL certificates",
           "format": "boolean",
           "default": "true",
+          "isRequired": false
+        },
+        {
+          "name": "CLICKHOUSE_CA_CERT",
+          "description": "Path to a PEM CA bundle for ClickHouse server certificate verification",
+          "format": "filepath",
+          "isRequired": false
+        },
+        {
+          "name": "CLICKHOUSE_CLIENT_CERT",
+          "description": "Path to a PEM client certificate for the ClickHouse HTTPS connection",
+          "format": "filepath",
+          "isRequired": false
+        },
+        {
+          "name": "CLICKHOUSE_CLIENT_CERT_KEY",
+          "description": "Path to the PEM private key for CLICKHOUSE_CLIENT_CERT",
+          "format": "filepath",
+          "isRequired": false
+        },
+        {
+          "name": "CLICKHOUSE_TLS_MODE",
+          "description": "Client certificate mode: mutual, proxy, or strict",
+          "choices": ["mutual", "proxy", "strict"],
           "isRequired": false
         },
         {
@@ -113,8 +137,8 @@
         },
         {
           "name": "CLICKHOUSE_PASSWORD",
-          "description": "Password for ClickHouse authentication",
-          "isRequired": true,
+          "description": "Password for ClickHouse authentication. Required unless a client certificate uses the default or mutual TLS mode",
+          "isRequired": false,
           "isSecret": true
         },
         {
@@ -134,6 +158,30 @@
           "description": "Verify SSL certificates",
           "format": "boolean",
           "default": "true",
+          "isRequired": false
+        },
+        {
+          "name": "CLICKHOUSE_CA_CERT",
+          "description": "Path to a PEM CA bundle for ClickHouse server certificate verification",
+          "format": "filepath",
+          "isRequired": false
+        },
+        {
+          "name": "CLICKHOUSE_CLIENT_CERT",
+          "description": "Path to a PEM client certificate for the ClickHouse HTTPS connection",
+          "format": "filepath",
+          "isRequired": false
+        },
+        {
+          "name": "CLICKHOUSE_CLIENT_CERT_KEY",
+          "description": "Path to the PEM private key for CLICKHOUSE_CLIENT_CERT",
+          "format": "filepath",
+          "isRequired": false
+        },
+        {
+          "name": "CLICKHOUSE_TLS_MODE",
+          "description": "Client certificate mode: mutual, proxy, or strict",
+          "choices": ["mutual", "proxy", "strict"],
           "isRequired": false
         },
         {

--- a/tests/test_context_config_override.py
+++ b/tests/test_context_config_override.py
@@ -1,6 +1,7 @@
 """Tests for request-scoped ClickHouse client configuration overrides."""
 
 import asyncio
+import base64
 import json
 import threading
 import time
@@ -9,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from clickhouse_connect.driver.httpclient import HttpClient
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
 from fastmcp.server.dependencies import get_context
@@ -314,16 +316,75 @@ class TestConfigOverrideUnit:
         assert "svc_user" not in str(exc_info.value)
         mock_cc.get_client.assert_not_called()
 
-    @patch("mcp_clickhouse.mcp_server.get_config")
-    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
-    def test_ordinary_dsn_query_is_preserved(self, mock_cc, mock_get_config):
-        dsn = "http://route.example:8123/default?query_limit=10"
-        mock_get_config.return_value = _mock_config(_base_client_config())
-        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+    @pytest.mark.parametrize(
+        ("base_password", "overrides", "expected_url", "expected_database", "expected_auth"),
+        [
+            pytest.param(
+                "base_password",
+                {},
+                "http://base.example:8123",
+                "base_db",
+                "base_user:base_password",
+                id="populated-base-fields-win",
+            ),
+            pytest.param(
+                "",
+                {},
+                "http://base.example:8123",
+                "base_db",
+                "base_user:dsn_password",
+                id="dsn-fills-empty-password",
+            ),
+            pytest.param(
+                "base_password",
+                {
+                    "host": "request.example",
+                    "port": 9443,
+                    "username": "request_user",
+                    "password": "request_password",
+                    "database": "request_db",
+                    "secure": True,
+                },
+                "https://request.example:9443",
+                "request_db",
+                "request_user:request_password",
+                id="explicit-request-fields-win",
+            ),
+        ],
+    )
+    def test_dsn_driver_connection_precedence(
+        self, monkeypatch, base_password, overrides, expected_url, expected_database, expected_auth
+    ):
+        def skip_server_discovery(client, *_args, **_kwargs):
+            client.server_version = "26.3.20.7"
 
-        create_clickhouse_client({"dsn": dsn})
+        monkeypatch.setattr(HttpClient, "_init_common_settings", skip_server_discovery)
+        dsn = "https://dsn_user:dsn_password@dsn.example:8443/dsn_db?query_limit=10"
 
-        assert mock_cc.get_client.call_args.kwargs["dsn"] == dsn
+        with patch.dict(
+            "os.environ",
+            {
+                "CLICKHOUSE_HOST": "base.example",
+                "CLICKHOUSE_PORT": "8123",
+                "CLICKHOUSE_USER": "base_user",
+                "CLICKHOUSE_PASSWORD": base_password,
+                "CLICKHOUSE_DATABASE": "base_db",
+                "CLICKHOUSE_SECURE": "false",
+                "CLICKHOUSE_VERIFY": "true",
+            },
+            clear=True,
+        ):
+            client = create_clickhouse_client({"dsn": dsn, **overrides})
+        try:
+            assert isinstance(client, HttpClient)
+            assert client.url == expected_url
+            assert client.database == expected_database
+            assert client.headers["Authorization"] == (
+                "Basic " + base64.b64encode(expected_auth.encode()).decode()
+            )
+            assert client.query_limit == 10
+        finally:
+            client.close()
 
     @pytest.mark.parametrize(
         ("secure", "expected_interface"),

--- a/tests/test_context_config_override.py
+++ b/tests/test_context_config_override.py
@@ -14,6 +14,7 @@ from fastmcp.exceptions import ToolError
 from fastmcp.server.dependencies import get_context
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 
+from mcp_clickhouse.mcp_env import TLS_TOP_LEVEL_ONLY_KEYS
 from mcp_clickhouse.mcp_server import (
     CLIENT_CONFIG_OVERRIDES_KEY,
     _active_queries,
@@ -174,6 +175,409 @@ class TestConfigOverrideUnit:
             create_clickhouse_client({key: "do-not-expose"})
 
         assert "do-not-expose" not in str(mock_cc.mock_calls)
+        mock_cc.get_client.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "verify",
+            "ca_cert",
+            "client_cert",
+            "client_cert_key",
+            "tls_mode",
+            "server_host_name",
+            "pool_mgr",
+        ],
+    )
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_generic_args_cannot_override_tls_client_keys(
+        self, mock_cc, mock_get_config, key
+    ):
+        with pytest.raises(ToolError, match=rf"generic_args.*{key}") as exc_info:
+            create_clickhouse_client({"generic_args": {key: "do-not-expose"}})
+
+        assert "do-not-expose" not in str(exc_info.value)
+        mock_get_config.assert_not_called()
+        mock_cc.get_client.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("overrides", "error_name"),
+        [
+            (
+                {"client_cert": "/secrets/client.pem", "secure": False},
+                "CLICKHOUSE_CLIENT_CERT",
+            ),
+            ({"client_cert_key": "/secrets/client-key.pem"}, "CLICKHOUSE_CLIENT_CERT_KEY"),
+            ({"tls_mode": "mutual"}, "CLICKHOUSE_TLS_MODE"),
+            (
+                {"ca_cert": "/secrets/ca.pem", "verify": False},
+                "CLICKHOUSE_CA_CERT",
+            ),
+            (
+                {"client_cert": "/secrets/client.pem", "tls_mode": "invalid"},
+                "CLICKHOUSE_TLS_MODE",
+            ),
+        ],
+    )
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_invalid_tls_overrides_fail_before_client_creation(
+        self, mock_cc, mock_get_config, overrides, error_name
+    ):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(interface="https", secure=True, verify=True)
+        )
+
+        with pytest.raises(ToolError, match=error_name) as exc_info:
+            create_clickhouse_client(overrides)
+
+        assert "/secrets/" not in str(exc_info.value)
+        assert "invalid" not in str(exc_info.value)
+        mock_cc.get_client.assert_not_called()
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_managed_certificate_requires_https_interface(self, mock_cc, mock_get_config):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(interface="http", secure=True)
+        )
+
+        with pytest.raises(ToolError, match="CLICKHOUSE_CLIENT_CERT.*interface=https"):
+            create_clickhouse_client({"client_cert": "/secrets/client.pem"})
+
+        mock_cc.get_client.assert_not_called()
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_pool_manager_cannot_bypass_managed_certificates(
+        self, mock_cc, mock_get_config
+    ):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(interface="https", secure=True, verify=True)
+        )
+
+        with pytest.raises(ToolError, match="pool_mgr.*CLICKHOUSE_CA_CERT") as exc_info:
+            create_clickhouse_client(
+                {"ca_cert": "/secrets/ca.pem", "pool_mgr": object()}
+            )
+
+        assert "/secrets/" not in str(exc_info.value)
+        mock_cc.get_client.assert_not_called()
+
+    @pytest.mark.parametrize("key", sorted(TLS_TOP_LEVEL_ONLY_KEYS))
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_dsn_query_cannot_override_managed_tls_config(self, mock_cc, mock_get_config, key):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(
+                interface="https",
+                secure=True,
+                verify=True,
+                ca_cert="/secrets/managed-ca.pem",
+            )
+        )
+
+        with pytest.raises(ToolError, match=rf"DSN.*{key}") as exc_info:
+            create_clickhouse_client(
+                {"dsn": f"https://route.example:8443/default?{key}=do-not-expose"}
+            )
+
+        assert "do-not-expose" not in str(exc_info.value)
+        assert "/secrets/" not in str(exc_info.value)
+        mock_cc.get_client.assert_not_called()
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_dsn_override_cannot_select_chdb_backend(self, mock_cc, mock_get_config):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(interface="https", secure=True, verify=True)
+        )
+
+        with pytest.raises(ToolError, match="chdb") as exc_info:
+            create_clickhouse_client({"dsn": "chdb://memory"})
+
+        assert "memory" not in str(exc_info.value)
+        mock_cc.get_client.assert_not_called()
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_invalid_dsn_override_does_not_echo_userinfo(self, mock_cc, mock_get_config):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(interface="https", secure=True, verify=True)
+        )
+
+        with pytest.raises(ToolError, match="not a valid URL") as exc_info:
+            create_clickhouse_client({"dsn": "https://svc_user:svc_secret_79@host\uff03x/db"})
+
+        assert "svc_secret_79" not in str(exc_info.value)
+        assert "svc_user" not in str(exc_info.value)
+        mock_cc.get_client.assert_not_called()
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_ordinary_dsn_query_is_preserved(self, mock_cc, mock_get_config):
+        dsn = "http://route.example:8123/default?query_limit=10"
+        mock_get_config.return_value = _mock_config(_base_client_config())
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client({"dsn": dsn})
+
+        assert mock_cc.get_client.call_args.kwargs["dsn"] == dsn
+
+    @pytest.mark.parametrize(
+        ("secure", "expected_interface"),
+        [(True, "https"), (False, "http")],
+    )
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_secure_override_keeps_interface_aligned(
+        self, mock_cc, mock_get_config, secure, expected_interface
+    ):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(interface="http" if secure else "https", secure=not secure)
+        )
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client({"secure": secure})
+
+        assert mock_cc.get_client.call_args.kwargs["interface"] == expected_interface
+
+    @pytest.mark.parametrize(
+        ("secure", "expected_secure"),
+        [("true", True), ("TRUE", True), (" false ", False)],
+    )
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_string_secure_override_is_normalized(
+        self, mock_cc, mock_get_config, secure, expected_secure
+    ):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(
+                interface="http" if expected_secure else "https", secure=not expected_secure
+            )
+        )
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client({"secure": secure})
+
+        call_kwargs = mock_cc.get_client.call_args.kwargs
+        assert call_kwargs["secure"] is expected_secure
+        assert call_kwargs["interface"] == ("https" if expected_secure else "http")
+
+    @pytest.mark.parametrize("secure", ["1", "yes", 1, "typo", None])
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_invalid_secure_override_is_rejected(self, mock_cc, mock_get_config, secure):
+        mock_get_config.return_value = _mock_config(_base_client_config())
+
+        with pytest.raises(ToolError, match="CLICKHOUSE_SECURE"):
+            create_clickhouse_client({"secure": secure})
+
+        mock_cc.get_client.assert_not_called()
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_inconsistent_secure_and_interface_overrides_are_rejected(
+        self, mock_cc, mock_get_config
+    ):
+        mock_get_config.return_value = _mock_config(_base_client_config())
+
+        with pytest.raises(ToolError, match="interface override must be http or https"):
+            create_clickhouse_client({"secure": True, "interface": "http"})
+
+        mock_cc.get_client.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("base_secure", "base_interface", "interface_override"),
+        [
+            (True, "https", "http"),
+            (False, "http", "https"),
+        ],
+    )
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_interface_override_must_agree_with_base_secure_setting(
+        self,
+        mock_cc,
+        mock_get_config,
+        base_secure,
+        base_interface,
+        interface_override,
+    ):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(secure=base_secure, interface=base_interface)
+        )
+
+        with pytest.raises(ToolError, match="interface override must be http or https"):
+            create_clickhouse_client({"interface": interface_override})
+
+        mock_cc.get_client.assert_not_called()
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_environment_tls_error_becomes_tool_error(self, mock_cc, mock_get_config):
+        mock_get_config.return_value.get_client_config.side_effect = ValueError(
+            "CLICKHOUSE_CLIENT_CERT requires CLICKHOUSE_SECURE=true"
+        )
+
+        with pytest.raises(ToolError, match="CLICKHOUSE_CLIENT_CERT"):
+            create_clickhouse_client()
+
+        mock_cc.get_client.assert_not_called()
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_token_auth_override_is_not_blocked_by_password_check(self, mock_cc, mock_get_config):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(interface="https", secure=True, verify=True)
+        )
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client({"username": None, "password": None, "access_token": "tok"})
+
+        call_kwargs = mock_cc.get_client.call_args.kwargs
+        assert call_kwargs["access_token"] == "tok"
+        assert call_kwargs["password"] is None
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_mutual_base_switching_to_strict_without_env_password_passes_through(
+        self, mock_cc, mock_get_config, monkeypatch
+    ):
+        monkeypatch.delenv("CLICKHOUSE_PASSWORD", raising=False)
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(
+                interface="https",
+                secure=True,
+                verify=True,
+                password="",
+                client_cert="/secrets/client.pem",
+            )
+        )
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client({"tls_mode": "strict"})
+
+        call_kwargs = mock_cc.get_client.call_args.kwargs
+        assert call_kwargs["password"] == ""
+        assert call_kwargs["tls_mode"] == "strict"
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_tls_overrides_are_normalized(self, mock_cc, mock_get_config):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(interface="https", secure=True, verify=True)
+        )
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client(
+            {
+                "ca_cert": "/secrets/ca.pem",
+                "client_cert": "/secrets/client.pem",
+                "client_cert_key": "/secrets/client-key.pem",
+                "tls_mode": "  PrOxY  ",
+            }
+        )
+
+        call_kwargs = mock_cc.get_client.call_args.kwargs
+        assert call_kwargs["ca_cert"] == "/secrets/ca.pem"
+        assert call_kwargs["client_cert"] == "/secrets/client.pem"
+        assert call_kwargs["client_cert_key"] == "/secrets/client-key.pem"
+        assert call_kwargs["tls_mode"] == "proxy"
+        assert call_kwargs["password"] == "secret"
+
+    @pytest.mark.parametrize("tls_mode", ["", "  "])
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_blank_tls_mode_override_means_unset(self, mock_cc, mock_get_config, tls_mode):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(
+                interface="https",
+                secure=True,
+                verify=True,
+                password="secret",
+                client_cert="/secrets/client.pem",
+                tls_mode="strict",
+            )
+        )
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client({"tls_mode": tls_mode})
+
+        call_kwargs = mock_cc.get_client.call_args.kwargs
+        assert "tls_mode" not in call_kwargs
+        assert call_kwargs["password"] == ""
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_mutual_tls_override_does_not_pass_base_password(
+        self, mock_cc, mock_get_config
+    ):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(interface="https", secure=True, verify=True)
+        )
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client({"client_cert": "/secrets/client.pem"})
+
+        assert mock_cc.get_client.call_args.kwargs["password"] == ""
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_verify_proxy_keeps_basic_auth_with_client_certificate(
+        self, mock_cc, mock_get_config, monkeypatch
+    ):
+        monkeypatch.setenv("CLICKHOUSE_PASSWORD", "proxy-secret")
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(
+                interface="https",
+                secure=True,
+                verify=True,
+                password="",
+                client_cert="/secrets/client.pem",
+            )
+        )
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client(
+            {"verify": "proxy", "ca_cert": "/secrets/ca.pem"}
+        )
+
+        call_kwargs = mock_cc.get_client.call_args.kwargs
+        assert call_kwargs["verify"] == "proxy"
+        assert call_kwargs["password"] == "proxy-secret"
+        assert "tls_mode" not in call_kwargs
+
+    @pytest.mark.parametrize(
+        ("verify", "expected"),
+        [("true", True), ("FALSE", False), ("Proxy", "proxy"), (True, True), (False, False)],
+    )
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_verify_override_is_normalized(self, mock_cc, mock_get_config, verify, expected):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(interface="https", secure=True, verify=True)
+        )
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client({"verify": verify})
+
+        actual = mock_cc.get_client.call_args.kwargs["verify"]
+        assert actual == expected
+        assert type(actual) is type(expected)
+
+    @pytest.mark.parametrize("verify", ["no", "typo", "1", None])
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_invalid_verify_override_is_rejected(self, mock_cc, mock_get_config, verify):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(interface="https", secure=True, verify=True)
+        )
+
+        with pytest.raises(ToolError, match="CLICKHOUSE_VERIFY"):
+            create_clickhouse_client({"verify": verify})
+
         mock_cc.get_client.assert_not_called()
 
     @pytest.mark.parametrize(
@@ -511,6 +915,24 @@ class TestConfigOverrideMcpBoundary:
 
             assert CLIENT_CONFIG_OVERRIDES_KEY in str(exc_info.value)
             assert invalid_value not in str(exc_info.value)
+            get_client.assert_not_called()
+        finally:
+            mcp_server.middleware.remove(middleware)
+
+    @pytest.mark.asyncio
+    async def test_tls_override_rejection_is_a_safe_tool_error(self, mcp_server):
+        middleware = ConfigOverrideMiddleware(
+            {"client_cert": "/secrets/client.pem", "secure": False}
+        )
+        mcp_server.add_middleware(middleware)
+        try:
+            with patch("mcp_clickhouse.mcp_server.clickhouse_connect.get_client") as get_client:
+                async with Client(mcp_server) as client:
+                    with pytest.raises(ToolError) as exc_info:
+                        await client.call_tool("list_databases", {})
+
+            assert "CLICKHOUSE_CLIENT_CERT" in str(exc_info.value)
+            assert "/secrets/" not in str(exc_info.value)
             get_client.assert_not_called()
         finally:
             mcp_server.middleware.remove(middleware)

--- a/tests/test_tls_config.py
+++ b/tests/test_tls_config.py
@@ -1,0 +1,198 @@
+from types import SimpleNamespace
+
+import pytest
+
+from mcp_clickhouse import mcp_server
+from mcp_clickhouse.mcp_env import ClickHouseConfig
+
+
+TLS_ENV_VARS = (
+    "CLICKHOUSE_CA_CERT",
+    "CLICKHOUSE_CLIENT_CERT",
+    "CLICKHOUSE_CLIENT_CERT_KEY",
+    "CLICKHOUSE_TLS_MODE",
+)
+
+
+@pytest.fixture(autouse=True)
+def clickhouse_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLICKHOUSE_ENABLED", "true")
+    monkeypatch.setenv("CLICKHOUSE_HOST", "clickhouse.example.com")
+    monkeypatch.setenv("CLICKHOUSE_USER", "mcp_user")
+    monkeypatch.setenv("CLICKHOUSE_PASSWORD", "secret")
+    monkeypatch.setenv("CLICKHOUSE_SECURE", "true")
+    monkeypatch.setenv("CLICKHOUSE_VERIFY", "true")
+    for name in TLS_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_tls_properties_and_client_config(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLICKHOUSE_CA_CERT", "/certs/ca.pem")
+    monkeypatch.setenv("CLICKHOUSE_CLIENT_CERT", "/certs/client.pem")
+    monkeypatch.setenv("CLICKHOUSE_CLIENT_CERT_KEY", "/certs/client-key.pem")
+    monkeypatch.setenv("CLICKHOUSE_TLS_MODE", "  StRiCt  ")
+
+    config = ClickHouseConfig()
+    client_config = config.get_client_config()
+
+    assert config.ca_cert == "/certs/ca.pem"
+    assert config.client_cert == "/certs/client.pem"
+    assert config.client_cert_key == "/certs/client-key.pem"
+    assert config.tls_mode == "strict"
+    assert client_config["ca_cert"] == "/certs/ca.pem"
+    assert client_config["client_cert"] == "/certs/client.pem"
+    assert client_config["client_cert_key"] == "/certs/client-key.pem"
+    assert client_config["tls_mode"] == "strict"
+    assert client_config["password"] == "secret"
+
+
+def test_tls_options_omitted_by_default():
+    client_config = ClickHouseConfig().get_client_config()
+
+    for name in ("ca_cert", "client_cert", "client_cert_key", "tls_mode"):
+        assert name not in client_config
+    assert client_config["password"] == "secret"
+
+
+def test_ca_cert_without_client_certificate(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLICKHOUSE_CA_CERT", "/certs/private-ca.pem")
+
+    client_config = ClickHouseConfig().get_client_config()
+
+    assert client_config["ca_cert"] == "/certs/private-ca.pem"
+    assert "client_cert" not in client_config
+    assert client_config["password"] == "secret"
+
+
+@pytest.mark.parametrize("env_password", [None, "secret"])
+@pytest.mark.parametrize("tls_mode", [None, "  MuTuAl  "])
+def test_mutual_tls_does_not_require_or_pass_password(
+    monkeypatch: pytest.MonkeyPatch, env_password: str | None, tls_mode: str | None
+):
+    monkeypatch.setenv("CLICKHOUSE_CLIENT_CERT", "/certs/client.pem")
+    if env_password is None:
+        monkeypatch.delenv("CLICKHOUSE_PASSWORD")
+    else:
+        monkeypatch.setenv("CLICKHOUSE_PASSWORD", env_password)
+    if tls_mode is not None:
+        monkeypatch.setenv("CLICKHOUSE_TLS_MODE", tls_mode)
+
+    client_config = ClickHouseConfig().get_client_config()
+
+    assert client_config["password"] == ""
+    if tls_mode is None:
+        assert "tls_mode" not in client_config
+    else:
+        assert client_config["tls_mode"] == "mutual"
+
+
+@pytest.mark.parametrize("name", ["CLICKHOUSE_HOST", "CLICKHOUSE_USER"])
+def test_mutual_tls_still_requires_host_and_user(monkeypatch: pytest.MonkeyPatch, name: str):
+    monkeypatch.setenv("CLICKHOUSE_CLIENT_CERT", "/certs/client.pem")
+    monkeypatch.delenv("CLICKHOUSE_PASSWORD")
+    monkeypatch.delenv(name)
+
+    with pytest.raises(ValueError, match=name):
+        ClickHouseConfig()
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {},
+        {"CLICKHOUSE_CA_CERT": "/certs/private-ca.pem"},
+        {"CLICKHOUSE_CLIENT_CERT": "/certs/client.pem", "CLICKHOUSE_TLS_MODE": "proxy"},
+        {"CLICKHOUSE_CLIENT_CERT": "/certs/client.pem", "CLICKHOUSE_TLS_MODE": "strict"},
+    ],
+    ids=["no-tls", "ca-only", "proxy", "strict"],
+)
+def test_password_required_without_mutual_tls(monkeypatch: pytest.MonkeyPatch, env: dict):
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.delenv("CLICKHOUSE_PASSWORD")
+
+    with pytest.raises(ValueError, match="CLICKHOUSE_PASSWORD"):
+        ClickHouseConfig()
+
+
+def test_invalid_tls_mode_is_rejected(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLICKHOUSE_CLIENT_CERT", "/certs/client.pem")
+    monkeypatch.setenv("CLICKHOUSE_TLS_MODE", "invalid")
+
+    with pytest.raises(ValueError, match="CLICKHOUSE_TLS_MODE.*mutual, proxy, strict"):
+        ClickHouseConfig()
+
+
+def test_blank_tls_mode_is_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLICKHOUSE_CLIENT_CERT", "/certs/client.pem")
+    monkeypatch.setenv("CLICKHOUSE_TLS_MODE", "  ")
+
+    client_config = ClickHouseConfig().get_client_config()
+
+    assert "tls_mode" not in client_config
+    assert client_config["password"] == ""
+
+
+def test_client_cert_key_requires_client_cert(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLICKHOUSE_CLIENT_CERT_KEY", "/certs/client-key.pem")
+
+    with pytest.raises(ValueError, match="CLICKHOUSE_CLIENT_CERT_KEY.*CLICKHOUSE_CLIENT_CERT"):
+        ClickHouseConfig()
+
+
+def test_tls_mode_requires_client_cert(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLICKHOUSE_TLS_MODE", "mutual")
+
+    with pytest.raises(ValueError, match="CLICKHOUSE_TLS_MODE.*CLICKHOUSE_CLIENT_CERT"):
+        ClickHouseConfig()
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("CLICKHOUSE_CA_CERT", "/certs/ca.pem"),
+        ("CLICKHOUSE_CLIENT_CERT", "/certs/client.pem"),
+        ("CLICKHOUSE_CLIENT_CERT_KEY", "/certs/client-key.pem"),
+        ("CLICKHOUSE_TLS_MODE", "mutual"),
+    ],
+)
+def test_tls_options_require_secure_connection(
+    monkeypatch: pytest.MonkeyPatch, name: str, value: str
+):
+    monkeypatch.setenv("CLICKHOUSE_SECURE", "false")
+    monkeypatch.setenv(name, value)
+
+    with pytest.raises(ValueError, match=f"{name}.*CLICKHOUSE_SECURE=true"):
+        ClickHouseConfig()
+
+
+def test_ca_cert_requires_certificate_verification(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLICKHOUSE_CA_CERT", "/certs/ca.pem")
+    monkeypatch.setenv("CLICKHOUSE_VERIFY", "false")
+
+    with pytest.raises(ValueError, match="CLICKHOUSE_CA_CERT.*CLICKHOUSE_VERIFY=true"):
+        ClickHouseConfig()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected", "readonly"),
+    [(None, False, "1"), ("false", False, "1"), ("true", True, "0")],
+)
+def test_write_access_property_controls_readonly_setting(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str | None,
+    expected: bool,
+    readonly: str,
+):
+    if value is None:
+        monkeypatch.delenv("CLICKHOUSE_ALLOW_WRITE_ACCESS", raising=False)
+    else:
+        monkeypatch.setenv("CLICKHOUSE_ALLOW_WRITE_ACCESS", value)
+
+    config = ClickHouseConfig()
+    monkeypatch.setattr(mcp_server, "get_config", lambda: config)
+
+    assert config.allow_write_access is expected
+    assert mcp_server.build_query_settings(SimpleNamespace(server_settings={})) == {
+        "readonly": readonly
+    }


### PR DESCRIPTION
Add outbound ClickHouse HTTPS configuration for private CA bundles and client certificates through `CLICKHOUSE_CA_CERT`, `CLICKHOUSE_CLIENT_CERT`, `CLICKHOUSE_CLIENT_CERT_KEY`, and `CLICKHOUSE_TLS_MODE`.

- Mutual mode uses certificate authentication without a password. Strict/proxy modes retain Basic authentication.
- Validate TLS settings and request overrides, preserve token and DSN authentication, and retain read-only defaults. Update tests, README, and registry metadata.
- Applies to the ClickHouse connection only. ClickHouse Cloud does not support X.509 user authentication.

Validation: Ruff clean. 710 tests passed, 1 xfailed. Live probes on ClickHouse 26.3.20.7 covered certificate authentication, TLS proxies, invalid configuration, read-only enforcement, and concurrent identity isolation.

Closes #168 as superseded.
