### PR TITLE
Lazy-load chdb to avoid ~80-100 MB memory overhead when disabled

### DIFF
--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -8,7 +8,6 @@ import re
 import uuid
 
 import clickhouse_connect
-import chdb.session as chs
 from clickhouse_connect.driver.binding import format_query_value
 from dotenv import load_dotenv
 from fastmcp import FastMCP
@@ -689,6 +688,7 @@ def _init_chdb_client():
         client_config = get_chdb_config().get_client_config()
         data_path = client_config["data_path"]
         logger.info(f"Creating chDB client with data_path={data_path}")
+        import chdb.session as chs
         client = chs.Session(path=data_path)
         logger.info(f"Successfully connected to chDB with data_path={data_path}")
         return client


### PR DESCRIPTION
Move the top-level `import chdb.session` into `_init_chdb_client()` so the embedded ClickHouse engine is only loaded when CHDB_ENABLED=true.

## Summary

The `chdb` library (which embeds a full ClickHouse engine) is currently imported unconditionally at module level in `mcp_server.py`, even when `CHDB_ENABLED=false` (the default). This adds ~80–100 MB to the RSS of every server instance regardless of whether chdb is actually used.

This PR moves the `import chdb.session` into `_init_chdb_client()`, which is only called when `CHDB_ENABLED=true`. The conditional tool registration at the bottom of the file already gates chdb usage behind this flag — the import was simply in the wrong place.

### Before
- `import chdb.session as chs` at top level → always loaded
- Observed RSS in k8s: ~140 MB per pod

### After
- Import inside `_init_chdb_client()` → only loaded when `CHDB_ENABLED=true`
- Expected RSS without chdb: ~40–50 MB per pod

### Changes
- Remove top-level `import chdb.session as chs` from `mcp_server.py`
- Add lazy `import chdb.session as chs` inside `_init_chdb_client()`

No behavioral change when `CHDB_ENABLED=true` — the import happens at the same point in the initialization flow, just no longer at module load time.
