### PR TITLE
EDIT: Recommend read-only agent in README (no SQL validation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ An MCP server for ClickHouse.
   * Execute SQL queries on your ClickHouse cluster.
   * Input: `sql` (string): The SQL query to execute.
   * All ClickHouse queries are run with `readonly = 1` to ensure they are safe.
+  * **Recommendation:** Use a read-only agent (or a ClickHouse user with only read permissions) for production.
 
 * `list_databases`
   * List all databases on your ClickHouse cluster.
@@ -51,6 +52,8 @@ curl http://localhost:8000/health
 ```
 
 ## Security
+
+**Read-only agent:** Using a read-only agent (or a ClickHouse user restricted to read-only access) is recommended when connecting this MCP server to your cluster.
 
 ### Authentication for HTTP/SSE Transports
 


### PR DESCRIPTION
## Issue
#131

## Summary
Documents that a read-only agent (or read-only ClickHouse user) is the recommended way to keep usage safe when not enforcing SQL validation in the server.

## Changes
- **README – Features:** Under `run_select_query`, added a recommendation to use a read-only agent or a ClickHouse user with only read permissions in production.
- **README – Security:** Added a short note at the top of the Security section recommending a read-only agent or read-only ClickHouse user when connecting this MCP server to a cluster.

## Context
This branch does not add SQL query validation. Relying on a read-only agent or read-only DB user is the recommended approach for production.