### PR TITLE
Make chdb an optional dependency for Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ An MCP server for ClickHouse.
   * Execute SQL queries using [chDB](https://github.com/chdb-io/chdb)'s embedded ClickHouse engine.
   * Input: `query` (string): The SQL query to execute.
   * Query data directly from various sources (files, URLs, databases) without ETL processes.
+  * Requires the optional `chdb` extra: `pip install 'mcp-clickhouse[chdb]'`
 
 ### Health Check Endpoint
 
@@ -183,7 +184,7 @@ For chDB (embedded ClickHouse engine), add the following configuration:
       "args": [
         "run",
         "--with",
-        "mcp-clickhouse",
+        "mcp-clickhouse[chdb]",
         "--python",
         "3.10",
         "mcp-clickhouse"
@@ -208,7 +209,7 @@ You can also enable both ClickHouse and chDB simultaneously:
       "args": [
         "run",
         "--with",
-        "mcp-clickhouse",
+        "mcp-clickhouse[chdb]",
         "--python",
         "3.10",
         "mcp-clickhouse"
@@ -261,6 +262,11 @@ If you prefer to use the system Python installation instead of uv, you can insta
 1. Install the package using pip:
    ```bash
    python3 -m pip install mcp-clickhouse
+   ```
+
+   To install chDB support as well:
+   ```bash
+   python3 -m pip install 'mcp-clickhouse[chdb]'
    ```
 
    To upgrade to the latest version:
@@ -541,6 +547,7 @@ The following environment variables are used to configure the ClickHouse and chD
 * `CHDB_ENABLED`: Enable/disable chDB functionality
   * Default: `"false"`
   * Set to `"true"` to enable chDB tools
+  * Requires installing the optional extra: `mcp-clickhouse[chdb]`
 * `CHDB_DATA_PATH`: The path to the chDB data directory
   * Default: `":memory:"` (in-memory database)
   * Use `:memory:` for in-memory database
@@ -667,7 +674,7 @@ uv run ruff check . # run linting
 docker compose up -d test_services # start ClickHouse
 uv run pytest -v tests
 uv run pytest -v tests/test_tool.py # ClickHouse only
-uv run pytest -v tests/test_chdb_tool.py # chDB only
+uv run --extra chdb pytest -v tests/test_chdb_tool.py # chDB only
 ```
 
 ## YouTube Overview

--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ uv run ruff check . # run linting
 docker compose up -d test_services # start ClickHouse
 uv run pytest -v tests
 uv run pytest -v tests/test_tool.py # ClickHouse only
-uv run --extra chdb pytest -v tests/test_chdb_tool.py # chDB only
+CHDB_ENABLED=true uv run --extra chdb pytest -v tests/test_chdb_tool.py # chDB only
 ```
 
 ## YouTube Overview

--- a/fastmcp.json
+++ b/fastmcp.json
@@ -8,8 +8,7 @@
     "dependencies": [
       "clickhouse-connect",
       "python-dotenv",
-      "truststore",
-      "chdb"
+      "truststore"
     ]
   }
 }

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -127,7 +127,10 @@ async def health_check(request: Request) -> PlainTextResponse:
             if chdb_config.enabled and _chdb_client is not None:
                 return PlainTextResponse("OK - MCP server running with chDB enabled")
             elif chdb_config.enabled and _chdb_error_message:
-                return PlainTextResponse(f"ERROR - {_chdb_error_message}", status_code=503)
+                return PlainTextResponse(
+                    "ERROR. chDB initialization failed. Check server logs for details.",
+                    status_code=503,
+                )
             else:
                 # Both ClickHouse and chDB are disabled - this is an error
                 return PlainTextResponse(

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -704,12 +704,20 @@ def _init_chdb_client():
         _chdb_error_message = None
         logger.info(f"Successfully connected to chDB with data_path={data_path}")
         return client
-    except ImportError:
-        _chdb_error_message = (
-            "chDB support requires the optional dependency. "
-            "Install mcp-clickhouse[chdb] to enable chDB features."
-        )
-        logger.warning(_chdb_error_message)
+    except ModuleNotFoundError as e:
+        if e.name in {"chdb", "chdb.session"}:
+            _chdb_error_message = (
+                "chDB support requires the optional dependency. "
+                "Install mcp-clickhouse[chdb] to enable chDB features."
+            )
+            logger.warning(_chdb_error_message)
+            return None
+        _chdb_error_message = f"Failed to initialize chDB client: {e}"
+        logger.error(_chdb_error_message)
+        return None
+    except ImportError as e:
+        _chdb_error_message = f"Failed to initialize chDB client: {e}"
+        logger.error(_chdb_error_message)
         return None
     except Exception as e:
         _chdb_error_message = f"Failed to initialize chDB client: {e}"

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -96,6 +96,8 @@ if mcp_config.server_transport in http_transports:
         )
 
 mcp = FastMCP(name=MCP_SERVER_NAME, auth=auth_provider)
+_chdb_client = None
+_chdb_error_message: Optional[str] = None
 
 
 @mcp.custom_route("/health", methods=["GET"])
@@ -122,8 +124,10 @@ async def health_check(request: Request) -> PlainTextResponse:
         if not clickhouse_enabled:
             # If ClickHouse is disabled, check chDB status
             chdb_config = get_chdb_config()
-            if chdb_config.enabled:
+            if chdb_config.enabled and _chdb_client is not None:
                 return PlainTextResponse("OK - MCP server running with chDB enabled")
+            elif chdb_config.enabled and _chdb_error_message:
+                return PlainTextResponse(f"ERROR - {_chdb_error_message}", status_code=503)
             else:
                 # Both ClickHouse and chDB are disabled - this is an error
                 return PlainTextResponse(
@@ -617,6 +621,8 @@ def create_chdb_client():
     """Create a chDB client connection."""
     if not get_chdb_config().enabled:
         raise ValueError("chDB is not enabled. Set CHDB_ENABLED=true to enable it.")
+    if _chdb_client is None:
+        raise RuntimeError(_chdb_error_message or "chDB client is not available.")
     return _chdb_client
 
 
@@ -680,9 +686,11 @@ def chdb_initial_prompt() -> str:
 
 def _init_chdb_client():
     """Initialize the global chDB client instance."""
+    global _chdb_error_message
     try:
         if not get_chdb_config().enabled:
             logger.info("chDB is disabled, skipping client initialization")
+            _chdb_error_message = None
             return None
 
         client_config = get_chdb_config().get_client_config()
@@ -690,11 +698,46 @@ def _init_chdb_client():
         logger.info(f"Creating chDB client with data_path={data_path}")
         import chdb.session as chs
         client = chs.Session(path=data_path)
+        _chdb_error_message = None
         logger.info(f"Successfully connected to chDB with data_path={data_path}")
         return client
-    except Exception as e:
-        logger.error(f"Failed to initialize chDB client: {e}")
+    except ImportError:
+        _chdb_error_message = (
+            "chDB support requires the optional dependency. "
+            "Install mcp-clickhouse[chdb] to enable chDB features."
+        )
+        logger.warning(_chdb_error_message)
         return None
+    except Exception as e:
+        _chdb_error_message = f"Failed to initialize chDB client: {e}"
+        logger.error(_chdb_error_message)
+        return None
+
+
+def _register_chdb_tools():
+    """Register chDB tools when the feature is enabled and available.
+
+    Note: This function is not idempotent. Calling it multiple times will
+    register duplicate tools. It is intended to be called once at module load.
+    """
+    global _chdb_client
+    if not get_chdb_config().enabled:
+        return
+
+    _chdb_client = _init_chdb_client()
+    if _chdb_client is None:
+        logger.warning("chDB is enabled but unavailable; skipping chDB tool registration")
+        return
+
+    atexit.register(_chdb_client.close)
+    mcp.add_tool(Tool.from_function(run_chdb_select_query))
+    chdb_prompt = Prompt.from_function(
+        chdb_initial_prompt,
+        name="chdb_initial_prompt",
+        description="This prompt helps users understand how to interact and perform common operations in chDB",
+    )
+    mcp.add_prompt(chdb_prompt)
+    logger.info("chDB tools and prompts registered")
 
 
 # Register tools based on configuration
@@ -712,16 +755,4 @@ if os.getenv("CLICKHOUSE_ENABLED", "true").lower() == "true":
     logger.info("ClickHouse tools registered")
 
 
-if os.getenv("CHDB_ENABLED", "false").lower() == "true":
-    _chdb_client = _init_chdb_client()
-    if _chdb_client:
-        atexit.register(lambda: _chdb_client.close())
-
-    mcp.add_tool(Tool.from_function(run_chdb_select_query))
-    chdb_prompt = Prompt.from_function(
-        chdb_initial_prompt,
-        name="chdb_initial_prompt",
-        description="This prompt helps users understand how to interact and perform common operations in chDB",
-    )
-    mcp.add_prompt(chdb_prompt)
-    logger.info("chDB tools and prompts registered")
+_register_chdb_tools()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
      "python-dotenv>=1.0.1",
      "clickhouse-connect>=0.8.16",
      "truststore>=0.10",
-     "chdb>=3.3.0",
      "cachetools>=5.5.0",
 ]
 
@@ -22,6 +21,9 @@ mcp-clickhouse = "mcp_clickhouse.main:main"
 Home = "https://github.com/ClickHouse/mcp-clickhouse"
 
 [project.optional-dependencies]
+chdb = [
+    "chdb>=3.3.0"
+]
 dev = [
     "ruff",
     "pytest",

--- a/tests/test_chdb_tool.py
+++ b/tests/test_chdb_tool.py
@@ -15,10 +15,29 @@ class TestChDBTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up the environment before chDB tests."""
+        cls._previous_chdb_enabled = os.environ.get("CHDB_ENABLED")
+        cls._previous_chdb_client = mcp_server._chdb_client
+        cls._previous_chdb_error_message = mcp_server._chdb_error_message
+
         os.environ["CHDB_ENABLED"] = "true"
         if mcp_server._chdb_client is None:
             mcp_server._chdb_client = mcp_server._init_chdb_client()
         cls.client = mcp_server.create_chdb_client()
+        cls._created_client = cls._previous_chdb_client is None and cls.client is mcp_server._chdb_client
+
+    @classmethod
+    def tearDownClass(cls):
+        """Restore module and environment state after chDB tests."""
+        if getattr(cls, "_created_client", False):
+            cls.client.close()
+
+        mcp_server._chdb_client = cls._previous_chdb_client
+        mcp_server._chdb_error_message = cls._previous_chdb_error_message
+
+        if cls._previous_chdb_enabled is None:
+            os.environ.pop("CHDB_ENABLED", None)
+        else:
+            os.environ["CHDB_ENABLED"] = cls._previous_chdb_enabled
 
     def test_run_chdb_select_query_simple(self):
         """Test running a simple SELECT query in chDB."""

--- a/tests/test_chdb_tool.py
+++ b/tests/test_chdb_tool.py
@@ -1,9 +1,11 @@
+import os
+import tempfile
 import unittest
 import importlib.util
 
 from dotenv import load_dotenv
 
-from mcp_clickhouse import create_chdb_client, run_chdb_select_query
+from mcp_clickhouse import mcp_server
 
 load_dotenv()
 
@@ -13,28 +15,34 @@ class TestChDBTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up the environment before chDB tests."""
-        cls.client = create_chdb_client()
+        os.environ["CHDB_ENABLED"] = "true"
+        if mcp_server._chdb_client is None:
+            mcp_server._chdb_client = mcp_server._init_chdb_client()
+        cls.client = mcp_server.create_chdb_client()
 
     def test_run_chdb_select_query_simple(self):
         """Test running a simple SELECT query in chDB."""
         query = "SELECT 1 as test_value"
-        result = run_chdb_select_query(query)
+        result = mcp_server.run_chdb_select_query(query)
         self.assertIsInstance(result, list)
         self.assertIn("test_value", str(result))
 
-    def test_run_chdb_select_query_with_url_table_function(self):
-        """Test running a SELECT query with url table function in chDB."""
-        query = "SELECT COUNT(1) FROM url('https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_0.parquet', 'Parquet')"
-        result = run_chdb_select_query(query)
-        print(result)
+    def test_run_chdb_select_query_with_file_table_function(self):
+        """Test running a SELECT query against a local file via chDB."""
+        with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as temp_file:
+            temp_file.write("value\n1\n2\n3\n")
+            temp_path = temp_file.name
+
+        self.addCleanup(lambda: os.path.exists(temp_path) and os.unlink(temp_path))
+        query = f"SELECT SUM(value) AS total FROM file('{temp_path}', 'CSVWithNames')"
+        result = mcp_server.run_chdb_select_query(query)
         self.assertIsInstance(result, list)
-        self.assertIn("1000000", str(result))
+        self.assertEqual(result[0]["total"], 6)
 
     def test_run_chdb_select_query_failure(self):
         """Test running a SELECT query with an error in chDB."""
         query = "SELECT * FROM non_existent_table_chDB"
-        result = run_chdb_select_query(query)
-        print(result)
+        result = mcp_server.run_chdb_select_query(query)
         self.assertIsInstance(result, dict)
         self.assertEqual(result["status"], "error")
         self.assertIn("message", result)
@@ -42,8 +50,7 @@ class TestChDBTools(unittest.TestCase):
     def test_run_chdb_select_query_empty_result(self):
         """Test running a SELECT query that returns empty result in chDB."""
         query = "SELECT 1 WHERE 1 = 0"
-        result = run_chdb_select_query(query)
-        print(result)
+        result = mcp_server.run_chdb_select_query(query)
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 0)
 

--- a/tests/test_chdb_tool.py
+++ b/tests/test_chdb_tool.py
@@ -1,4 +1,5 @@
 import unittest
+import importlib.util
 
 from dotenv import load_dotenv
 
@@ -7,6 +8,7 @@ from mcp_clickhouse import create_chdb_client, run_chdb_select_query
 load_dotenv()
 
 
+@unittest.skipUnless(importlib.util.find_spec("chdb") is not None, "requires chdb extra")
 class TestChDBTools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_optional_chdb.py
+++ b/tests/test_optional_chdb.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_clickhouse import mcp_server
+
+
+def test_create_chdb_client_surfaces_optional_dependency_message():
+    with (
+        patch.dict("os.environ", {"CHDB_ENABLED": "true"}, clear=False),
+        patch.object(mcp_server, "_chdb_client", None),
+        patch.object(
+            mcp_server,
+            "_chdb_error_message",
+            "chDB support requires the optional dependency. "
+            "Install mcp-clickhouse[chdb] to enable chDB features.",
+        ),
+    ):
+        with pytest.raises(RuntimeError, match=r"mcp-clickhouse\[chdb\]"):
+            mcp_server.create_chdb_client()
+
+
+def test_register_chdb_tools_skips_when_client_is_unavailable():
+    with (
+        patch.dict("os.environ", {"CHDB_ENABLED": "true"}, clear=False),
+        patch.object(mcp_server, "_init_chdb_client", return_value=None),
+        patch.object(mcp_server, "_chdb_client", None),
+        patch.object(mcp_server.mcp, "add_tool") as add_tool,
+        patch.object(mcp_server.mcp, "add_prompt") as add_prompt,
+    ):
+        mcp_server._register_chdb_tools()
+
+    add_tool.assert_not_called()
+    add_prompt.assert_not_called()
+
+
+def test_register_chdb_tools_registers_when_client_is_available():
+    mock_client = MagicMock()
+    with (
+        patch.dict("os.environ", {"CHDB_ENABLED": "true"}, clear=False),
+        patch.object(mcp_server, "_init_chdb_client", return_value=mock_client),
+        patch.object(mcp_server, "_chdb_client", None),
+        patch.object(mcp_server.mcp, "add_tool") as add_tool,
+        patch.object(mcp_server.mcp, "add_prompt") as add_prompt,
+    ):
+        mcp_server._register_chdb_tools()
+
+    add_tool.assert_called_once()
+    add_prompt.assert_called_once()

--- a/tests/test_optional_chdb.py
+++ b/tests/test_optional_chdb.py
@@ -89,5 +89,7 @@ async def test_health_check_hides_internal_chdb_init_error_details():
         response = await mcp_server.health_check(request)
 
     assert response.status_code == 503
-    assert b"check server logs for details" in response.body
-    assert b"/tmp/private.db" not in response.body
+    body = response.body.lower()
+    assert b"initialization failed" in body
+    assert b"check server logs for details" in body
+    assert b"/tmp/private.db" not in body

--- a/tests/test_optional_chdb.py
+++ b/tests/test_optional_chdb.py
@@ -12,7 +12,9 @@ def test_init_chdb_client_surfaces_optional_dependency_message():
 
     def raising_import(name, globals=None, locals=None, fromlist=(), level=0):
         if name == "chdb.session":
-            raise ImportError("No module named 'chdb'")
+            error = ModuleNotFoundError("No module named 'chdb'")
+            error.name = "chdb"
+            raise error
         return real_import(name, globals, locals, fromlist, level)
 
     with (
@@ -23,6 +25,25 @@ def test_init_chdb_client_surfaces_optional_dependency_message():
 
     assert client is None
     assert "mcp-clickhouse[chdb]" in mcp_server._chdb_error_message
+
+
+def test_init_chdb_client_treats_other_import_errors_as_init_failures():
+    real_import = builtins.__import__
+
+    def raising_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "chdb.session":
+            raise ImportError("dlopen(/tmp/chdb.so) failed")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with (
+        patch.dict("os.environ", {"CHDB_ENABLED": "true"}, clear=False),
+        patch("builtins.__import__", side_effect=raising_import),
+    ):
+        client = mcp_server._init_chdb_client()
+
+    assert client is None
+    assert "Failed to initialize chDB client" in mcp_server._chdb_error_message
+    assert "mcp-clickhouse[chdb]" not in mcp_server._chdb_error_message
 
 
 def test_create_chdb_client_surfaces_optional_dependency_message():

--- a/tests/test_optional_chdb.py
+++ b/tests/test_optional_chdb.py
@@ -1,8 +1,28 @@
+import builtins
 from unittest.mock import MagicMock, patch
 
 import pytest
+from starlette.requests import Request
 
 from mcp_clickhouse import mcp_server
+
+
+def test_init_chdb_client_surfaces_optional_dependency_message():
+    real_import = builtins.__import__
+
+    def raising_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "chdb.session":
+            raise ImportError("No module named 'chdb'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with (
+        patch.dict("os.environ", {"CHDB_ENABLED": "true"}, clear=False),
+        patch("builtins.__import__", side_effect=raising_import),
+    ):
+        client = mcp_server._init_chdb_client()
+
+    assert client is None
+    assert "mcp-clickhouse[chdb]" in mcp_server._chdb_error_message
 
 
 def test_create_chdb_client_surfaces_optional_dependency_message():
@@ -47,3 +67,27 @@ def test_register_chdb_tools_registers_when_client_is_available():
 
     add_tool.assert_called_once()
     add_prompt.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_health_check_hides_internal_chdb_init_error_details():
+    request = Request({"type": "http", "method": "GET", "headers": []})
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"CLICKHOUSE_ENABLED": "false", "CHDB_ENABLED": "true"},
+            clear=False,
+        ),
+        patch.object(mcp_server, "_chdb_client", None),
+        patch.object(
+            mcp_server,
+            "_chdb_error_message",
+            "Failed to initialize chDB client: /tmp/private.db is unreadable",
+        ),
+    ):
+        response = await mcp_server.health_check(request)
+
+    assert response.status_code == 503
+    assert b"check server logs for details" in response.body
+    assert b"/tmp/private.db" not in response.body

--- a/uv.lock
+++ b/uv.lock
@@ -802,7 +802,6 @@ version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
-    { name = "chdb" },
     { name = "clickhouse-connect" },
     { name = "fastmcp" },
     { name = "python-dotenv" },
@@ -810,6 +809,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+chdb = [
+    { name = "chdb" },
+]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -819,7 +821,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cachetools", specifier = ">=5.5.0" },
-    { name = "chdb", specifier = ">=3.3.0" },
+    { name = "chdb", marker = "extra == 'chdb'", specifier = ">=3.3.0" },
     { name = "clickhouse-connect", specifier = ">=0.8.16" },
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -828,7 +830,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "truststore", specifier = ">=0.10" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["chdb", "dev"]
 
 [[package]]
 name = "mdurl"


### PR DESCRIPTION
## Summary
- Moves chdb from a hard dependency to an optional extra via `pip install mcp-clickhouse[chdb]` fixing installation on Windows where chdb has no wheels
- Conditionally registers chdb tools only when the package is installed and initialization succeeds
- Clear error messages guiding users to install the extra if it's missing
- Updates README, `fastmcp.json`, and test commands to reflect the optional dependency

Closes #143