### PR TITLE
feat: adding correct tool annotations

### DIFF
--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -19,6 +19,7 @@ from fastmcp.prompts import Prompt
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from fastmcp.server.dependencies import get_context
 from fastmcp.tools import Tool
+from mcp.types import ToolAnnotations
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
@@ -817,6 +818,7 @@ def _register_chdb_tools():
             run_chdb_select_query_async,
             name="run_chdb_select_query",
             description="Run SQL in chDB, an in-process ClickHouse engine",
+            annotations=ToolAnnotations(readOnlyHint=True),
         )
     )
     chdb_prompt = Prompt.from_function(
@@ -830,8 +832,8 @@ def _register_chdb_tools():
 
 # Register tools based on configuration
 if os.getenv("CLICKHOUSE_ENABLED", "true").lower() == "true":
-    mcp.add_tool(Tool.from_function(list_databases))
-    mcp.add_tool(Tool.from_function(list_tables))
+    mcp.add_tool(Tool.from_function(list_databases, annotations=ToolAnnotations(readOnlyHint=True)))
+    mcp.add_tool(Tool.from_function(list_tables, annotations=ToolAnnotations(readOnlyHint=True)))
     mcp.add_tool(
         Tool.from_function(
             run_query_async,
@@ -841,6 +843,7 @@ if os.getenv("CLICKHOUSE_ENABLED", "true").lower() == "true":
                 "Set CLICKHOUSE_ALLOW_WRITE_ACCESS=true to allow DDL and DML operations. "
                 "Set CLICKHOUSE_ALLOW_DROP=true to additionally allow destructive operations (DROP, TRUNCATE)."
             ),
+            annotations=ToolAnnotations(readOnlyHint=not get_config().allow_write_access),
         )
     )
     logger.info("ClickHouse tools registered")


### PR DESCRIPTION
## Summary
- Add MCP `ToolAnnotations` with `readOnlyHint` to all registered tools
- `list_databases`, `list_tables`, and `run_chdb_select_query` are marked as `readOnlyHint=True` (always read-only)
- `run_query` annotation is set dynamically based on `CLICKHOUSE_ALLOW_WRITE_ACCESS`: read-only by default, non-read-only when write access is enabled

## Motivation
MCP clients (e.g. Claude Code, ChatGPT) use tool annotations to decide whether to prompt users for confirmation before executing a tool call. Without annotations, clients may conservatively require confirmation for every call — even read-only ones like listing databases or tables.

## Test plan
- [ ] Verify `list_databases`, `list_tables`, `run_chdb_select_query` expose `readOnlyHint=true` in tool metadata
- [ ] Verify `run_query` exposes `readOnlyHint=true` when `CLICKHOUSE_ALLOW_WRITE_ACCESS` is unset or `false`
- [ ] Verify `run_query` exposes `readOnlyHint=false` when `CLICKHOUSE_ALLOW_WRITE_ACCESS=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)