### PR TITLE
fix: use ContextVar for client config overrides and propagate context to thread pool

### DIFF
--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import contextvars
 from typing import Optional, List, Any, Dict
 import concurrent.futures
 import atexit
@@ -60,14 +61,45 @@ class Table:
 MCP_SERVER_NAME = "mcp-clickhouse"
 CLIENT_CONFIG_OVERRIDES_KEY = "clickhouse_client_config_overrides"
 
+# ContextVar for per-request client config overrides. This is used instead of
+# FastMCP's async ctx.get_state/set_state because create_clickhouse_client is
+# a sync function called from a ThreadPoolExecutor worker thread.
+# Middleware should set this via _client_config_overrides_var.set({...}).
+_client_config_overrides_var: contextvars.ContextVar[Optional[dict]] = contextvars.ContextVar(
+    "client_config_overrides", default=None
+)
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(MCP_SERVER_NAME)
 
-QUERY_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=10)
-atexit.register(lambda: QUERY_EXECUTOR.shutdown(wait=True))
+_thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=10)
+atexit.register(lambda: _thread_pool.shutdown(wait=True))
+
+
+class _ContextPropagatingExecutor:
+    """Wrapper around ThreadPoolExecutor that propagates contextvars to worker threads.
+
+    ThreadPoolExecutor.submit does not copy the current context into worker threads,
+    so ContextVar values set in the async middleware are invisible to sync functions
+    running in the pool. This wrapper uses contextvars.copy_context().run() to ensure
+    the calling context is available in the worker.
+    """
+
+    def __init__(self, executor: concurrent.futures.ThreadPoolExecutor):
+        self._executor = executor
+
+    def submit(self, fn, *args, **kwargs):
+        ctx = contextvars.copy_context()
+        return self._executor.submit(ctx.run, fn, *args, **kwargs)
+
+    def shutdown(self, **kwargs):
+        return self._executor.shutdown(**kwargs)
+
+
+QUERY_EXECUTOR = _ContextPropagatingExecutor(_thread_pool)
 
 load_dotenv()
 
@@ -501,17 +533,13 @@ def run_query(query: str):
 def create_clickhouse_client():
     client_config = get_config().get_client_config()
 
