### PR TITLE
Preserve large integer precision in JSON responses

### DIFF
--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -183,8 +183,29 @@ def result_to_column(query_columns, result) -> List[Column]:
     return [Column(**dict(zip(query_columns, row))) for row in result]
 
 
+JS_MAX_SAFE_INTEGER = (1 << 53) - 1
+
+
+def _json_safe_value(obj: Any) -> Any:
+    if isinstance(obj, int) and not isinstance(obj, bool):
+        if abs(obj) > JS_MAX_SAFE_INTEGER:
+            return str(obj)
+        return obj
+
+    if isinstance(obj, tuple):
+        return [_json_safe_value(item) for item in obj]
+
+    if isinstance(obj, list):
+        return [_json_safe_value(item) for item in obj]
+
+    if isinstance(obj, dict):
+        return {key: _json_safe_value(value) for key, value in obj.items()}
+
+    return obj
+
+
 def _serialize_tool_result(obj: Any) -> str:
-    return json.dumps(obj, default=str)
+    return json.dumps(_json_safe_value(obj), default=str)
 
 
 def list_databases() -> str:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,7 +5,7 @@ from fastmcp.exceptions import ToolError
 import asyncio
 import time
 from unittest.mock import patch
-from mcp_clickhouse.mcp_server import mcp, create_clickhouse_client
+from mcp_clickhouse.mcp_server import _serialize_tool_result, create_clickhouse_client, mcp
 from dotenv import load_dotenv
 import json
 
@@ -105,6 +105,17 @@ async def test_list_databases(mcp_server, setup_test_database):
         databases = json.loads(result.content[0].text)
         assert test_db in databases
         assert "system" in databases  # System database should always exist
+
+
+def test_serialize_tool_result_stringifies_large_integers():
+    payload = {"rows": [[1875924584784080993, 42, True]], "value": -1875924584784080993}
+
+    result = json.loads(_serialize_tool_result(payload))
+
+    assert result == {
+        "rows": [["1875924584784080993", 42, True]],
+        "value": "-1875924584784080993",
+    }
 
 
 @pytest.mark.asyncio
@@ -229,6 +240,19 @@ async def test_run_select_query_with_aggregation(mcp_server, setup_test_database
         assert len(query_result["rows"]) == 1
         assert query_result["rows"][0][0] == 4  # count
         assert query_result["rows"][0][1] == 29.5  # average age
+
+
+@pytest.mark.asyncio
+async def test_run_select_query_preserves_uint64_precision(mcp_server):
+    """Large UInt64 values should be serialized as strings to avoid JS precision loss."""
+    async with Client(mcp_server) as client:
+        query = "SELECT toUInt64('1875924584784080993') as value"
+        result = await client.call_tool("run_query", {"query": query})
+
+        query_result = json.loads(result.content[0].text)
+
+        assert query_result["columns"] == ["value"]
+        assert query_result["rows"] == [["1875924584784080993"]]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Convert integers outside JavaScript's safe integer range to strings before serializing MCP tool results.
- Preserve regular integers and booleans while applying the conversion recursively to nested rows and response payloads.
- Add regression coverage for large UInt64 query results and the serializer helper.

Fixes #111

## Testing
- `python -m pytest tests/test_mcp_server.py -k "stringifies_large_integers" -q`
- `python -m ruff check mcp_clickhouse/mcp_server.py tests/test_mcp_server.py`