### PR TITLE
add support for SNI override

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,9 @@ The following environment variables are used to configure the ClickHouse and chD
   * Default: `"true"`
   * Set to `"false"` to disable certificate verification (not recommended for production)
   * TLS certificates: The package uses your operating system trust store for TLS certificate verification via `truststore`. We call `truststore.inject_into_ssl()` at startup to ensure proper certificate handling. Python’s default SSL behavior is used as a fallback only if an unexpected error occurs.
+* `CLICKHOUSE_SERVER_HOST_NAME`: Server hostname for SNI override and certificate validation
+  * Default: None (uses the connection hostname)
+  * This is useful when connecting through proxies or load balancers where the certificate hostname differs from the connection hostname. When set, this hostname will be used for both SNI (Server Name Indication) during the TLS handshake and for certificate hostname validation.
 * `CLICKHOUSE_CONNECT_TIMEOUT`: Connection timeout in seconds
   * Default: `"30"`
   * Increase this value if you experience connection timeouts

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -40,6 +40,7 @@ class ClickHouseConfig:
         CLICKHOUSE_PORT: The port number (default: 8443 if secure=True, 8123 if secure=False)
         CLICKHOUSE_SECURE: Enable HTTPS (default: true)
         CLICKHOUSE_VERIFY: Verify SSL certificates (default: true)
+        CLICKHOUSE_SERVER_HOST_NAME: Server hostname for SNI override and certificate validation (default: None)
         CLICKHOUSE_CONNECT_TIMEOUT: Connection timeout in seconds (default: 30)
         CLICKHOUSE_SEND_RECEIVE_TIMEOUT: Send/receive timeout in seconds (default: 300)
         CLICKHOUSE_DATABASE: Default database to use (default: None)
@@ -113,6 +114,11 @@ class ClickHouseConfig:
         return os.getenv("CLICKHOUSE_VERIFY", "true").lower() == "true"
 
     @property
+    def server_host_name(self) -> Optional[str]:
+        """Get the server hostname for SNI override."""
+        return os.getenv("CLICKHOUSE_SERVER_HOST_NAME")
+
+    @property
     def connect_timeout(self) -> int:
         """Get the connection timeout in seconds.
 
@@ -161,6 +167,9 @@ class ClickHouseConfig:
 
         if self.proxy_path:
             config["proxy_path"] = self.proxy_path
+
+        if self.server_host_name:
+            config["server_host_name"] = self.server_host_name
 
         return config
 

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -517,15 +517,19 @@ def create_clickhouse_client():
         # If we're outside a request context, just proceed with the default config
         pass
 
+    config_fields = [
+        f"secure={client_config['secure']}",
+        f"verify={client_config['verify']}",
+        f"connect_timeout={client_config['connect_timeout']}s",
+        f"send_receive_timeout={client_config['send_receive_timeout']}s",
+    ]
+    if "server_host_name" in client_config:
+        config_fields.append(f"server_host_name={client_config['server_host_name']}")
     log_msg = (
         f"Creating ClickHouse client connection to {client_config['host']}:{client_config['port']} "
         f"as {client_config['username']} "
-        f"(secure={client_config['secure']}, verify={client_config['verify']}, "
-        f"connect_timeout={client_config['connect_timeout']}s, "
-        f"send_receive_timeout={client_config['send_receive_timeout']}s)"
+        f"({', '.join(config_fields)})"
     )
-    if "server_host_name" in client_config:
-        log_msg += f" (server_host_name={client_config['server_host_name']})"
     logger.info(log_msg)
 
     try:

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -461,13 +461,16 @@ def run_select_query(query: str):
 
 def create_clickhouse_client():
     client_config = get_config().get_client_config()
-    logger.info(
+    log_msg = (
         f"Creating ClickHouse client connection to {client_config['host']}:{client_config['port']} "
         f"as {client_config['username']} "
         f"(secure={client_config['secure']}, verify={client_config['verify']}, "
         f"connect_timeout={client_config['connect_timeout']}s, "
         f"send_receive_timeout={client_config['send_receive_timeout']}s)"
     )
+    if "server_host_name" in client_config:
+        log_msg += f" (server_host_name={client_config['server_host_name']})"
+    logger.info(log_msg)
 
     try:
         client = clickhouse_connect.get_client(**client_config)

--- a/tests/test_config_interface.py
+++ b/tests/test_config_interface.py
@@ -94,3 +94,29 @@ def test_role_configuration(monkeypatch: pytest.MonkeyPatch):
     client_config = config.get_client_config()
 
     assert client_config["settings"]["role"] == "analytics_reader"
+
+
+def test_server_host_name_configuration(monkeypatch: pytest.MonkeyPatch):
+    """Test that server_host_name is included when CLICKHOUSE_SERVER_HOST_NAME is set."""
+    monkeypatch.setenv("CLICKHOUSE_HOST", "load-balancer.example.com")
+    monkeypatch.setenv("CLICKHOUSE_USER", "test")
+    monkeypatch.setenv("CLICKHOUSE_PASSWORD", "test")
+    monkeypatch.setenv("CLICKHOUSE_SERVER_HOST_NAME", "server.example.com")
+
+    config = ClickHouseConfig()
+    client_config = config.get_client_config()
+
+    assert client_config["server_host_name"] == "server.example.com"
+
+
+def test_server_host_name_omitted_when_unset(monkeypatch: pytest.MonkeyPatch):
+    """Test that server_host_name is omitted when CLICKHOUSE_SERVER_HOST_NAME is not set."""
+    monkeypatch.setenv("CLICKHOUSE_HOST", "load-balancer.example.com")
+    monkeypatch.setenv("CLICKHOUSE_USER", "test")
+    monkeypatch.setenv("CLICKHOUSE_PASSWORD", "test")
+    monkeypatch.delenv("CLICKHOUSE_SERVER_HOST_NAME", raising=False)
+
+    config = ClickHouseConfig()
+    client_config = config.get_client_config()
+
+    assert "server_host_name" not in client_config


### PR DESCRIPTION
# Summary
Adds support for `CLICKHOUSE_SERVER_HOST_NAME` environment variable to enable SNI (Server Name Indication) override during TLS connections.

# Usage
```bash
export CLICKHOUSE_HOST=load-balancer.example.com
export CLICKHOUSE_SERVER_HOST_NAME=server.example.com
```

Closes #126