-    try:
-        ctx = get_context()
-        session_config_overrides = ctx.get_state(CLIENT_CONFIG_OVERRIDES_KEY)
-        if session_config_overrides and not isinstance(session_config_overrides, dict):
-            logger.warning(f"{CLIENT_CONFIG_OVERRIDES_KEY} must be a dict, got {type(session_config_overrides).__name__}. Ignoring.")
-        elif session_config_overrides:
-            logger.debug(f"Applying session-specific ClickHouse client config overrides: {list(session_config_overrides.keys())}")
-            client_config.update(session_config_overrides)
-    except RuntimeError:
-        # If we're outside a request context, just proceed with the default config
-        pass
+    # Check for per-request config overrides set by middleware via the ContextVar.
+    session_config_overrides = _client_config_overrides_var.get()
+    if session_config_overrides and not isinstance(session_config_overrides, dict):
+        logger.warning(f"{CLIENT_CONFIG_OVERRIDES_KEY} must be a dict, got {type(session_config_overrides).__name__}. Ignoring.")
+    elif session_config_overrides:
+        logger.debug(f"Applying session-specific ClickHouse client config overrides: {list(session_config_overrides.keys())}")
+        client_config.update(session_config_overrides)
 
     logger.info(
         f"Creating ClickHouse client connection to {client_config['host']}:{client_config['port']} "

--- a/tests/test_context_config_override.py
+++ b/tests/test_context_config_override.py
@@ -5,12 +5,12 @@ from unittest.mock import patch, MagicMock
 
 from fastmcp import Client
 from fastmcp.server.middleware import Middleware, MiddlewareContext, CallNext
-from fastmcp.server.dependencies import get_context
 
 from mcp_clickhouse.mcp_server import (
     mcp,
     create_clickhouse_client,
     CLIENT_CONFIG_OVERRIDES_KEY,
+    _client_config_overrides_var,
 )
 
 
@@ -21,52 +21,51 @@ class ConfigOverrideMiddleware(Middleware):
         self.overrides = overrides
 
     async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
-        ctx = get_context()
-        ctx.set_state(CLIENT_CONFIG_OVERRIDES_KEY, self.overrides)
-        return await call_next(context)
+        token = _client_config_overrides_var.set(self.overrides)
+        try:
+            return await call_next(context)
+        finally:
+            _client_config_overrides_var.reset(token)
 
 
 class TestConfigOverrideUnit:
     """Unit tests for the config override merge logic in create_clickhouse_client."""
 
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
-    @patch("mcp_clickhouse.mcp_server.get_context")
-    def test_overrides_merged_into_client_config(self, mock_get_context, mock_cc):
-        """Verify overrides from context state are merged into the client config."""
-        mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = {"connect_timeout": 99, "send_receive_timeout": 199}
-        mock_get_context.return_value = mock_ctx
+    def test_overrides_merged_into_client_config(self, mock_cc):
+        """Verify overrides from ContextVar are merged into the client config."""
         mock_cc.get_client.return_value = MagicMock(server_version="24.1")
 
-        create_clickhouse_client()
+        token = _client_config_overrides_var.set(
+            {"connect_timeout": 99, "send_receive_timeout": 199}
+        )
+        try:
+            create_clickhouse_client()
+        finally:
+            _client_config_overrides_var.reset(token)
 
         call_kwargs = mock_cc.get_client.call_args[1]
         assert call_kwargs["connect_timeout"] == 99
         assert call_kwargs["send_receive_timeout"] == 199
 
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
-    @patch("mcp_clickhouse.mcp_server.get_context")
-    def test_empty_overrides_no_change(self, mock_get_context, mock_cc):
+    def test_empty_overrides_no_change(self, mock_cc):
         """Empty overrides dict should not alter the base config."""
-        mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = {}
-        mock_get_context.return_value = mock_ctx
         mock_cc.get_client.return_value = MagicMock(server_version="24.1")
 
-        create_clickhouse_client()
+        token = _client_config_overrides_var.set({})
+        try:
+            create_clickhouse_client()
+        finally:
+            _client_config_overrides_var.reset(token)
 
         call_kwargs = mock_cc.get_client.call_args[1]
-        # Base config values from env should pass through unchanged
         assert "host" in call_kwargs
         assert "username" in call_kwargs
 
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
-    @patch("mcp_clickhouse.mcp_server.get_context")
-    def test_no_overrides_in_context(self, mock_get_context, mock_cc):
-        """When context state has no overrides, base config is used as-is."""
-        mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = None
-        mock_get_context.return_value = mock_ctx
+    def test_no_overrides_in_context(self, mock_cc):
+        """When ContextVar has no overrides (default None), base config is used."""
         mock_cc.get_client.return_value = MagicMock(server_version="24.1")
 
         create_clickhouse_client()
@@ -75,16 +74,21 @@ class TestConfigOverrideUnit:
         assert "host" in call_kwargs
 
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
-    def test_no_request_context_falls_back_to_defaults(self, mock_cc):
-        """Outside a request context (RuntimeError), base config is used."""
+    def test_username_override(self, mock_cc):
+        """Verify username can be overridden for per-user credential passthrough."""
         mock_cc.get_client.return_value = MagicMock(server_version="24.1")
 
-        # get_context is NOT mocked, so it will raise RuntimeError
-        # since there's no active FastMCP request context
-        create_clickhouse_client()
+        token = _client_config_overrides_var.set(
+            {"username": "other_user", "password": "other_pass"}
+        )
+        try:
+            create_clickhouse_client()
+        finally:
+            _client_config_overrides_var.reset(token)
 
         call_kwargs = mock_cc.get_client.call_args[1]
-        assert "host" in call_kwargs
+        assert call_kwargs["username"] == "other_user"
+        assert call_kwargs["password"] == "other_pass"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

`CLIENT_CONFIG_OVERRIDES_KEY` (introduced for per-request client config overrides via middleware) does not work. Two bugs prevent the override from being applied:

### Bug 1: Async/sync mismatch in `create_clickhouse_client`

`create_clickhouse_client()` is a sync function that calls `ctx.get_state(CLIENT_CONFIG_OVERRIDES_KEY)` without `await`:

```python
session_config_overrides = ctx.get_state(CLIENT_CONFIG_OVERRIDES_KEY)
```

`Context.get_state` is `async def`, so calling it without `await` returns a coroutine object, not the dict. The override is silently ignored. The unit tests pass because `MagicMock.get_state.return_value` returns synchronously, masking the bug.

### Bug 2: `QUERY_EXECUTOR.submit` doesn't propagate `contextvars`

```python
future = QUERY_EXECUTOR.submit(execute_query, query)
```

`ThreadPoolExecutor.submit` does not copy the current context into worker threads. Even if Bug 1 were fixed, `ContextVar` values set by middleware in the async context are invisible to `execute_query` running in the thread pool.

## Fix

1. **Replace `ctx.get_state`/`set_state` with a module-level `ContextVar`** (`_client_config_overrides_var`). This is synchronous and works naturally with `contextvars` propagation.

2. **Wrap `ThreadPoolExecutor` in `_ContextPropagatingExecutor`** that uses `contextvars.copy_context().run()` to propagate the calling context into worker threads.

## How middleware should use it

```python
from mcp_clickhouse.mcp_server import _client_config_overrides_var

class MyMiddleware(Middleware):
    async def on_call_tool(self, context, call_next):
        token = _client_config_overrides_var.set({"username": "other_user", "password": "..."})
        try:
            return await call_next(context)
        finally:
            _client_config_overrides_var.reset(token)
```

## Testing

- Updated unit tests to use `ContextVar` directly instead of mocked `ctx.get_state`
- Added test for username/password override (the primary use case for per-user credential passthrough)
- Existing integration tests unchanged

## Related

- #161 — Docker image is outdated and missing middleware/override features