### PR TITLE
fix: stringify large ClickHouse integers to prevent JSON precision loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Connection failures now log actionable hints for common misconfigurations (native TCP port used instead of the HTTP interface, TLS/`CLICKHOUSE_SECURE` mismatches), and a warning is logged when `CLICKHOUSE_PORT` is set to a native protocol port (9000/9440). ([#102](https://github.com/ClickHouse/mcp-clickhouse/issues/102))
 
+### Fixed
+- Large ClickHouse integers (`UInt64`, `Int64`, `UInt128`, `Int128`, `UInt256`, `Int256`) beyond JavaScript's safe integer range (`2^53 - 1`) are now serialized as JSON strings instead of raw number literals, preventing silent precision loss when tool results are decoded by JS-based MCP clients. ([#111](https://github.com/ClickHouse/mcp-clickhouse/issues/111))
+
 ## 0.4.1 - 2026-07-17
 
 ### Changed

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -188,8 +188,41 @@ def result_to_column(query_columns, result) -> List[Column]:
     return [Column(**dict(zip(query_columns, row))) for row in result]
 
 
+# The largest integer magnitude that round-trips exactly through an IEEE 754
+# double-precision float, i.e. JavaScript's `Number` type. Most MCP clients
+# (including Claude Desktop) decode tool results with `JSON.parse`, which
+# represents every JSON number as a `Number`. ClickHouse integer types such as
+# UInt64/Int64/UInt128/Int128/UInt256/Int256 routinely exceed this range, so
+# emitting them as raw JSON number literals silently corrupts the value on the
+# client side (see https://github.com/ClickHouse/mcp-clickhouse/issues/111).
+_JSON_SAFE_INT_LIMIT = 2**53 - 1
+
+
+def _json_safe(obj: Any) -> Any:
+    """Recursively stringify integers that JSON number literals can't carry safely.
+
+    `json.dumps` serializes Python `int` natively for any magnitude, and never
+    routes it through a `default=` hook, so `default=str` alone does not help
+    here. This walks dicts/lists/tuples (covering nested ClickHouse Array,
+    Tuple, and Map values) and converts any out-of-range int to its exact
+    decimal string before serialization. `bool` is a subclass of `int` but is
+    always within range, so it is left untouched to preserve JSON true/false.
+    """
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, int):
+        if obj > _JSON_SAFE_INT_LIMIT or obj < -_JSON_SAFE_INT_LIMIT:
+            return str(obj)
+        return obj
+    if isinstance(obj, dict):
+        return {key: _json_safe(value) for key, value in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_json_safe(item) for item in obj]
+    return obj
+
+
 def _serialize_tool_result(obj: Any) -> str:
-    return json.dumps(obj, default=str)
+    return json.dumps(_json_safe(obj), default=str)
 
 
 def list_databases() -> str:

--- a/tests/test_json_serialization.py
+++ b/tests/test_json_serialization.py
@@ -1,0 +1,159 @@
+"""Unit tests for JSON-safe serialization of tool results.
+
+Regression coverage for https://github.com/ClickHouse/mcp-clickhouse/issues/111:
+large ClickHouse integers (UInt64, Int64, UInt128, Int128, UInt256, Int256) were
+serialized as raw JSON number literals. JSON itself has no size limit on numbers,
+but most MCP clients decode results the way JavaScript's `JSON.parse` does, which
+represents every JSON number as an IEEE 754 double. Integers larger than
+2**53 - 1 (`Number.MAX_SAFE_INTEGER`) silently lose precision when decoded that
+way -- e.g. the reporter's 1875924584784080993 becomes 1875924584784081000.
+
+Python's own `json` module has arbitrary-precision integers, so a plain
+`json.dumps` -> `json.loads` round trip in this test suite can't reproduce that
+corruption directly. Instead, these tests assert on the *mechanism* of the fix:
+out-of-range integers must be emitted as JSON strings (exact decimal text),
+never as bare number literals, so that any float64-based JSON consumer receives
+a string it can parse losslessly instead of a number it will round.
+
+These are pure unit tests -- no ClickHouse connection required.
+"""
+
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from mcp_clickhouse.mcp_server import _json_safe, _serialize_tool_result, execute_query
+
+# The reporter's example from issue #111: a UInt64 value that exceeds
+# Number.MAX_SAFE_INTEGER and gets rounded to 1875924584784081000 by JS.
+BIG_UINT64 = 1875924584784080993
+JS_MAX_SAFE_INTEGER = 2**53 - 1
+
+
+class TestJsonSafe(unittest.TestCase):
+    """Unit tests for the `_json_safe` helper in isolation."""
+
+    def test_small_int_untouched(self):
+        self.assertEqual(_json_safe(42), 42)
+        self.assertIsInstance(_json_safe(42), int)
+
+    def test_int_at_safe_boundary_untouched(self):
+        result = _json_safe(JS_MAX_SAFE_INTEGER)
+        self.assertEqual(result, JS_MAX_SAFE_INTEGER)
+        self.assertIsInstance(result, int)
+
+    def test_int_beyond_safe_boundary_stringified(self):
+        result = _json_safe(JS_MAX_SAFE_INTEGER + 1)
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, str(JS_MAX_SAFE_INTEGER + 1))
+
+    def test_large_uint64_stringified(self):
+        result = _json_safe(BIG_UINT64)
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, str(BIG_UINT64))
+        self.assertEqual(int(result), BIG_UINT64)
+
+    def test_large_negative_int_stringified(self):
+        big_negative = -BIG_UINT64
+        result = _json_safe(big_negative)
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, str(big_negative))
+
+    def test_bool_untouched(self):
+        # bool is a subclass of int; it must never become the string "True"/"False".
+        self.assertIs(_json_safe(True), True)
+        self.assertIs(_json_safe(False), False)
+
+    def test_nested_dict_list_and_tuple(self):
+        # Covers ClickHouse Array/Tuple/Map-shaped values nested in a result.
+        nested = {
+            "a": [1, BIG_UINT64, {"b": BIG_UINT64}],
+            "c": (BIG_UINT64, "text"),
+        }
+        result = _json_safe(nested)
+        self.assertEqual(result["a"][0], 1)
+        self.assertEqual(result["a"][1], str(BIG_UINT64))
+        self.assertEqual(result["a"][2]["b"], str(BIG_UINT64))
+        self.assertEqual(result["c"], [str(BIG_UINT64), "text"])
+
+    def test_non_numeric_types_untouched(self):
+        self.assertEqual(_json_safe("hello"), "hello")
+        self.assertIsNone(_json_safe(None))
+        self.assertEqual(_json_safe(3.14), 3.14)
+
+    def test_dict_keys_left_alone(self):
+        # JSON object keys are always emitted as exact-text strings regardless
+        # of magnitude, so only values need the safety conversion.
+        result = _json_safe({BIG_UINT64: "value"})
+        self.assertIn(BIG_UINT64, result)
+        self.assertEqual(result[BIG_UINT64], "value")
+
+
+class TestSerializeToolResult(unittest.TestCase):
+    """Unit tests for `_serialize_tool_result`, the function every MCP tool funnels through."""
+
+    def test_large_uint64_survives_json_round_trip_as_string(self):
+        payload = {"columns": ["id"], "rows": [[BIG_UINT64]]}
+        serialized = _serialize_tool_result(payload)
+        decoded = json.loads(serialized)
+
+        value = decoded["rows"][0][0]
+        # Must be carried as a string (exact decimal text), not a bare JSON
+        # number -- that's what protects it from a JS float64 `Number`.
+        self.assertIsInstance(value, str)
+        self.assertEqual(int(value), BIG_UINT64)
+
+    def test_small_ints_stay_numeric(self):
+        payload = {"columns": ["id"], "rows": [[1], [2]]}
+        serialized = _serialize_tool_result(payload)
+        decoded = json.loads(serialized)
+        self.assertEqual(decoded["rows"], [[1], [2]])
+        self.assertIsInstance(decoded["rows"][0][0], int)
+
+    def test_non_serializable_type_still_falls_back_to_str(self):
+        # Existing behavior (e.g. Decimal/UUID/datetime) must be preserved:
+        # `default=str` still handles types json.dumps can't encode natively.
+        class Weird:
+            def __str__(self):
+                return "weird-value"
+
+        serialized = _serialize_tool_result({"value": Weird()})
+        self.assertEqual(json.loads(serialized), {"value": "weird-value"})
+
+
+class TestExecuteQueryBigIntRegression(unittest.TestCase):
+    """End-to-end regression test through `execute_query` with a mocked ClickHouse client.
+
+    Reproduces the reporter's scenario -- a `run_query` call whose result set
+    contains a UInt64 value beyond the JS-safe integer range -- without needing
+    a live ClickHouse server.
+    """
+
+    def test_execute_query_stringifies_large_uint64(self):
+        mock_result = MagicMock()
+        mock_result.column_names = ["big_value"]
+        mock_result.result_rows = [(BIG_UINT64,)]
+
+        mock_client = MagicMock()
+        mock_client.server_settings = {}
+        mock_client.query.return_value = mock_result
+
+        # Bypass the real env-var-backed config singleton entirely so this
+        # test is hermetic regardless of process env / test execution order.
+        fake_config = SimpleNamespace(allow_write_access=False, allow_drop=False)
+
+        with (
+            patch("mcp_clickhouse.mcp_server.create_clickhouse_client", return_value=mock_client),
+            patch("mcp_clickhouse.mcp_server.get_config", return_value=fake_config),
+        ):
+            result_json = execute_query("SELECT big_value FROM some_table")
+
+        decoded = json.loads(result_json)
+        self.assertEqual(decoded["columns"], ["big_value"])
+        self.assertEqual(decoded["rows"], [[str(BIG_UINT64)]])
+        self.assertEqual(int(decoded["rows"][0][0]), BIG_UINT64)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Large ClickHouse integers (`UInt64`, `Int64`, `UInt128`, `Int128`, `UInt256`, `Int256`) were getting corrupted in tool results — e.g. `1875924584784080993` would come back as `1875924584784081000` on the client side.

