### PR TITLE
Joe/171 oauth seems to have been broken in recent updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+- Support for FastMCP OAuth/OIDC auth providers on HTTP/SSE transports via the `FASTMCP_SERVER_AUTH` environment variable (e.g. Azure Entra, Google, GitHub, WorkOS). Static token, FastMCP OAuth, and disabled mode are now mutually exclusive; configure exactly one. ([#171](https://github.com/ClickHouse/mcp-clickhouse/issues/171))
+
+### Changed
+- `/health` endpoint is now unauthenticated across all auth modes (previously gated only under static-token mode, which was asymmetric and incompatible with redirect-based OAuth providers). Response bodies trimmed to `OK` / generic error strings to avoid leaking ClickHouse version information or connection exception details; underlying errors are logged server-side.
+
 ## 0.3.0 - 2026-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ An MCP server for ClickHouse.
 ### Health Check Endpoint
 
 When running with HTTP or SSE transport, a health check endpoint is available at `/health`. This endpoint:
-- Returns `200 OK` with the ClickHouse version if the server is healthy and can connect to ClickHouse
-- Returns `503 Service Unavailable` if the server cannot connect to ClickHouse
+- Returns `200 OK` (body: `OK`) if the server is healthy and can connect to ClickHouse
+- Returns `503 Service Unavailable` with a generic error message if the server cannot connect to ClickHouse
+
+The endpoint is intentionally unauthenticated so orchestrator probes (e.g. Kubernetes liveness/readiness, load balancers) can reach it without credentials. The response body is deliberately minimal to avoid leaking backend version strings or error details; debug failures via the server logs.
 
 Example:
 ```bash
 curl http://localhost:8000/health
-# Response: OK - Connected to ClickHouse 24.3.1
+# Response: OK
 ```
 
 ## Security
@@ -56,6 +58,16 @@ curl http://localhost:8000/health
 ### Authentication for HTTP/SSE Transports
 
 When using HTTP or SSE transport, authentication is **required by default**. The `stdio` transport (default) does not require authentication as it only communicates via standard input/output.
+
+Three authentication modes are supported. Pick one:
+
+| Mode                       | When to use                               | Env var                                                                                        |
+|----------------------------|-------------------------------------------|------------------------------------------------------------------------------------------------|
+| Static bearer token        | Simple deployments, internal services     | `CLICKHOUSE_MCP_AUTH_TOKEN`                                                                    |
+| OAuth / OIDC (via FastMCP) | Azure Entra, Google, GitHub, WorkOS, etc. | `FASTMCP_SERVER_AUTH=<provider-class-path>` (+ provider-specific `FASTMCP_SERVER_AUTH_*` vars) |
+| Disabled                   | Local development only                    | `CLICKHOUSE_MCP_AUTH_DISABLED=true`                                                            |
+
+Startup fails if none of these are configured for HTTP/SSE transports.
 
 #### Setting Up Authentication
 
@@ -93,6 +105,21 @@ When using HTTP or SSE transport, authentication is **required by default**. The
    ```bash
    curl -H "Authorization: Bearer your-generated-token" http://localhost:8000/health
    ```
+
+#### OAuth / OIDC via FastMCP
+
+For production deployments with identity providers (Azure Entra, Google, GitHub, WorkOS, etc.), delegate authentication to [FastMCP's built-in auth providers](https://gofastmcp.com/servers/auth) instead of using a static token. Set `FASTMCP_SERVER_AUTH` to the **full class path** of a FastMCP auth provider, along with the provider-specific `FASTMCP_SERVER_AUTH_*` variables, and leave `CLICKHOUSE_MCP_AUTH_TOKEN` unset.
+
+Example (Azure Entra):
+
+```bash
+export FASTMCP_SERVER_AUTH=fastmcp.server.auth.providers.azure.AzureProvider
+export FASTMCP_SERVER_AUTH_AZURE_TENANT_ID="<tenant-id>"
+export FASTMCP_SERVER_AUTH_AZURE_CLIENT_ID="<client-id>"
+export FASTMCP_SERVER_AUTH_AZURE_CLIENT_SECRET="<client-secret>"
+```
+
+See the [FastMCP docs](https://gofastmcp.com/servers/auth) for the full list of providers and their required environment variables.
 
 #### Development Mode (Disabling Authentication)
 
@@ -515,11 +542,15 @@ The following environment variables are used to configure the ClickHouse and chD
 * `CLICKHOUSE_MCP_QUERY_TIMEOUT`: Timeout in seconds for SELECT tools
   * Default: `"30"`
   * Increase this if you see `Query timed out after ...` errors for heavy queries
-* `CLICKHOUSE_MCP_AUTH_TOKEN`: Authentication token for HTTP/SSE transports
+* `CLICKHOUSE_MCP_AUTH_TOKEN`: Static bearer token for HTTP/SSE transports
   * Default: None
-  * **Required** when using HTTP or SSE transport (unless `CLICKHOUSE_MCP_AUTH_DISABLED=true`)
+  * One of `CLICKHOUSE_MCP_AUTH_TOKEN`, `FASTMCP_SERVER_AUTH`, or `CLICKHOUSE_MCP_AUTH_DISABLED=true` is **required** for HTTP/SSE transports
   * Generate using `uuidgen` or `openssl rand -hex 32`
   * Clients must send this token in the `Authorization: Bearer <token>` header
+* `FASTMCP_SERVER_AUTH`: Delegate authentication to a [FastMCP auth provider](https://gofastmcp.com/servers/auth)
+  * Default: None
+  * Value is the **full class path** of an AuthProvider subclass, e.g. `fastmcp.server.auth.providers.azure.AzureProvider` or `fastmcp.server.auth.providers.google.GoogleProvider`
+  * When set, FastMCP auto-loads the provider from its own `FASTMCP_SERVER_AUTH_*` environment variables; leave `CLICKHOUSE_MCP_AUTH_TOKEN` unset in this mode
 * `CLICKHOUSE_MCP_AUTH_DISABLED`: Disable authentication for HTTP/SSE transports
   * Default: `"false"` (authentication is enabled)
   * Set to `"true"` to disable authentication for local development/testing only
@@ -620,7 +651,7 @@ CLICKHOUSE_PASSWORD=clickhouse
 CLICKHOUSE_MCP_SERVER_TRANSPORT=http
 CLICKHOUSE_MCP_BIND_HOST=0.0.0.0  # Bind to all interfaces
 CLICKHOUSE_MCP_BIND_PORT=4200  # Custom port (default: 8000)
-CLICKHOUSE_MCP_AUTH_TOKEN=your-generated-token  # Required for HTTP/SSE
+CLICKHOUSE_MCP_AUTH_TOKEN=your-generated-token  # One auth mode required for HTTP/SSE (or FASTMCP_SERVER_AUTH, or CLICKHOUSE_MCP_AUTH_DISABLED=true)
 ```
 
 For local development with HTTP transport (authentication disabled):

--- a/README.md
+++ b/README.md
@@ -101,10 +101,7 @@ Startup fails if none of these are configured for HTTP/SSE transports.
    }
    ```
 
-   For command-line tools:
-   ```bash
-   curl -H "Authorization: Bearer your-generated-token" http://localhost:8000/health
-   ```
+   Note: the `/health` endpoint is intentionally unauthenticated (see [Health Check Endpoint](#health-check-endpoint) above). To verify that bearer-token auth is actually rejecting unauthenticated requests, hit the MCP endpoint itself e.g. with the MCP Inspector, or by POSTing a JSON-RPC request to `/mcp` with and without the `Authorization` header and confirming the unauthenticated call returns `401`.
 
 #### OAuth / OIDC via FastMCP
 
@@ -480,11 +477,7 @@ CLICKHOUSE_PASSWORD=clickhouse
    CLICKHOUSE_MCP_SERVER_TRANSPORT=http CLICKHOUSE_MCP_AUTH_TOKEN="your-token" python -m mcp_clickhouse.main
 
    # Then in another terminal:
-   # Without auth (if disabled):
    curl http://localhost:8000/health
-
-   # With auth:
-   curl -H "Authorization: Bearer your-token" http://localhost:8000/health
    ```
 
 ### Environment Variables

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -300,10 +300,12 @@ class MCPServerConfig:
         CLICKHOUSE_MCP_BIND_HOST: Bind host for HTTP/SSE (default: 127.0.0.1)
         CLICKHOUSE_MCP_BIND_PORT: Bind port for HTTP/SSE (default: 8000)
         CLICKHOUSE_MCP_QUERY_TIMEOUT: SELECT tool timeout in seconds (default: 30)
-        CLICKHOUSE_MCP_AUTH_TOKEN: Authentication token for HTTP/SSE transports (required
-            unless CLICKHOUSE_MCP_AUTH_DISABLED=true)
-        CLICKHOUSE_MCP_AUTH_DISABLED: Disable authentication (default: false, use
-            only for development)
+        CLICKHOUSE_MCP_AUTH_TOKEN: Static bearer token for HTTP/SSE transports.
+            One authentication mode must be configured for HTTP/SSE; the other two
+            options are FASTMCP_SERVER_AUTH (FastMCP OAuth/OIDC providers) and
+            CLICKHOUSE_MCP_AUTH_DISABLED=true.
+        CLICKHOUSE_MCP_AUTH_DISABLED: Disable authentication entirely (default: false,
+            development only)
     """
 
     @property

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -84,6 +84,28 @@ def _resolve_auth(mcp_config) -> Dict[str, Any]:
     if mcp_config.server_transport not in _HTTP_TRANSPORTS:
         return {}
 
+    configured = {
+        "CLICKHOUSE_MCP_AUTH_DISABLED": mcp_config.auth_disabled,
+        "CLICKHOUSE_MCP_AUTH_TOKEN": bool(mcp_config.auth_token),
+        "FASTMCP_SERVER_AUTH": bool(os.getenv("FASTMCP_SERVER_AUTH")),
+    }
+    active = [name for name, is_set in configured.items() if is_set]
+
+    if len(active) > 1:
+        raise ValueError(
+            "Multiple authentication modes configured for HTTP/SSE transport: "
+            f"{', '.join(active)}. These are mutually exclusive; unset all but one."
+        )
+
+    if not active:
+        raise ValueError(
+            "Authentication is required for HTTP/SSE transports. Configure exactly one of:\n"
+            "  - CLICKHOUSE_MCP_AUTH_TOKEN=<token>   (static bearer token)\n"
+            "  - FASTMCP_SERVER_AUTH=<class-path>    (FastMCP auth provider, full class path;\n"
+            "       e.g. fastmcp.server.auth.providers.azure.AzureProvider)\n"
+            "  - CLICKHOUSE_MCP_AUTH_DISABLED=true   (disables auth; development only)"
+        )
+
     if mcp_config.auth_disabled:
         logger.warning("WARNING: MCP SERVER AUTHENTICATION IS DISABLED")
         logger.warning("Only use this for local development/testing.")
@@ -98,19 +120,11 @@ def _resolve_auth(mcp_config) -> Dict[str, Any]:
         logger.info("Authentication enabled for HTTP/SSE transport (static bearer token)")
         return {"auth": verifier}
 
-    fastmcp_provider = os.getenv("FASTMCP_SERVER_AUTH")
-    if fastmcp_provider:
-        logger.info("Authentication delegated to FastMCP provider: %s", fastmcp_provider)
-        # Return empty kwargs so FastMCP auto-loads from FASTMCP_SERVER_AUTH_* env vars.
-        return {}
-
-    raise ValueError(
-        "Authentication is required for HTTP/SSE transports. Configure one of:\n"
-        "  - CLICKHOUSE_MCP_AUTH_TOKEN=<token>   (static bearer token)\n"
-        "  - FASTMCP_SERVER_AUTH=<class-path>    (FastMCP auth provider, full class path;\n"
-        "       e.g. fastmcp.server.auth.providers.azure.AzureProvider)\n"
-        "  - CLICKHOUSE_MCP_AUTH_DISABLED=true   (disables auth; development only)"
+    logger.info(
+        "Authentication delegated to FastMCP provider: %s", os.getenv("FASTMCP_SERVER_AUTH")
     )
+    # Return empty kwargs so FastMCP auto-loads from FASTMCP_SERVER_AUTH_* env vars.
+    return {}
 
 
 mcp = FastMCP(name=MCP_SERVER_NAME, **_resolve_auth(get_mcp_config()))

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -71,51 +71,59 @@ atexit.register(lambda: QUERY_EXECUTOR.shutdown(wait=True))
 
 load_dotenv()
 
-# Configure authentication for HTTP/SSE transports
-auth_provider = None
-mcp_config = get_mcp_config()
-http_transports = [TransportType.HTTP.value, TransportType.SSE.value]
+_HTTP_TRANSPORTS = (TransportType.HTTP.value, TransportType.SSE.value)
 
-if mcp_config.server_transport in http_transports:
+
+def _resolve_auth(mcp_config) -> Dict[str, Any]:
+    """Resolve FastMCP auth kwargs for the current transport.
+
+    An empty return dict omits the `auth` kwarg so FastMCP auto-detects its
+    provider from FASTMCP_SERVER_AUTH / FASTMCP_SERVER_AUTH_* env vars.
+    Returning {"auth": None} instead explicitly disables auth.
+    """
+    if mcp_config.server_transport not in _HTTP_TRANSPORTS:
+        return {}
+
     if mcp_config.auth_disabled:
         logger.warning("WARNING: MCP SERVER AUTHENTICATION IS DISABLED")
         logger.warning("Only use this for local development/testing.")
         logger.warning("DO NOT expose to networks.")
-    elif mcp_config.auth_token:
-        auth_provider = StaticTokenVerifier(
+        return {"auth": None}
+
+    if mcp_config.auth_token:
+        verifier = StaticTokenVerifier(
             tokens={mcp_config.auth_token: {"client_id": "mcp-client", "scopes": []}},
             required_scopes=[],
         )
-        logger.info("Authentication enabled for HTTP/SSE transport")
-    else:
-        # No token configured and auth not disabled
-        raise ValueError(
-            "Authentication token required for HTTP/SSE transports. "
-            "Set CLICKHOUSE_MCP_AUTH_TOKEN environment variable or set "
-            "CLICKHOUSE_MCP_AUTH_DISABLED=true (for development only)."
-        )
+        logger.info("Authentication enabled for HTTP/SSE transport (static bearer token)")
+        return {"auth": verifier}
 
-mcp = FastMCP(name=MCP_SERVER_NAME, auth=auth_provider)
+    fastmcp_provider = os.getenv("FASTMCP_SERVER_AUTH")
+    if fastmcp_provider:
+        logger.info("Authentication delegated to FastMCP provider: %s", fastmcp_provider)
+        # Return empty kwargs so FastMCP auto-loads from FASTMCP_SERVER_AUTH_* env vars.
+        return {}
+
+    raise ValueError(
+        "Authentication is required for HTTP/SSE transports. Configure one of:\n"
+        "  - CLICKHOUSE_MCP_AUTH_TOKEN=<token>   (static bearer token)\n"
+        "  - FASTMCP_SERVER_AUTH=<class-path>    (FastMCP auth provider, full class path;\n"
+        "       e.g. fastmcp.server.auth.providers.azure.AzureProvider)\n"
+        "  - CLICKHOUSE_MCP_AUTH_DISABLED=true   (disables auth; development only)"
+    )
+
+
+mcp = FastMCP(name=MCP_SERVER_NAME, **_resolve_auth(get_mcp_config()))
 _chdb_client = None
 _chdb_error_message: Optional[str] = None
 
 
 @mcp.custom_route("/health", methods=["GET"])
 async def health_check(request: Request) -> PlainTextResponse:
-    """Health check endpoint for monitoring server status.
+    """Liveness probe. Intentionally unauthenticated and minimal.
 
-    Returns OK if the server is running and can connect to ClickHouse.
+    Debug via server logs.
     """
-    if auth_provider is not None:
-        auth_header = request.headers.get("Authorization")
-        if not auth_header or not auth_header.startswith("Bearer "):
-            return PlainTextResponse("Unauthorized", status_code=401)
-
-        token = auth_header[7:]
-        access_token = await auth_provider.verify_token(token)
-        if access_token is None:
-            return PlainTextResponse("Unauthorized", status_code=401)
-
     try:
         # Check if ClickHouse is enabled by trying to create config
         # If ClickHouse is disabled, this will succeed but connection will fail
@@ -125,26 +133,31 @@ async def health_check(request: Request) -> PlainTextResponse:
             # If ClickHouse is disabled, check chDB status
             chdb_config = get_chdb_config()
             if chdb_config.enabled and _chdb_client is not None:
-                return PlainTextResponse("OK - MCP server running with chDB enabled")
+                return PlainTextResponse("OK")
             elif chdb_config.enabled and _chdb_error_message:
                 return PlainTextResponse(
                     "ERROR. chDB initialization failed. Check server logs for details.",
                     status_code=503,
                 )
             else:
-                # Both ClickHouse and chDB are disabled - this is an error
+                logger.error(
+                    "Health check failed: both CLICKHOUSE_ENABLED=false and CHDB_ENABLED=false"
+                )
                 return PlainTextResponse(
-                    "ERROR - Both ClickHouse and chDB are disabled. At least one must be enabled.",
+                    "ERROR. Server misconfigured. Check server logs for details.",
                     status_code=503,
                 )
 
         # Try to create a client connection to verify ClickHouse connectivity
-        client = create_clickhouse_client()
-        version = client.server_version
-        return PlainTextResponse(f"OK - Connected to ClickHouse {version}")
-    except Exception as e:
-        # Return 503 Service Unavailable if we can't connect to ClickHouse
-        return PlainTextResponse(f"ERROR - Cannot connect to ClickHouse: {str(e)}", status_code=503)
+        create_clickhouse_client()
+        return PlainTextResponse("OK")
+    except Exception:
+        # Log the underlying error server-side, but don't leak details over the wire.
+        logger.exception("Health check failed: ClickHouse connection error")
+        return PlainTextResponse(
+            "ERROR. ClickHouse connection failed. Check server logs for details.",
+            status_code=503,
+        )
 
 
 def result_to_table(query_columns, result) -> List[Table]:

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -72,9 +72,6 @@ def test_auth_token_with_sse_transport(monkeypatch: pytest.MonkeyPatch):
     assert config.auth_disabled is False
 
 
-_FASTMCP_JWT_VERIFIER = "fastmcp.server.auth.providers.jwt.JWTVerifier"
-
-
 def _clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for var in (
         "CLICKHOUSE_MCP_AUTH_TOKEN",
@@ -84,74 +81,17 @@ def _clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(var, raising=False)
 
 
-def test_resolve_auth_stdio_returns_no_kwargs(monkeypatch: pytest.MonkeyPatch):
-    """stdio transport never requires auth and never touches FastMCP auth kwargs."""
+def test_resolve_auth_oauth_omits_auth_kwarg(monkeypatch: pytest.MonkeyPatch):
+    """FASTMCP_SERVER_AUTH alone returns empty kwargs (no `auth` key)."""
     _clear_auth_env(monkeypatch)
-    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "stdio")
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH", "fastmcp.server.auth.providers.jwt.JWTVerifier")
 
     assert _resolve_auth(MCPServerConfig()) == {}
 
 
-def test_resolve_auth_http_static_token(monkeypatch: pytest.MonkeyPatch):
-    """A static token produces a StaticTokenVerifier passed into FastMCP."""
-    _clear_auth_env(monkeypatch)
-    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
-    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_TOKEN", "secret")
-
-    kwargs = _resolve_auth(MCPServerConfig())
-
-    assert isinstance(kwargs.get("auth"), StaticTokenVerifier)
-
-
-def test_resolve_auth_http_fastmcp_oauth(monkeypatch: pytest.MonkeyPatch):
-    """FASTMCP_SERVER_AUTH alone satisfies auth; kwargs stay empty so FastMCP auto-loads."""
-    _clear_auth_env(monkeypatch)
-    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
-    monkeypatch.setenv("FASTMCP_SERVER_AUTH", _FASTMCP_JWT_VERIFIER)
-
-    assert _resolve_auth(MCPServerConfig()) == {}
-
-
-def test_resolve_auth_http_fastmcp_oauth_constructs_server(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """End-to-end: FASTMCP_SERVER_AUTH with a real class path must actually let
-    FastMCP(...) construct without raising. This guards against our docs or
-    examples prescribing an invalid short-name that _resolve_auth accepts but
-    FastMCP rejects at construction time."""
-    from fastmcp import FastMCP
-
-    _clear_auth_env(monkeypatch)
-    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
-    monkeypatch.setenv("FASTMCP_SERVER_AUTH", _FASTMCP_JWT_VERIFIER)
-    # JWTVerifier needs at least one verification key source; a public JWKS URI
-    # keeps the class importable without network use during init.
-    monkeypatch.setenv(
-        "FASTMCP_SERVER_AUTH_JWT_VERIFIER_JWKS_URI",
-        "https://example.invalid/.well-known/jwks.json",
-    )
-
-    kwargs = _resolve_auth(MCPServerConfig())
-    # Must not raise:
-    FastMCP(name="test", **kwargs)
-
-
-def test_resolve_auth_static_token_takes_precedence_over_fastmcp(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """If both are set, static token wins (explicit over implicit)."""
-    _clear_auth_env(monkeypatch)
-    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
-    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_TOKEN", "secret")
-    monkeypatch.setenv("FASTMCP_SERVER_AUTH", _FASTMCP_JWT_VERIFIER)
-
-    kwargs = _resolve_auth(MCPServerConfig())
-
-    assert isinstance(kwargs.get("auth"), StaticTokenVerifier)
-
-
-def test_resolve_auth_disabled_explicitly_passes_none(monkeypatch: pytest.MonkeyPatch):
-    """AUTH_DISABLED=true must pass auth=None so FastMCP won't auto-load OAuth env vars."""
+def test_resolve_auth_disabled_passes_explicit_none(monkeypatch: pytest.MonkeyPatch):
+    """CLICKHOUSE_MCP_AUTH_DISABLED=true returns {"auth": None}, not {}."""
     _clear_auth_env(monkeypatch)
     monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
     monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
@@ -159,19 +99,22 @@ def test_resolve_auth_disabled_explicitly_passes_none(monkeypatch: pytest.Monkey
     assert _resolve_auth(MCPServerConfig()) == {"auth": None}
 
 
-def test_resolve_auth_http_without_any_mode_raises(monkeypatch: pytest.MonkeyPatch):
-    """HTTP transport with no auth config must fail startup."""
+def test_resolve_auth_static_token_takes_precedence_over_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """With both static token and FASTMCP_SERVER_AUTH set, returns the static verifier."""
     _clear_auth_env(monkeypatch)
     monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_TOKEN", "secret")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH", "fastmcp.server.auth.providers.jwt.JWTVerifier")
 
-    with pytest.raises(ValueError, match="FASTMCP_SERVER_AUTH"):
-        _resolve_auth(MCPServerConfig())
+    assert isinstance(_resolve_auth(MCPServerConfig()).get("auth"), StaticTokenVerifier)
 
 
-def test_resolve_auth_sse_without_any_mode_raises(monkeypatch: pytest.MonkeyPatch):
-    """SSE behaves the same as HTTP."""
+def test_resolve_auth_http_without_any_mode_raises(monkeypatch: pytest.MonkeyPatch):
+    """HTTP transport with no auth configured raises ValueError."""
     _clear_auth_env(monkeypatch)
-    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "sse")
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
 
     with pytest.raises(ValueError):
         _resolve_auth(MCPServerConfig())

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -1,6 +1,8 @@
 import pytest
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 
 from mcp_clickhouse.mcp_env import MCPServerConfig
+from mcp_clickhouse.mcp_server import _resolve_auth
 
 
 def test_auth_token_configuration(monkeypatch: pytest.MonkeyPatch):
@@ -68,3 +70,108 @@ def test_auth_token_with_sse_transport(monkeypatch: pytest.MonkeyPatch):
     assert config.server_transport == "sse"
     assert config.auth_token == "sse-auth-token"
     assert config.auth_disabled is False
+
+
+_FASTMCP_JWT_VERIFIER = "fastmcp.server.auth.providers.jwt.JWTVerifier"
+
+
+def _clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "CLICKHOUSE_MCP_AUTH_TOKEN",
+        "CLICKHOUSE_MCP_AUTH_DISABLED",
+        "FASTMCP_SERVER_AUTH",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_resolve_auth_stdio_returns_no_kwargs(monkeypatch: pytest.MonkeyPatch):
+    """stdio transport never requires auth and never touches FastMCP auth kwargs."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "stdio")
+
+    assert _resolve_auth(MCPServerConfig()) == {}
+
+
+def test_resolve_auth_http_static_token(monkeypatch: pytest.MonkeyPatch):
+    """A static token produces a StaticTokenVerifier passed into FastMCP."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_TOKEN", "secret")
+
+    kwargs = _resolve_auth(MCPServerConfig())
+
+    assert isinstance(kwargs.get("auth"), StaticTokenVerifier)
+
+
+def test_resolve_auth_http_fastmcp_oauth(monkeypatch: pytest.MonkeyPatch):
+    """FASTMCP_SERVER_AUTH alone satisfies auth; kwargs stay empty so FastMCP auto-loads."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH", _FASTMCP_JWT_VERIFIER)
+
+    assert _resolve_auth(MCPServerConfig()) == {}
+
+
+def test_resolve_auth_http_fastmcp_oauth_constructs_server(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """End-to-end: FASTMCP_SERVER_AUTH with a real class path must actually let
+    FastMCP(...) construct without raising. This guards against our docs or
+    examples prescribing an invalid short-name that _resolve_auth accepts but
+    FastMCP rejects at construction time."""
+    from fastmcp import FastMCP
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH", _FASTMCP_JWT_VERIFIER)
+    # JWTVerifier needs at least one verification key source; a public JWKS URI
+    # keeps the class importable without network use during init.
+    monkeypatch.setenv(
+        "FASTMCP_SERVER_AUTH_JWT_VERIFIER_JWKS_URI",
+        "https://example.invalid/.well-known/jwks.json",
+    )
+
+    kwargs = _resolve_auth(MCPServerConfig())
+    # Must not raise:
+    FastMCP(name="test", **kwargs)
+
+
+def test_resolve_auth_static_token_takes_precedence_over_fastmcp(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If both are set, static token wins (explicit over implicit)."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_TOKEN", "secret")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH", _FASTMCP_JWT_VERIFIER)
+
+    kwargs = _resolve_auth(MCPServerConfig())
+
+    assert isinstance(kwargs.get("auth"), StaticTokenVerifier)
+
+
+def test_resolve_auth_disabled_explicitly_passes_none(monkeypatch: pytest.MonkeyPatch):
+    """AUTH_DISABLED=true must pass auth=None so FastMCP won't auto-load OAuth env vars."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
+
+    assert _resolve_auth(MCPServerConfig()) == {"auth": None}
+
+
+def test_resolve_auth_http_without_any_mode_raises(monkeypatch: pytest.MonkeyPatch):
+    """HTTP transport with no auth config must fail startup."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+
+    with pytest.raises(ValueError, match="FASTMCP_SERVER_AUTH"):
+        _resolve_auth(MCPServerConfig())
+
+
+def test_resolve_auth_sse_without_any_mode_raises(monkeypatch: pytest.MonkeyPatch):
+    """SSE behaves the same as HTTP."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "sse")
+
+    with pytest.raises(ValueError):
+        _resolve_auth(MCPServerConfig())

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -1,5 +1,4 @@
 import pytest
-from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 
 from mcp_clickhouse.mcp_env import MCPServerConfig
 from mcp_clickhouse.mcp_server import _resolve_auth
@@ -99,16 +98,15 @@ def test_resolve_auth_disabled_passes_explicit_none(monkeypatch: pytest.MonkeyPa
     assert _resolve_auth(MCPServerConfig()) == {"auth": None}
 
 
-def test_resolve_auth_static_token_takes_precedence_over_oauth(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """With both static token and FASTMCP_SERVER_AUTH set, returns the static verifier."""
+def test_resolve_auth_rejects_multiple_modes(monkeypatch: pytest.MonkeyPatch):
+    """Configuring more than one auth mode raises ValueError."""
     _clear_auth_env(monkeypatch)
     monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
     monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_TOKEN", "secret")
     monkeypatch.setenv("FASTMCP_SERVER_AUTH", "fastmcp.server.auth.providers.jwt.JWTVerifier")
 
-    assert isinstance(_resolve_auth(MCPServerConfig()).get("auth"), StaticTokenVerifier)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _resolve_auth(MCPServerConfig())
 
 
 def test_resolve_auth_http_without_any_mode_raises(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_optional_chdb.py
+++ b/tests/test_optional_chdb.py
@@ -117,26 +117,8 @@ async def test_health_check_hides_internal_chdb_init_error_details():
 
 
 @pytest.mark.asyncio
-async def test_health_check_hides_clickhouse_version_on_success():
-    """The success response must not leak the ClickHouse version string."""
-    request = Request({"type": "http", "method": "GET", "headers": []})
-
-    fake_client = MagicMock()
-    fake_client.server_version = "24.3.2.23-stable-internal-build"
-
-    with (
-        patch.dict("os.environ", {"CLICKHOUSE_ENABLED": "true"}, clear=False),
-        patch.object(mcp_server, "create_clickhouse_client", return_value=fake_client),
-    ):
-        response = await mcp_server.health_check(request)
-
-    assert response.status_code == 200
-    assert response.body == b"OK"
-
-
-@pytest.mark.asyncio
 async def test_health_check_hides_clickhouse_connection_error_details():
-    """The failure response must not leak exception details (hostnames, creds, etc.)."""
+    """A 503 response from a connection failure does not include the exception's hostname or credentials."""
     request = Request({"type": "http", "method": "GET", "headers": []})
 
     def raise_with_secrets():

--- a/tests/test_optional_chdb.py
+++ b/tests/test_optional_chdb.py
@@ -114,3 +114,48 @@ async def test_health_check_hides_internal_chdb_init_error_details():
     assert b"initialization failed" in body
     assert b"check server logs for details" in body
     assert b"/tmp/private.db" not in body
+
+
+@pytest.mark.asyncio
+async def test_health_check_hides_clickhouse_version_on_success():
+    """The success response must not leak the ClickHouse version string."""
+    request = Request({"type": "http", "method": "GET", "headers": []})
+
+    fake_client = MagicMock()
+    fake_client.server_version = "24.3.2.23-stable-internal-build"
+
+    with (
+        patch.dict("os.environ", {"CLICKHOUSE_ENABLED": "true"}, clear=False),
+        patch.object(mcp_server, "create_clickhouse_client", return_value=fake_client),
+    ):
+        response = await mcp_server.health_check(request)
+
+    assert response.status_code == 200
+    assert response.body == b"OK"
+
+
+@pytest.mark.asyncio
+async def test_health_check_hides_clickhouse_connection_error_details():
+    """The failure response must not leak exception details (hostnames, creds, etc.)."""
+    request = Request({"type": "http", "method": "GET", "headers": []})
+
+    def raise_with_secrets():
+        raise ConnectionError(
+            "HTTPConnectionPool(host='internal-ch.prod.mycorp.local', port=8443): "
+            "password=hunter2 failed"
+        )
+
+    with (
+        patch.dict("os.environ", {"CLICKHOUSE_ENABLED": "true"}, clear=False),
+        patch.object(
+            mcp_server, "create_clickhouse_client", side_effect=raise_with_secrets
+        ),
+    ):
+        response = await mcp_server.health_check(request)
+
+    assert response.status_code == 503
+    body = response.body.lower()
+    assert b"clickhouse connection failed" in body
+    assert b"check server logs for details" in body
+    assert b"internal-ch.prod.mycorp.local" not in body
+    assert b"hunter2" not in body


### PR DESCRIPTION
## Summary
#113 (`a1f3639`) added static bearer-token auth for HTTP/SSE transports but unintentionally broke FastMCP's OAuth/OIDC providers.

1. Startup raised `ValueError` unless `CLICKHOUSE_MCP_AUTH_TOKEN` or `CLICKHOUSE_MCP_AUTH_DISABLED=true` was set, leaving no path to configure OAuth.
2. Even with a workaround token, `FastMCP(auth=StaticTokenVerifier(...))` overrode FastMCP's env-var-driven provider auto-discovery, so `FASTMCP_SERVER_AUTH_AZURE_*` vars were silently ignored.

## Changes

- `mcp_clickhouse/mcp_server.py`: extracted auth resolution into `_resolve_auth()`. Three mutually exclusive modes for HTTP/SSE:
  1. `CLICKHOUSE_MCP_AUTH_DISABLED=true` -> `auth=None`
  2. `CLICKHOUSE_MCP_AUTH_TOKEN` -> `StaticTokenVerifier`
  3. `FASTMCP_SERVER_AUTH=<full class path>` -> omit `auth` kwarg so FastMCP auto-loads from `FASTMCP_SERVER_AUTH_*`.
  4. Startup fails if none is configured.
- `/health` hardening: removed the inline auth gate (it only worked under static-token mode and was incompatible with redirect-based OAuth providers anyway). Response bodies trimmed to `OK` / generic `ERROR. ... Check server logs for details.` Underlying errors are logged server-side.

Closes #171 