### PR TITLE
Add context-cost badge (581 tokens — well under the 2,636 median)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <!-- mcp-name: io.github.ClickHouse/mcp-clickhouse -->
 
 [![PyPI - Version](https://img.shields.io/pypi/v/mcp-clickhouse)](https://pypi.org/project/mcp-clickhouse)
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fclickhouse.json)](https://athakur3.github.io/mcp-context-cost/METHODOLOGY)
 
 An MCP server for ClickHouse.
 


### PR DESCRIPTION
One line: a shields.io badge showing what mcp-clickhouse's tool schemas cost in context tokens — currently **581 tokens across 3 tools** (`list_tables`: 370, `run_query`: 133, `list_databases`: 79), measured 2026-08-16. Among 57 popular MCP servers we measured the median is 2,636, so this is a lean server — worth letting the README say so.

The badge JSON lives in [our repo](https://github.com/athakur3/mcp-context-cost) and refreshes weekly; the number links to a reproducible methodology — raw `tools/list` capture + pinned `o200k_base` tokenizer, re-derivable in five lines from [results/clickhouse/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/clickhouse/measurement.json).

If you'd rather not carry this, close freely — no hard feelings. To own the number in your own CI instead: sd2k/mcp-tokens-action (badge support proposed in sd2k/mcp-tokens-action#5).