**Root cause:** `_serialize_tool_result()` in `mcp_clickhouse/mcp_server.py` called `json.dumps(obj, default=str)`. The `default=` hook is only invoked for types `json.dumps` doesn't know how to encode natively — `int` is natively serializable at any magnitude, so `default=str` never fires for it, regardless of size. `clickhouse_connect` returns ClickHouse's large integer types as native Python `int`, so they were emitted as raw JSON number literals. JSON itself has no limit on integer size, but most MCP clients (including Claude Desktop) decode results the way JavaScript's `JSON.parse` does, representing every JSON number as an IEEE 754 double. Any integer beyond `Number.MAX_SAFE_INTEGER` (`2**53 - 1`) is silently rounded to the nearest representable double on the client, which is exactly the corruption reported in #111.

**Fix:** Added `_json_safe()`, a recursive pre-pass that walks dicts/lists/tuples (covering nested ClickHouse `Array`, `Tuple`, and `Map` values) and converts any `int` outside `[-(2**53-1), 2**53-1]` to its exact decimal string, then routed `_serialize_tool_result()` through it before calling `json.dumps`. `_serialize_tool_result` is the single choke point every tool (`run_query`, `list_tables`, `list_databases`, `run_chdb_select_query`) already funnels its output through, so the one change covers all of them, matching the issue's own suggestion ("wrap such types as a string"). `bool` is excluded (it's a subclass of `int` in Python but always in-range) so `true`/`false` are unaffected. Dict *keys* are left untouched since JSON object keys are always emitted as exact-text strings by `json.dumps` regardless of magnitude — only numeric *values* were ever at risk.

