### PR TITLE
feat: add gemini-extension.json to support Gemini CLI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,17 @@ You can also enable both ClickHouse and chDB simultaneously:
 }
 ```
 
-3. Locate the command entry for `uv` and replace it with the absolute path to the `uv` executable. This ensures that the correct version of `uv` is used when starting the server. On a mac, you can find this path using `which uv`.
+3. ## Usage with Gemini CLI
 
-4. Restart Claude Desktop to apply the changes.
+You can install and run the ClickHouse MCP server directly as a native extension using the Gemini CLI. This will automatically manage the environment and start the server when needed.
+
+```bash
+gemini extensions install [https://github.com/ClickHouse/mcp-clickhouse](https://github.com/ClickHouse/mcp-clickhouse)
+```
+
+4. Locate the command entry for `uv` and replace it with the absolute path to the `uv` executable. This ensures that the correct version of `uv` is used when starting the server. On a mac, you can find this path using `which uv`.
+
+5. Restart Claude Desktop to apply the changes.
 
 ### Optional Write Access
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,6 @@
 {
   "name": "clickhouse",
+  "version": "1.0.0",
   "description": "Connect Gemini to your ClickHouse database to query data and explore schemas.",
   "mcpServers": {
     "clickhouse": {
@@ -18,25 +19,34 @@
       }
     }
   },
-  "settings": {
-    "CLICKHOUSE_HOST": {
+  "settings": [
+    {
+      "name": "CLICKHOUSE_HOST",
       "type": "string",
       "description": "The hostname of your ClickHouse database",
-      "default": "localhost"
+      "default": "localhost",
+      "required": false
     },
-    "CLICKHOUSE_PORT": {
+    {
+      "name": "CLICKHOUSE_PORT",
       "type": "string",
       "description": "The port number (e.g., 8123 for local, 8443 for Cloud)",
-      "default": "8443"
+      "default": "8443",
+      "required": false
     },
-    "CLICKHOUSE_USER": {
+    {
+      "name": "CLICKHOUSE_USER",
       "type": "string",
       "description": "Database username",
-      "default": "default"
+      "default": "default",
+      "required": false
     },
-    "CLICKHOUSE_PASSWORD": {
+    {
+      "name": "CLICKHOUSE_PASSWORD",
       "type": "password",
-      "description": "Database password (input will be masked securely)"
+      "description": "Database password (input will be masked securely)",
+      "sensitive": true,
+      "required": true
     }
-  }
+  ]
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,42 @@
+{
+  "name": "clickhouse",
+  "description": "Connect Gemini to your ClickHouse database to query data and explore schemas.",
+  "mcpServers": {
+    "clickhouse": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "mcp-clickhouse",
+        "mcp-clickhouse"
+      ],
+      "env": {
+        "CLICKHOUSE_HOST": "${settings.CLICKHOUSE_HOST}",
+        "CLICKHOUSE_PORT": "${settings.CLICKHOUSE_PORT}",
+        "CLICKHOUSE_USER": "${settings.CLICKHOUSE_USER}",
+        "CLICKHOUSE_PASSWORD": "${settings.CLICKHOUSE_PASSWORD}"
+      }
+    }
+  },
+  "settings": {
+    "CLICKHOUSE_HOST": {
+      "type": "string",
+      "description": "The hostname of your ClickHouse database",
+      "default": "localhost"
+    },
+    "CLICKHOUSE_PORT": {
+      "type": "string",
+      "description": "The port number (e.g., 8123 for local, 8443 for Cloud)",
+      "default": "8443"
+    },
+    "CLICKHOUSE_USER": {
+      "type": "string",
+      "description": "Database username",
+      "default": "default"
+    },
+    "CLICKHOUSE_PASSWORD": {
+      "type": "password",
+      "description": "Database password (input will be masked securely)"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a `gemini-extension.json` manifest to the repository, enabling out-of-the-box support for the Gemini CLI. 

By adding this file, users can now install the ClickHouse MCP server as a native extension using a single command:
`gemini extensions install https://github.com/ClickHouse/mcp-clickhouse`

**Key Additions:**
* Defines the `uv run` command for execution so the extension is enabled by default.
* Adds a `settings` block that prompts the user for their `CLICKHOUSE_HOST`, `PORT`, `USER`, and `PASSWORD` during installation, automatically mapping them to the expected environment variables securely.