### PR TITLE
ci: cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `ci` workflow runs tests only; no GitHub API writes. Workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 hardening pattern. YAML validated locally.