**Behavior change to note for review:** a `run_query` row value that is a `UInt64` above `2**53 - 1` now comes back as a JSON string instead of a JSON number (e.g. `"1875924584784080993"` instead of the previously-corrupted `1875924584784081000`). Values at or below that threshold are untouched and still serialize as plain JSON numbers, so this only changes the encoding for values that were already silently wrong on any float64-based client — it does not affect small/typical integer columns (ids, counts, etc.).

### Validation

```bash
uv sync --all-extras --dev
uv run ruff check .
uv run pytest tests/test_json_serialization.py -v
```
- `ruff check .` → **All checks passed!**
- `tests/test_json_serialization.py` (13 new unit tests, no ClickHouse connection required) → **13 passed**. These cover `_json_safe` directly (boundary values, negative values, nested dict/list/tuple, bool, dict keys, non-numeric passthrough), `_serialize_tool_result` (round-trip of a large `UInt64`, small ints staying numeric, existing `default=str` fallback for non-JSON-native types like `Decimal`), and an `execute_query` regression test with a mocked ClickHouse client reproducing the reporter's exact scenario end-to-end.
- Confirmed the new tests actually catch the bug: reverted `mcp_clickhouse/mcp_server.py` to the pre-fix version (`git stash`) and re-ran — `tests/test_json_serialization.py` fails to even collect (`ImportError: cannot import name '_json_safe'`), i.e. red in CI. Restored the fix (`git stash pop`) and re-ran — 13 passed again.

```bash
uv run pytest tests -q
```
Result: **63 passed, 2 skipped, 42 errors, 6 failed.** Every error/failure traces to `ValueError: Missing required environment variables: CLICKHOUSE_HOST, CLICKHOUSE_USER, CLICKHOUSE_PASSWORD` — this sandbox doesn't have Docker available to run `test-services` (`docker compose up -d test_services`), so the DB-backed integration suite (`test_tool.py`, `test_mcp_server.py`, `test_pagination.py`, part of `test_context_config_override.py`) couldn't connect to a real ClickHouse instance. This is an environment limitation, not a regression from this change — verified none of the failures reference `_json_safe`/`_serialize_tool_result`/this diff. Upstream CI provisions a `clickhouse/clickhouse-server:24.10` service container and should exercise the full DB-backed suite; happy to address anything that surfaces there.

Fixes #111

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.
