### PR TITLE
fix: close DROP and TRUNCATE protection bypasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+- With `CLICKHOUSE_ALLOW_WRITE_ACCESS=true` and `CLICKHOUSE_ALLOW_DROP` unset, the server now runs `SHOW GRANTS` once at first connection and logs a warning if the ClickHouse user holds `ALL`, `DROP`, `TRUNCATE`, `DELETE`, `UPDATE`, or `ALTER` (beyond `ALTER ADD`) privileges, since the destructive-operation gate is not server-enforced. The check is fail-open and never blocks startup or queries. Grants held via roles are not expanded, so the advisory only flags direct grants.
+
+### Changed
+- The destructive-operation gate (`CLICKHOUSE_ALLOW_DROP`) now also blocks `DELETE`, `UPDATE` (including the `ALTER TABLE ... DELETE` / `UPDATE` mutations), `REPLACE TABLE` / `REPLACE PARTITION` / `CREATE OR REPLACE`, `ALTER TABLE ... CLEAR COLUMN` / `CLEAR INDEX` / `CLEAR PROJECTION`, and `DETACH ... PERMANENTLY`. These previously ran with write access alone and now require `CLICKHOUSE_ALLOW_DROP=true` as well. Plain `DETACH` stays allowed because it is reversible with `ATTACH`.
+- Connection failures now log actionable hints for common misconfigurations (native TCP port used instead of the HTTP interface, TLS/`CLICKHOUSE_SECURE` mismatches), and a warning is logged when `CLICKHOUSE_PORT` is set to a native protocol port (9000/9440). ([#102](https://github.com/ClickHouse/mcp-clickhouse/issues/102))
+
 ### Fixed
 - Destructive-operation protection no longer misses `TRUNCATE` statements that omit the `TABLE` keyword (`TRUNCATE db.name` is valid ClickHouse syntax), `TRUNCATE DATABASE`, `TRUNCATE ALL TABLES FROM`, `ALTER TABLE ... DROP PARTITION` / `DROP PART` / `DROP COLUMN`, or `DROP` of object types outside `TABLE`/`DATABASE`/`VIEW`/`DICTIONARY`. With `CLICKHOUSE_ALLOW_WRITE_ACCESS=true` and `CLICKHOUSE_ALLOW_DROP` unset, these statements previously ran and deleted data.
 - Destructive-operation protection no longer rejects safe statements that merely contain `drop` or `truncate` inside a string literal, a quoted identifier, or a SQL comment, such as `INSERT INTO logs VALUES ('drop the table')`. Comments can no longer hide a destructive statement from the check either.
-
-### Changed
-- Connection failures now log actionable hints for common misconfigurations (native TCP port used instead of the HTTP interface, TLS/`CLICKHOUSE_SECURE` mismatches), and a warning is logged when `CLICKHOUSE_PORT` is set to a native protocol port (9000/9440). ([#102](https://github.com/ClickHouse/mcp-clickhouse/issues/102))
 
 ## 0.4.1 - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- Destructive-operation protection no longer misses `TRUNCATE` statements that omit the `TABLE` keyword (`TRUNCATE db.name` is valid ClickHouse syntax), `TRUNCATE DATABASE`, `TRUNCATE ALL TABLES FROM`, `ALTER TABLE ... DROP PARTITION` / `DROP PART` / `DROP COLUMN`, or `DROP` of object types outside `TABLE`/`DATABASE`/`VIEW`/`DICTIONARY`. With `CLICKHOUSE_ALLOW_WRITE_ACCESS=true` and `CLICKHOUSE_ALLOW_DROP` unset, these statements previously ran and deleted data.
+- Destructive-operation protection no longer rejects safe statements that merely contain `drop` or `truncate` inside a string literal, a quoted identifier, or a SQL comment, such as `INSERT INTO logs VALUES ('drop the table')`. Comments can no longer hide a destructive statement from the check either.
+
 ### Changed
 - Connection failures now log actionable hints for common misconfigurations (native TCP port used instead of the HTTP interface, TLS/`CLICKHOUSE_SECURE` mismatches), and a warning is logged when `CLICKHOUSE_PORT` is set to a native protocol port (9000/9440). ([#102](https://github.com/ClickHouse/mcp-clickhouse/issues/102))
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ By default, this MCP enforces read-only queries so that accidental mutations can
 
 ### Destructive Operation Protection
 
-Even when write access is enabled (`CLICKHOUSE_ALLOW_WRITE_ACCESS=true`), destructive operations (DROP TABLE, DROP DATABASE, DROP VIEW, DROP DICTIONARY, TRUNCATE TABLE) require an additional opt-in flag for safety. This prevents accidental data deletion during AI exploration.
+Even when write access is enabled (`CLICKHOUSE_ALLOW_WRITE_ACCESS=true`), destructive operations require an additional opt-in flag for safety. This prevents accidental data deletion during AI exploration. The check covers any `DROP` statement (`DROP TABLE`, `DROP DATABASE`, `DROP VIEW`, `DROP DICTIONARY`, `DROP FUNCTION`, `DROP INDEX`, and so on), the `ALTER TABLE ... DROP PARTITION` / `DROP PART` / `DROP COLUMN` clauses, and every form of `TRUNCATE`. Keywords inside string literals, quoted identifiers, and SQL comments are ignored, so they neither trigger the check nor hide a statement from it.
 
 To enable destructive operations, set both flags:
 ```json
@@ -554,7 +554,7 @@ These variables configure the [clickhouse-connect](https://clickhouse.com/docs/e
   * Default: `"false"`
   * Set to `"true"` to allow DDL (CREATE, ALTER, DROP) and DML (INSERT, UPDATE, DELETE) operations
   * When disabled (default), queries run with `readonly=1` setting to prevent data modifications
-* `CLICKHOUSE_ALLOW_DROP`: Allow destructive operations (DROP TABLE, DROP DATABASE, DROP VIEW, DROP DICTIONARY, TRUNCATE TABLE)
+* `CLICKHOUSE_ALLOW_DROP`: Allow destructive operations (any `DROP` statement, `ALTER TABLE ... DROP PARTITION` / `DROP PART` / `DROP COLUMN`, and any `TRUNCATE` statement)
   * Default: `"false"`
   * Only takes effect when `CLICKHOUSE_ALLOW_WRITE_ACCESS=true` is also set
   * Set to `"true"` to explicitly allow destructive DROP and TRUNCATE operations

--- a/README.md
+++ b/README.md
@@ -263,11 +263,22 @@ You can also enable both ClickHouse and chDB simultaneously:
 
 ### Optional Write Access
 
-By default, this MCP enforces read-only queries so that accidental mutations cannot happen during exploration. To allow DDL or INSERT/UPDATE statements, set the `CLICKHOUSE_ALLOW_WRITE_ACCESS` environment variable to `true`. The server keeps enforcing read-only mode if the ClickHouse instance itself disallows writes.
+By default, this MCP enforces read-only queries so that accidental mutations cannot happen during exploration. To allow DDL or INSERT statements, set the `CLICKHOUSE_ALLOW_WRITE_ACCESS` environment variable to `true`. The server keeps enforcing read-only mode if the ClickHouse instance itself disallows writes.
 
 ### Destructive Operation Protection
 
-Even when write access is enabled (`CLICKHOUSE_ALLOW_WRITE_ACCESS=true`), destructive operations require an additional opt-in flag for safety. This prevents accidental data deletion during AI exploration. The check covers any `DROP` statement (`DROP TABLE`, `DROP DATABASE`, `DROP VIEW`, `DROP DICTIONARY`, `DROP FUNCTION`, `DROP INDEX`, and so on), the `ALTER TABLE ... DROP PARTITION` / `DROP PART` / `DROP COLUMN` clauses, and every form of `TRUNCATE`. Keywords inside string literals, quoted identifiers, and SQL comments are ignored, so they neither trigger the check nor hide a statement from it.
+Even when write access is enabled (`CLICKHOUSE_ALLOW_WRITE_ACCESS=true`), destructive operations require an additional opt-in flag for safety. The check covers any `DROP` statement (including the `ALTER TABLE ... DROP PARTITION` / `DROP PART` / `DROP COLUMN` clauses), any `TRUNCATE`, `DELETE` and `UPDATE` (both the lightweight statements and the `ALTER TABLE ... DELETE` / `ALTER TABLE ... UPDATE` mutations), `REPLACE TABLE`, `CREATE OR REPLACE`, `ALTER TABLE ... REPLACE PARTITION`, `ALTER TABLE ... CLEAR COLUMN` / `CLEAR INDEX` / `CLEAR PROJECTION`, and `DETACH ... PERMANENTLY`. Keywords inside string literals, quoted identifiers, and SQL comments are ignored, so they neither trigger the check nor hide a statement from it.
+
+This check runs in the MCP server and is a best-effort guard against accidents. It is not a security boundary. The security boundary is the ClickHouse user's grants. Read-only mode (the default) is enforced server-side via `readonly=1`. The destructive-operation gate is not server-enforced.
+
+For write mode, give the MCP server a dedicated ClickHouse user with only the privileges it needs:
+
+```sql
+CREATE USER mcp_agent IDENTIFIED BY '...';
+GRANT SELECT, INSERT, CREATE TABLE, ALTER ADD COLUMN ON mydb.* TO mcp_agent;
+```
+
+Every statement outside these grants then fails server-side with `ACCESS_DENIED`, regardless of MCP flags. The server settings `max_table_size_to_drop` and `max_partition_size_to_drop` can also cap blast radius if pinned with settings constraints.
 
 To enable destructive operations, set both flags:
 ```json
@@ -277,9 +288,9 @@ To enable destructive operations, set both flags:
 }
 ```
 
-This two-tier approach ensures that accidental drops are very difficult:
-- **Write operations** (INSERT, UPDATE, CREATE) require `CLICKHOUSE_ALLOW_WRITE_ACCESS=true`
-- **Destructive operations** (DROP, TRUNCATE) additionally require `CLICKHOUSE_ALLOW_DROP=true`
+This two-tier approach makes accidental deletion difficult:
+- **Write operations** (INSERT, CREATE, ALTER ADD COLUMN) require `CLICKHOUSE_ALLOW_WRITE_ACCESS=true`
+- **Destructive operations** (DROP, TRUNCATE, DELETE, UPDATE, and the rest of the list above) additionally require `CLICKHOUSE_ALLOW_DROP=true`
 
 ### Running Without uv (Using System Python)
 
@@ -552,13 +563,12 @@ These variables configure the [clickhouse-connect](https://clickhouse.com/docs/e
   * Set to `"false"` to disable ClickHouse tools when using chDB only
 * `CLICKHOUSE_ALLOW_WRITE_ACCESS`: Allow write operations (DDL and DML) against ClickHouse
   * Default: `"false"`
-  * Set to `"true"` to allow DDL (CREATE, ALTER, DROP) and DML (INSERT, UPDATE, DELETE) operations
+  * Set to `"true"` to allow non-destructive DDL and DML (CREATE, INSERT, ALTER ADD COLUMN). Destructive statements additionally need `CLICKHOUSE_ALLOW_DROP=true`
   * When disabled (default), queries run with `readonly=1` setting to prevent data modifications
-* `CLICKHOUSE_ALLOW_DROP`: Allow destructive operations (any `DROP` statement, `ALTER TABLE ... DROP PARTITION` / `DROP PART` / `DROP COLUMN`, and any `TRUNCATE` statement)
+* `CLICKHOUSE_ALLOW_DROP`: Allow destructive operations (any `DROP` or `TRUNCATE`, `DELETE` and `UPDATE` including the `ALTER TABLE` variants, `REPLACE TABLE` / `REPLACE PARTITION` / `CREATE OR REPLACE`, `CLEAR COLUMN` / `CLEAR INDEX` / `CLEAR PROJECTION`, and `DETACH ... PERMANENTLY`)
   * Default: `"false"`
   * Only takes effect when `CLICKHOUSE_ALLOW_WRITE_ACCESS=true` is also set
-  * Set to `"true"` to explicitly allow destructive DROP and TRUNCATE operations
-  * This is a safety feature to prevent accidental data deletion during AI exploration
+  * This gate is a best-effort accident guard in the MCP server, not a security boundary. Restrict the ClickHouse user's grants for real enforcement (see [Destructive Operation Protection](#destructive-operation-protection))
 
 #### MCP server and transport
 

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -470,17 +470,31 @@ _SQL_COMMENTS_AND_QUOTED_TEXT = re.compile(
     re.VERBOSE | re.DOTALL,
 )
 
-# DROP is matched as a bare keyword rather than against a list of object types.
-# The list form silently allowed ALTER TABLE ... DROP PARTITION, DROP COLUMN,
-# DROP FUNCTION, DROP INDEX, DROP NAMED COLLECTION, and every object type added
-# to ClickHouse after the list was written.
-_DROP_KEYWORD = re.compile(r"\bDROP\b", re.IGNORECASE)
+# Matched against the scrubbed statement. Bare DROP also covers the
+# ALTER ... DROP PARTITION/PART/COLUMN clauses. TRUNCATE followed by an open
+# parenthesis is the rounding function, as is replace() after OR. Bare DELETE
+# and UPDATE cover both the lightweight and ALTER mutation forms. REPLACE
+# TABLE/PARTITION and OR REPLACE overwrite existing data. Bare CLEAR is
+# reversible, so only CLEAR COLUMN/INDEX/PROJECTION is flagged.
+_DESTRUCTIVE_KEYWORDS = re.compile(
+    r"""
+      \bDROP\b
+    | \bTRUNCATE\b(?!\s*\()
+    | \bDELETE\b
+    | \bUPDATE\b
+    | \bREPLACE\s+(?:TABLE|PARTITION)\b
+    | \bOR\s+REPLACE\b(?!\s*\()
+    | \bCLEAR\s+(?:COLUMN|INDEX|PROJECTION)\b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
 
-# Covers TRUNCATE TABLE, TRUNCATE DATABASE, TRUNCATE ALL TABLES FROM, and the
-# form where the TABLE keyword is omitted (`TRUNCATE db.name` is valid SQL in
-# ClickHouse). `truncate(x)` is the rounding function, so a following open
-# parenthesis marks an expression rather than a statement.
-_TRUNCATE_KEYWORD = re.compile(r"\bTRUNCATE\b(?!\s*\()", re.IGNORECASE)
+# DETACH ... PERMANENTLY is matched as two independent searches. A single
+# `DETACH .* PERMANENTLY` branch backtracks quadratically on crafted input,
+# and the validator runs on an executor thread that cancel cannot stop.
+# Plain DETACH is reversible via ATTACH and stays allowed.
+_DETACH_KEYWORD = re.compile(r"\bDETACH\b", re.IGNORECASE)
+_PERMANENTLY_KEYWORD = re.compile(r"\bPERMANENTLY\b", re.IGNORECASE)
 
 
 def _strip_comments_and_quoted_text(query: str) -> str:
@@ -494,13 +508,13 @@ def _strip_comments_and_quoted_text(query: str) -> str:
 
 
 def _validate_query_for_destructive_ops(query: str) -> None:
-    """Validate that destructive operations (DROP, TRUNCATE) are allowed.
+    """Reject destructive statements unless CLICKHOUSE_ALLOW_DROP is set.
 
     Args:
         query: The SQL query to validate
 
     Raises:
-        ToolError: If the query contains destructive operations but CLICKHOUSE_ALLOW_DROP is not set
+        ToolError: If the query contains a destructive statement and CLICKHOUSE_ALLOW_DROP is not set
     """
     config = get_config()
 
@@ -513,11 +527,15 @@ def _validate_query_for_destructive_ops(query: str) -> None:
         return
 
     statement = _strip_comments_and_quoted_text(query)
-    if _DROP_KEYWORD.search(statement) or _TRUNCATE_KEYWORD.search(statement):
+    if _DESTRUCTIVE_KEYWORDS.search(statement) or (
+        _DETACH_KEYWORD.search(statement) and _PERMANENTLY_KEYWORD.search(statement)
+    ):
         raise ToolError(
-            "Destructive operations (DROP, TRUNCATE) are not allowed. "
-            "Set CLICKHOUSE_ALLOW_DROP=true to enable these operations. "
-            "This is a safety feature to prevent accidental data deletion."
+            "Destructive operations are not allowed (DROP, TRUNCATE, DELETE, UPDATE, "
+            "REPLACE TABLE/PARTITION, CREATE OR REPLACE, CLEAR COLUMN/INDEX/PROJECTION, "
+            "DETACH PERMANENTLY). Set CLICKHOUSE_ALLOW_DROP=true to enable them. "
+            "This gate is a best-effort accident guard, not a security boundary. "
+            "Restrict the ClickHouse user's grants for real enforcement."
         )
 
 
@@ -674,8 +692,56 @@ def _format_connection_failure(error: Exception, client_config: dict) -> str:
     return message
 
 
+# Privileges the drop gate pretends to block but cannot enforce server-side.
+# ALTER includes ALTER DELETE and ALTER DROP PARTITION in the privilege
+# hierarchy. ALTER ADD is exempt because the README recipe grants it.
+_GRANTS_ADVISORY_PRIVILEGES = re.compile(
+    r"\b(ALL|DROP|TRUNCATE|DELETE|UPDATE|ALTER\b(?!\s+ADD\b))\b", re.IGNORECASE
+)
+
+_grants_advisory_done = False
+
+
+def _warn_if_overprivileged(client) -> None:
+    """Warn once when the drop gate is active but the ClickHouse user holds
+    privileges it cannot enforce against. Fail-open, never raises.
+    """
+    global _grants_advisory_done
+    if _grants_advisory_done:
+        return
+    # Check-then-set race across executor threads is harmless, worst case is a
+    # duplicate warning.
+    _grants_advisory_done = True
+
+    try:
+        result = client.query("SHOW GRANTS")
+        matched: set[str] = set()
+        role_grants = []
+        for row in result.result_rows:
+            grant = str(row[0])
+            if grant.upper().startswith("GRANT") and not re.search(r"\bON\b", grant, re.IGNORECASE):
+                # `GRANT <role> TO ...`; role privileges are not expanded here.
+                role_grants.append(grant)
+                continue
+            matched.update(m.group(1).upper() for m in _GRANTS_ADVISORY_PRIVILEGES.finditer(grant))
+        if matched:
+            logger.warning(
+                "CLICKHOUSE_ALLOW_DROP=false, but the ClickHouse user holds %s privileges. "
+                "The destructive-operation gate runs in the MCP server and is not enforced "
+                "server-side. See the README least-privilege recipe to restrict grants.",
+                ", ".join(sorted(matched)),
+            )
+        for grant in role_grants:
+            logger.info(
+                "Grants advisory cannot inspect privileges granted via roles: %s", grant
+            )
+    except Exception as e:
+        logger.debug("Grants advisory skipped: %s", e)
+
+
 def create_clickhouse_client():
     client_config = get_config().get_client_config()
+    overrides_applied = False
 
     try:
         ctx = get_context()
@@ -689,6 +755,7 @@ def create_clickhouse_client():
                 f"Applying session-specific ClickHouse client config overrides: {list(session_config_overrides.keys())}"
             )
             client_config.update(session_config_overrides)
+            overrides_applied = True
     except RuntimeError:
         # If we're outside a request context, just proceed with the default config
         pass
@@ -721,11 +788,17 @@ def create_clickhouse_client():
         # Test the connection
         version = client.server_version
         logger.info(f"Successfully connected to ClickHouse server version {version}")
-        return client
     except Exception as e:
         message = _format_connection_failure(e, client_config)
         logger.error(message)
         raise
+
+    config = get_config()
+    # Session overrides may connect as a different user. Skip the advisory
+    # without consuming the one-shot so a later base-config client still runs it.
+    if not overrides_applied and config.allow_write_access and not config.allow_drop:
+        _warn_if_overprivileged(client)
+    return client
 
 
 def build_query_settings(client) -> dict[str, str]:
@@ -983,7 +1056,10 @@ if os.getenv("CLICKHOUSE_ENABLED", "true").lower() == "true":
             description=(
                 "Execute SQL queries in ClickHouse. Queries run in read-only mode by default. "
                 "Set CLICKHOUSE_ALLOW_WRITE_ACCESS=true to allow DDL and DML operations. "
-                "Set CLICKHOUSE_ALLOW_DROP=true to additionally allow destructive operations (DROP, TRUNCATE)."
+                "Set CLICKHOUSE_ALLOW_DROP=true to additionally allow destructive operations "
+                "(DROP, TRUNCATE, DELETE, UPDATE, REPLACE TABLE/PARTITION, CREATE OR REPLACE, "
+                "CLEAR COLUMN/INDEX/PROJECTION, DETACH PERMANENTLY). That gate is a best-effort "
+                "accident guard, not a security boundary."
             ),
         )
     )

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -454,6 +454,45 @@ def list_tables(
     })
 
 
+# SQL comments and quoted text, blanked out before destructive-keyword matching.
+# A keyword inside a string literal must not trigger the guard, and a keyword
+# placed after a comment marker must not slip past it.
+_SQL_COMMENTS_AND_QUOTED_TEXT = re.compile(
+    r"""
+      '(?:\\.|''|[^'\\])*'              # string literal
+    | "(?:\\.|""|[^"\\])*"              # double-quoted identifier
+    | `(?:\\.|``|[^`\\])*`              # backtick-quoted identifier
+    | \$(?P<tag>\w*)\$.*?\$(?P=tag)\$    # dollar-quoted string or heredoc
+    | --[^\n]*                         # line comment
+    | \#[^\n]*                         # line comment
+    | /\*.*?\*/                        # block comment
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+# DROP is matched as a bare keyword rather than against a list of object types.
+# The list form silently allowed ALTER TABLE ... DROP PARTITION, DROP COLUMN,
+# DROP FUNCTION, DROP INDEX, DROP NAMED COLLECTION, and every object type added
+# to ClickHouse after the list was written.
+_DROP_KEYWORD = re.compile(r"\bDROP\b", re.IGNORECASE)
+
+# Covers TRUNCATE TABLE, TRUNCATE DATABASE, TRUNCATE ALL TABLES FROM, and the
+# form where the TABLE keyword is omitted (`TRUNCATE db.name` is valid SQL in
+# ClickHouse). `truncate(x)` is the rounding function, so a following open
+# parenthesis marks an expression rather than a statement.
+_TRUNCATE_KEYWORD = re.compile(r"\bTRUNCATE\b(?!\s*\()", re.IGNORECASE)
+
+
+def _strip_comments_and_quoted_text(query: str) -> str:
+    """Blank out comments and quoted text so keyword matching sees only SQL syntax.
+
+    Each match is replaced by a single space to keep surrounding tokens separate.
+    Unterminated literals and comments do not match and are left in place, which
+    keeps the destructive-operation check on the conservative side.
+    """
+    return _SQL_COMMENTS_AND_QUOTED_TEXT.sub(" ", query)
+
+
 def _validate_query_for_destructive_ops(query: str) -> None:
     """Validate that destructive operations (DROP, TRUNCATE) are allowed.
 
@@ -473,9 +512,8 @@ def _validate_query_for_destructive_ops(query: str) -> None:
     if config.allow_drop:
         return
 
-    # Simple pattern matching for destructive operations
-    destructive_pattern = r"\b(DROP\s+(\S+\s+)*(TABLE|DATABASE|VIEW|DICTIONARY)|TRUNCATE\s+TABLE)\b"
-    if re.search(destructive_pattern, query, re.IGNORECASE):
+    statement = _strip_comments_and_quoted_text(query)
+    if _DROP_KEYWORD.search(statement) or _TRUNCATE_KEYWORD.search(statement):
         raise ToolError(
             "Destructive operations (DROP, TRUNCATE) are not allowed. "
             "Set CLICKHOUSE_ALLOW_DROP=true to enable these operations. "

--- a/tests/test_destructive_ops.py
+++ b/tests/test_destructive_ops.py
@@ -1,0 +1,153 @@
+"""Tests for DROP and TRUNCATE protection in the query validator.
+
+These are unit tests for `_validate_query_for_destructive_ops` and its helper.
+They do not need a running ClickHouse server. Integration coverage of the same
+flag lives in `tests/test_tool.py`.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from mcp_clickhouse.mcp_server import (
+    _strip_comments_and_quoted_text,
+    _validate_query_for_destructive_ops,
+)
+
+
+def _config(allow_write_access: bool = True, allow_drop: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(allow_write_access=allow_write_access, allow_drop=allow_drop)
+
+
+@pytest.fixture
+def write_mode_without_drop():
+    """Write access enabled, destructive operations not opted in."""
+    with patch("mcp_clickhouse.mcp_server.get_config", return_value=_config()):
+        yield
+
+
+# Every statement here deletes data or objects. All of them parse on ClickHouse.
+DESTRUCTIVE_QUERIES = [
+    "DROP TABLE d.t",
+    "DROP TEMPORARY TABLE t",
+    "DROP DATABASE d",
+    "DROP VIEW d.v",
+    "DROP DICTIONARY d.dict",
+    "DROP FUNCTION f",
+    "DROP NAMED COLLECTION nc",
+    "DROP INDEX idx ON d.t",
+    "DROP USER u",
+    "DROP ROLE r",
+    # The TABLE keyword is optional in ClickHouse's TRUNCATE grammar.
+    "TRUNCATE d.t",
+    "TRUNCATE TABLE d.t",
+    "TRUNCATE IF EXISTS d.t",
+    "TRUNCATE DATABASE d",
+    "TRUNCATE ALL TABLES FROM d",
+    # ALTER clauses that drop data or schema.
+    "ALTER TABLE d.t DROP PARTITION tuple()",
+    "ALTER TABLE d.t DROP PART 'all_1_1_0'",
+    "ALTER TABLE d.t DROP COLUMN c",
+    # Case and whitespace variations.
+    "drop table d.t",
+    "DROP\n  TABLE\n  d.t",
+    # Comments must not hide the statement.
+    "-- harmless comment\nDROP TABLE d.t",
+    "/* harmless comment */ DROP TABLE d.t",
+    "# harmless comment\nTRUNCATE d.t",
+    "DROP /* sneaky */ TABLE d.t",
+]
+
+# None of these delete anything, so write mode must still run them.
+ALLOWED_QUERIES = [
+    "SELECT 1",
+    "SELECT * FROM d.t WHERE a = 1",
+    "CREATE TABLE d.t (a UInt8) ENGINE = MergeTree ORDER BY a",
+    "ALTER TABLE d.t ADD COLUMN b UInt8",
+    "INSERT INTO d.t (a) VALUES (1)",
+    # `truncate` is also a rounding function.
+    "SELECT truncate(3.7)",
+    "SELECT truncate(1.234, 2)",
+    "INSERT INTO d.t SELECT truncate(a) FROM d.s",
+    # Keywords inside string literals and identifiers are data, not statements.
+    "INSERT INTO d.logs (msg) VALUES ('drop the table')",
+    "INSERT INTO d.logs (msg) VALUES ('truncate everything')",
+    "SELECT * FROM d.logs WHERE msg = 'drop old table'",
+    "SELECT * FROM d.logs WHERE msg = 'it''s a drop table day'",
+    "SELECT * FROM d.logs WHERE msg = 'it\\'s a drop table day'",
+    'SELECT "drop table" FROM d.t',
+    "SELECT `drop table` FROM d.t",
+    "SELECT $$drop table$$",
+    "SELECT $tag$drop table$tag$",
+    # Keywords inside comments are not statements either.
+    "SELECT 1 -- drop table d.t",
+    "SELECT 1 # drop table d.t",
+    "SELECT 1 /* drop table d.t */",
+    "INSERT INTO d.t SELECT 1 /* remember to\ndrop table d.old */",
+    # Word boundaries.
+    "SELECT dropped, undropped FROM d.t",
+    "SELECT truncated FROM d.t",
+]
+
+
+@pytest.mark.parametrize("query", DESTRUCTIVE_QUERIES)
+def test_destructive_queries_blocked(write_mode_without_drop, query):
+    with pytest.raises(ToolError) as exc_info:
+        _validate_query_for_destructive_ops(query)
+
+    message = str(exc_info.value)
+    assert "Destructive operations (DROP, TRUNCATE) are not allowed" in message
+    assert "CLICKHOUSE_ALLOW_DROP=true" in message
+
+
+@pytest.mark.parametrize("query", ALLOWED_QUERIES)
+def test_non_destructive_queries_allowed(write_mode_without_drop, query):
+    _validate_query_for_destructive_ops(query)
+
+
+@pytest.mark.parametrize("query", DESTRUCTIVE_QUERIES)
+def test_destructive_queries_allowed_with_opt_in(query):
+    config = _config(allow_write_access=True, allow_drop=True)
+    with patch("mcp_clickhouse.mcp_server.get_config", return_value=config):
+        _validate_query_for_destructive_ops(query)
+
+
+@pytest.mark.parametrize("query", DESTRUCTIVE_QUERIES)
+def test_validation_skipped_in_read_only_mode(query):
+    """Read-only mode is enforced by the server-side readonly setting, not here."""
+    config = _config(allow_write_access=False, allow_drop=False)
+    with patch("mcp_clickhouse.mcp_server.get_config", return_value=config):
+        _validate_query_for_destructive_ops(query)
+
+
+@pytest.mark.parametrize(
+    "query,expected_removed",
+    [
+        ("SELECT 'drop table'", "drop table"),
+        ('SELECT "drop table"', "drop table"),
+        ("SELECT `drop table`", "drop table"),
+        ("SELECT $$drop table$$", "drop table"),
+        ("SELECT $tag$drop table$tag$", "drop table"),
+        ("SELECT 1 -- drop table", "drop table"),
+        ("SELECT 1 # drop table", "drop table"),
+        ("SELECT 1 /* drop table */", "drop table"),
+    ],
+)
+def test_strip_comments_and_quoted_text(query, expected_removed):
+    stripped = _strip_comments_and_quoted_text(query)
+
+    assert expected_removed not in stripped
+    assert stripped.startswith("SELECT")
+
+
+def test_strip_keeps_tokens_separated():
+    assert _strip_comments_and_quoted_text("DROP/* c */TABLE t") == "DROP TABLE t"
+
+
+def test_strip_leaves_unterminated_literal_in_place():
+    """An unterminated literal is a syntax error; keep the guard conservative."""
+    query = "INSERT INTO t VALUES ('drop table"
+
+    assert "drop table" in _strip_comments_and_quoted_text(query)

--- a/tests/test_destructive_ops.py
+++ b/tests/test_destructive_ops.py
@@ -1,10 +1,11 @@
-"""Tests for DROP and TRUNCATE protection in the query validator.
+"""Tests for destructive-statement protection in the query validator.
 
 These are unit tests for `_validate_query_for_destructive_ops` and its helper.
 They do not need a running ClickHouse server. Integration coverage of the same
 flag lives in `tests/test_tool.py`.
 """
 
+import time
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -50,9 +51,29 @@ DESTRUCTIVE_QUERIES = [
     "ALTER TABLE d.t DROP PARTITION tuple()",
     "ALTER TABLE d.t DROP PART 'all_1_1_0'",
     "ALTER TABLE d.t DROP COLUMN c",
+    # DELETE and UPDATE, both the lightweight statements and the ALTER mutations.
+    "DELETE FROM d.t WHERE 1",
+    "ALTER TABLE d.t DELETE WHERE 1",
+    "ALTER TABLE d.t UPDATE c = 0 WHERE 1",
+    "UPDATE d.t SET c = 0 WHERE 1",
+    # CLEAR COLUMN/INDEX/PROJECTION erase data even after the scrubber blanks
+    # the partition literal.
+    "ALTER TABLE d.t CLEAR COLUMN c IN PARTITION 'p'",
+    "ALTER TABLE d.t CLEAR INDEX i IN PARTITION 'p'",
+    "ALTER TABLE d.t CLEAR PROJECTION p IN PARTITION 'p'",
+    # REPLACE forms overwrite existing data.
+    "CREATE OR REPLACE TABLE d.t (a UInt8) ENGINE = MergeTree ORDER BY a",
+    "REPLACE TABLE d.t (a UInt8) ENGINE = MergeTree ORDER BY a",
+    "ALTER TABLE d.t REPLACE PARTITION 'p' FROM d.s",
+    "CREATE OR REPLACE VIEW d.v AS SELECT 1",
+    # DETACH is only destructive with PERMANENTLY.
+    "DETACH TABLE d.t PERMANENTLY",
+    "DETACH TABLE d.t SYNC PERMANENTLY",
     # Case and whitespace variations.
     "drop table d.t",
     "DROP\n  TABLE\n  d.t",
+    "delete from d.t where 1",
+    "Detach Table d.t Permanently",
     # Comments must not hide the statement.
     "-- harmless comment\nDROP TABLE d.t",
     "/* harmless comment */ DROP TABLE d.t",
@@ -67,10 +88,12 @@ ALLOWED_QUERIES = [
     "CREATE TABLE d.t (a UInt8) ENGINE = MergeTree ORDER BY a",
     "ALTER TABLE d.t ADD COLUMN b UInt8",
     "INSERT INTO d.t (a) VALUES (1)",
-    # `truncate` is also a rounding function.
+    # `truncate` is also a rounding function, `replace` a string function.
     "SELECT truncate(3.7)",
     "SELECT truncate(1.234, 2)",
     "INSERT INTO d.t SELECT truncate(a) FROM d.s",
+    "SELECT replace(x, 'a', 'b') FROM d.t",
+    "SELECT a OR replace(b, 'c', 'd') FROM d.t",
     # Keywords inside string literals and identifiers are data, not statements.
     "INSERT INTO d.logs (msg) VALUES ('drop the table')",
     "INSERT INTO d.logs (msg) VALUES ('truncate everything')",
@@ -89,6 +112,13 @@ ALLOWED_QUERIES = [
     # Word boundaries.
     "SELECT dropped, undropped FROM d.t",
     "SELECT truncated FROM d.t",
+    "SELECT updated_at, deleted_at FROM d.t",
+    # Plain DETACH is reversible with ATTACH.
+    "DETACH TABLE d.t",
+    "ATTACH TABLE d.t",
+    # New keywords inside literals and comments stay data.
+    "SELECT * FROM d.t WHERE note = 'please delete this'",
+    "SELECT 1 -- update d.t later",
 ]
 
 
@@ -98,8 +128,9 @@ def test_destructive_queries_blocked(write_mode_without_drop, query):
         _validate_query_for_destructive_ops(query)
 
     message = str(exc_info.value)
-    assert "Destructive operations (DROP, TRUNCATE) are not allowed" in message
+    assert "Destructive operations are not allowed" in message
     assert "CLICKHOUSE_ALLOW_DROP=true" in message
+    assert "not a security boundary" in message
 
 
 @pytest.mark.parametrize("query", ALLOWED_QUERIES)
@@ -151,3 +182,15 @@ def test_strip_leaves_unterminated_literal_in_place():
     query = "INSERT INTO t VALUES ('drop table"
 
     assert "drop table" in _strip_comments_and_quoted_text(query)
+
+
+def test_pathological_detach_input_is_fast(write_mode_without_drop):
+    """A single `DETACH .* PERMANENTLY` branch backtracked quadratically on
+    repeated DETACH without PERMANENTLY, wedging executor threads."""
+    pathological = "DETACH " * 20000
+
+    start = time.monotonic()
+    _validate_query_for_destructive_ops(pathological)
+    with pytest.raises(ToolError):
+        _validate_query_for_destructive_ops(pathological + "PERMANENTLY")
+    assert time.monotonic() - start < 3.0

--- a/tests/test_grants_advisory.py
+++ b/tests/test_grants_advisory.py
@@ -1,0 +1,165 @@
+"""Tests for the startup grants advisory.
+
+Unit tests with a mocked client, no ClickHouse server. The advisory warns when
+the drop gate is active but the connected user holds privileges the gate cannot
+enforce against.
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mcp_clickhouse.mcp_server as mcp_server
+from mcp_clickhouse.mcp_server import _warn_if_overprivileged, create_clickhouse_client
+
+LOGGER_NAME = "mcp-clickhouse"
+
+_CLIENT_CONFIG = {
+    "host": "localhost",
+    "port": 8123,
+    "username": "default",
+    "secure": False,
+    "verify": False,
+    "connect_timeout": 1,
+    "send_receive_timeout": 1,
+}
+
+
+@pytest.fixture(autouse=True)
+def reset_advisory_flag():
+    mcp_server._grants_advisory_done = False
+    yield
+    mcp_server._grants_advisory_done = False
+
+
+def _client_with_grants(rows):
+    client = MagicMock()
+    client.query.return_value = SimpleNamespace(result_rows=rows)
+    return client
+
+
+def _config(allow_write_access: bool, allow_drop: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        allow_write_access=allow_write_access,
+        allow_drop=allow_drop,
+        get_client_config=lambda: dict(_CLIENT_CONFIG),
+    )
+
+
+def _warnings(caplog):
+    return [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+@pytest.mark.parametrize(
+    "grant,privilege",
+    [
+        ("GRANT DROP ON *.* TO u", "DROP"),
+        ("GRANT ALL ON *.* TO u WITH GRANT OPTION", "ALL"),
+        ("GRANT TRUNCATE, DELETE ON d.* TO u", "TRUNCATE"),
+        ("GRANT ALTER ON *.* TO u", "ALTER"),
+        ("GRANT ALTER TABLE ON d.* TO u", "ALTER"),
+    ],
+)
+def test_warns_on_dangerous_privilege(caplog, grant, privilege):
+    client = _client_with_grants([(grant,)])
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        _warn_if_overprivileged(client)
+
+    warnings = _warnings(caplog)
+    assert len(warnings) == 1
+    assert privilege in warnings[0].getMessage()
+    assert "README" in warnings[0].getMessage()
+
+
+@pytest.mark.parametrize(
+    "grant",
+    [
+        "GRANT SELECT, INSERT ON d.* TO u",
+        # The README least-privilege recipe must not trigger the advisory.
+        "GRANT SELECT, INSERT, CREATE TABLE, ALTER ADD COLUMN ON d.* TO u",
+    ],
+)
+def test_no_warning_for_scoped_grants(caplog, grant):
+    client = _client_with_grants([(grant,)])
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        _warn_if_overprivileged(client)
+
+    assert not _warnings(caplog)
+
+
+def test_role_grant_logged_at_info(caplog):
+    client = _client_with_grants([("GRANT admin_role TO u",)])
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        _warn_if_overprivileged(client)
+
+    assert not _warnings(caplog)
+    infos = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert any("roles" in r.getMessage() and "admin_role" in r.getMessage() for r in infos)
+
+
+def test_show_grants_failure_is_silent(caplog):
+    client = MagicMock()
+    client.query.side_effect = RuntimeError("boom")
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        _warn_if_overprivileged(client)
+
+    assert not _warnings(caplog)
+
+
+def test_advisory_runs_once():
+    client = _client_with_grants([("GRANT DROP ON *.* TO u",)])
+    _warn_if_overprivileged(client)
+    _warn_if_overprivileged(client)
+
+    assert client.query.call_count == 1
+
+
+def test_advisory_runs_in_write_mode_without_drop(caplog):
+    client = _client_with_grants([("GRANT DROP ON *.* TO u",)])
+    config = _config(allow_write_access=True, allow_drop=False)
+    with patch("mcp_clickhouse.mcp_server.get_config", return_value=config):
+        with patch("mcp_clickhouse.mcp_server.clickhouse_connect.get_client", return_value=client):
+            with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+                assert create_clickhouse_client() is client
+
+    client.query.assert_called_once_with("SHOW GRANTS")
+    assert any("DROP" in r.getMessage() for r in _warnings(caplog))
+
+
+def test_advisory_skipped_for_session_override_client(caplog):
+    """An override client may connect as a different user. The advisory must
+    neither inspect it nor consume the one-shot for the base user."""
+    client = _client_with_grants([("GRANT DROP ON *.* TO u",)])
+    config = _config(allow_write_access=True, allow_drop=False)
+    ctx = MagicMock()
+    ctx.get_state.return_value = {"username": "other"}
+    with patch("mcp_clickhouse.mcp_server.get_config", return_value=config):
+        with patch("mcp_clickhouse.mcp_server.clickhouse_connect.get_client", return_value=client):
+            with patch("mcp_clickhouse.mcp_server.get_context", return_value=ctx):
+                assert create_clickhouse_client() is client
+            client.query.assert_not_called()
+            assert mcp_server._grants_advisory_done is False
+
+            # A later base-config client still runs the advisory.
+            with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+                create_clickhouse_client()
+
+    client.query.assert_called_once_with("SHOW GRANTS")
+    assert any("DROP" in r.getMessage() for r in _warnings(caplog))
+
+
+@pytest.mark.parametrize(
+    "allow_write_access,allow_drop",
+    [(False, False), (False, True), (True, True)],
+)
+def test_advisory_skipped_by_config(allow_write_access, allow_drop):
+    client = _client_with_grants([("GRANT DROP ON *.* TO u",)])
+    config = _config(allow_write_access, allow_drop)
+    with patch("mcp_clickhouse.mcp_server.get_config", return_value=config):
+        with patch("mcp_clickhouse.mcp_server.clickhouse_connect.get_client", return_value=client):
+            assert create_clickhouse_client() is client
+
+    client.query.assert_not_called()
+    assert mcp_server._grants_advisory_done is False

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -266,7 +266,7 @@ class TestClickhouseDropProtection(unittest.TestCase):
             run_query(drop_query)
 
         error_msg = str(context.exception)
-        self.assertIn("Destructive operations (DROP, TRUNCATE) are not allowed", error_msg)
+        self.assertIn("Destructive operations are not allowed", error_msg)
         self.assertIn("CLICKHOUSE_ALLOW_DROP=true", error_msg)
 
     @patch.dict(os.environ, {"CLICKHOUSE_ALLOW_WRITE_ACCESS": "true", "CLICKHOUSE_ALLOW_DROP": "false"})
@@ -282,7 +282,7 @@ class TestClickhouseDropProtection(unittest.TestCase):
             run_query(drop_query)
 
         error_msg = str(context.exception)
-        self.assertIn("Destructive operations (DROP, TRUNCATE) are not allowed", error_msg)
+        self.assertIn("Destructive operations are not allowed", error_msg)
         self.assertIn("CLICKHOUSE_ALLOW_DROP=true", error_msg)
 
         self.client.command(f"DROP DATABASE IF EXISTS {temp_db}")
@@ -344,7 +344,7 @@ class TestClickhouseDropProtection(unittest.TestCase):
             run_query(truncate_query)
 
         error_msg = str(context.exception)
-        self.assertIn("Destructive operations (DROP, TRUNCATE) are not allowed", error_msg)
+        self.assertIn("Destructive operations are not allowed", error_msg)
         self.assertIn("CLICKHOUSE_ALLOW_DROP=true", error_msg)
 
     def test_truncate_allowed_when_drop_flag_set(self):


### PR DESCRIPTION
## Summary

`_validate_query_for_destructive_ops` is the guard added in #93 to close #131, where an agent with MCP access dropped a production table. With `CLICKHOUSE_ALLOW_WRITE_ACCESS=true` and `CLICKHOUSE_ALLOW_DROP` unset, it is supposed to block destructive statements.

The guard is a single regex:

```
\b(DROP\s+(\S+\s+)*(TABLE|DATABASE|VIEW|DICTIONARY)|TRUNCATE\s+TABLE)\b
```

It is wrong in both directions: destructive statements get through, and safe statements get rejected.

## Destructive statements that are not blocked

The most important one is `TRUNCATE`. ClickHouse's grammar makes the `TABLE` keyword optional, so `TRUNCATE db.name` is valid and never matches `TRUNCATE\s+TABLE`. `TRUNCATE DATABASE` and `TRUNCATE ALL TABLES FROM` are missed for the same reason.

The `DROP` branch only recognizes four object types, and only when the object type keyword follows `DROP` on the same statement, so `ALTER TABLE ... DROP PARTITION`, `DROP PART`, and `DROP COLUMN` are missed too.

End to end against ClickHouse 26.8, write access on, `CLICKHOUSE_ALLOW_DROP` unset:

```
'TRUNCATE repro_db.events'                              rows 1000 -> 0     | EXECUTED (guard bypassed)
'ALTER TABLE repro_db.events DROP PARTITION tuple()'    rows 1000 -> 0     | EXECUTED (guard bypassed)
```

13 of the 24 destructive statements in the new test file get through the current regex:

```
DROP FUNCTION f
DROP NAMED COLLECTION nc
DROP INDEX idx ON d.t
DROP USER u
DROP ROLE r
TRUNCATE d.t
TRUNCATE IF EXISTS d.t
TRUNCATE DATABASE d
TRUNCATE ALL TABLES FROM d
ALTER TABLE d.t DROP PARTITION tuple()
ALTER TABLE d.t DROP PART 'all_1_1_0'
ALTER TABLE d.t DROP COLUMN c
# harmless comment\nTRUNCATE d.t
```

## Safe statements that are wrongly blocked

`(\S+\s+)*` skips over arbitrary tokens, including the contents of string literals, so writing the word `drop` into a table is treated as a DROP statement:

```
INSERT INTO d.logs (msg) VALUES ('drop the table')     -> blocked
SELECT * FROM d.logs WHERE msg = 'drop old table'      -> blocked
```

12 of the 23 safe statements in the new test file are rejected by the current regex.

## Fix

Blank out string literals, quoted identifiers, and comments first, then match the keyword against what is left.

- Literals and identifiers: `'...'`, `"..."`, `` `...` ``, `$$...$$` and `$tag$...$tag$`, with both backslash and doubled-quote escapes. Comments: `--`, `#`, and `/* */`. Each match is replaced with a single space so surrounding tokens stay separate. This removes the false positives, and it also means a comment can no longer hide a statement from the check.
- `DROP` is matched as a bare keyword rather than against a list of object types. The list form is what silently allowed `DROP FUNCTION`, `DROP INDEX`, the `ALTER` clauses, and every object type added to ClickHouse after the list was written. Word boundaries keep `dropped` and similar identifiers out.
- `TRUNCATE` is matched as a bare keyword unless followed by an open parenthesis, since `truncate(x)` is the rounding function rather than a statement.

An unterminated literal does not match the scrubber and is left in place, which keeps the check on the conservative side. Such a query is a syntax error anyway.

The tool contract does not change: same flags, same error message, same behavior when `CLICKHOUSE_ALLOW_DROP=true` and in read-only mode.

### Trade-off

Matching `DROP` as a bare keyword rejects an unquoted `drop` used as an identifier, for example `SELECT 1 AS drop`. This only affects write mode, backticking the identifier avoids it, and failing closed here seems clearly better than the current behavior of failing open on `TRUNCATE db.t`. Flagging it since it is a behavior change rather than a pure bug fix.

`DELETE FROM` and `ALTER TABLE ... DELETE` also destroy data but are outside the documented DROP/TRUNCATE contract, so this PR leaves them alone.

## Tests

New `tests/test_destructive_ops.py`, 105 unit tests, no ClickHouse server needed. It covers the destructive corpus above, the safe corpus, both flag combinations, read-only mode, and the scrubber itself. Every destructive statement in it was verified to parse and run on a real ClickHouse server rather than assumed from the client side.

Existing integration coverage in `tests/test_tool.py` is unchanged and still passes.

Full suite locally: 204 passed. The one failure, `test_system_database_access`, is pre-existing and unrelated. It fails on an unmodified checkout too. It asserts that `system.tables` appears in the first 100 tables of `system`, which stopped holding on ClickHouse versions newer than the 24.10 used in CI.

README and CHANGELOG updated in the same change, since the README enumerated the same too-narrow list of covered operations.
