### PR TITLE
allow publish to ghcr

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,63 @@
+name: Publish Docker image to GHCR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or branch to build from (e.g. v0.3.0)"
+        required: true
+        default: "main"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=match,pattern=v(\d+\.\d+\.\d+),group=1,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -49,7 +49,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=match,pattern=v(\d+\.\d+\.\d+),group=1,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Production stage - Use minimal Python image
 FROM python:3.13-slim-bookworm
 
+LABEL org.opencontainers.image.source="https://github.com/ClickHouse/mcp-clickhouse"
+LABEL org.opencontainers.image.description="MCP server for ClickHouse"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 # Set the working directory
 WORKDIR /app
 


### PR DESCRIPTION
Until we can get some kind of bot to auto submit releases to Docker's mcp namespace, we can publish to ghcr on each release. This PR provides a way to do that automatically on releases or manually via dispatch.