### PR TITLE
docs: Add one-click "Add to Kiro" install badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,42 @@ You can also enable both ClickHouse and chDB simultaneously:
 
 4. Restart Claude Desktop to apply the changes.
 
+### Kiro
+
+[![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=mcp-clickhouse&config=%7B%22command%22%3A%22uv%22%2C%22args%22%3A%5B%22run%22%2C%22--with%22%2C%22mcp-clickhouse%22%2C%22--python%22%2C%223.10%22%2C%22mcp-clickhouse%22%5D%2C%22env%22%3A%7B%22CLICKHOUSE_HOST%22%3A%22localhost%22%2C%22CLICKHOUSE_USER%22%3A%22default%22%2C%22CLICKHOUSE_PASSWORD%22%3A%22%22%7D%7D)
+
+Or add the following to your Kiro MCP config file (`~/.kiro/settings/mcp.json` for global, or `.kiro/settings/mcp.json` for project-scoped). See the [Kiro MCP documentation](https://kiro.dev/docs/mcp/) for more details.
+
+```json
+{
+  "mcpServers": {
+    "mcp-clickhouse": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "mcp-clickhouse",
+        "--python",
+        "3.10",
+        "mcp-clickhouse"
+      ],
+      "env": {
+        "CLICKHOUSE_HOST": "<clickhouse-host>",
+        "CLICKHOUSE_PORT": "<clickhouse-port>",
+        "CLICKHOUSE_USER": "<clickhouse-user>",
+        "CLICKHOUSE_PASSWORD": "<clickhouse-password>",
+        "CLICKHOUSE_SECURE": "true",
+        "CLICKHOUSE_VERIFY": "true",
+        "CLICKHOUSE_CONNECT_TIMEOUT": "30",
+        "CLICKHOUSE_SEND_RECEIVE_TIMEOUT": "30"
+      }
+    }
+  }
+}
+```
+
+Update the environment variables to point to your own ClickHouse service.
+
 ### Optional Write Access
 
 By default, this MCP enforces read-only queries so that accidental mutations cannot happen during exploration. To allow DDL or INSERT/UPDATE statements, set the `CLICKHOUSE_ALLOW_WRITE_ACCESS` environment variable to `true`. The server keeps enforcing read-only mode if the ClickHouse instance itself disallows writes.


### PR DESCRIPTION
Adds one-click install for [Kiro](https://kiro.dev), an AI-powered IDE.

When clicked, Kiro auto-configures this MCP server — no manual JSON editing needed.

- Added a new "Kiro" subsection under Configuration, following the same pattern as the existing Claude Desktop setup
- Includes one-click badge plus manual JSON config with the same env vars documented in the repo
- Config file paths included for both global (`~/.kiro/settings/mcp.json`) and project-scoped (`.kiro/settings/mcp.json`)
- Links to [Kiro MCP documentation](https://kiro.dev/docs/mcp/)

Only the README is modified — no other content changed.