### PR TITLE
fix request-scoped client overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- Per-request ClickHouse client configuration overrides now reach `run_query` worker threads. Invalid override state and role aliases fail closed, nested settings preserve the configured role, and opaque client objects remain supported. ([#191](https://github.com/ClickHouse/mcp-clickhouse/pull/191))
+
 ### Changed
 - Connection failures now log actionable hints for common misconfigurations (native TCP port used instead of the HTTP interface, TLS/`CLICKHOUSE_SECURE` mismatches), and a warning is logged when `CLICKHOUSE_PORT` is set to a native protocol port (9000/9440). ([#102](https://github.com/ClickHouse/mcp-clickhouse/issues/102))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Fixed
-- Per-request ClickHouse client configuration overrides now reach `run_query` worker threads. Invalid override state and role aliases fail closed, nested settings preserve the configured role, and opaque client objects remain supported. ([#191](https://github.com/ClickHouse/mcp-clickhouse/pull/191))
+- Per-request ClickHouse client configuration overrides now reach `run_query` worker threads. Invalid override state and role aliases fail closed, nested settings preserve the configured role, and opaque client objects remain supported.
 
 ### Changed
 - Connection failures now log actionable hints for common misconfigurations (native TCP port used instead of the HTTP interface, TLS/`CLICKHOUSE_SECURE` mismatches), and a warning is logged when `CLICKHOUSE_PORT` is set to a native protocol port (9000/9440). ([#102](https://github.com/ClickHouse/mcp-clickhouse/issues/102))

--- a/README.md
+++ b/README.md
@@ -451,6 +451,17 @@ ctx.set_state(CLIENT_CONFIG_OVERRIDES_KEY, {
 
 This enables advanced use cases like dynamic timeout adjustments, tenant-specific routing, or per-user connection settings.
 
+The state value must be a dictionary. Nested `settings` and `generic_args` values must be
+mappings and are merged with the base configuration. Invalid values fail the tool call before
+a ClickHouse client is created. `CLICKHOUSE_ROLE` remains active unless the override explicitly
+supplies `settings.role`. Top-level `role` and `ch_role` keys, plus the same keys under
+`generic_args`, are rejected.
+
+Treat these overrides as trusted middleware input. Middleware must authenticate and authorize
+request-derived values before setting them. A per-request ClickHouse role is connection
+configuration, not a tenant authorization boundary. Enforce tenant isolation with ClickHouse
+users, roles, and grants.
+
 ## Development
 
 1. In `test-services` directory run `docker compose up -d` to start the ClickHouse cluster.

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import uuid
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -61,6 +62,9 @@ class Table:
 
 MCP_SERVER_NAME = "mcp-clickhouse"
 CLIENT_CONFIG_OVERRIDES_KEY = "clickhouse_client_config_overrides"
+_CLIENT_CONFIG_OVERRIDES_UNSET = object()
+_NESTED_CLIENT_CONFIG_KEYS = ("settings", "generic_args")
+_REJECTED_ROLE_OVERRIDE_KEYS = ("role", "ch_role")
 
 # Configure logging
 logging.basicConfig(
@@ -483,8 +487,10 @@ def _validate_query_for_destructive_ops(query: str) -> None:
         )
 
 
-def execute_query(query: str) -> str:
-    client = create_clickhouse_client()
+def execute_query(
+    query: str, client_config_overrides: Optional[dict[str, Any]] = None
+) -> str:
+    client = create_clickhouse_client(client_config_overrides)
     try:
         _validate_query_for_destructive_ops(query)
 
@@ -507,7 +513,8 @@ def run_query(query: str) -> str:
     """
     logger.info(f"Executing query: {query}")
     try:
-        future = QUERY_EXECUTOR.submit(execute_query, query)
+        client_config_overrides = _get_client_config_overrides()
+        future = QUERY_EXECUTOR.submit(execute_query, query, client_config_overrides)
         timeout_secs = get_mcp_config().query_timeout
         try:
             return future.result(timeout=timeout_secs)
@@ -526,7 +533,8 @@ async def run_query_async(query: str) -> str:
     """Async MCP-facing wrapper for ClickHouse queries."""
     logger.info(f"Executing query: {query}")
     try:
-        future = QUERY_EXECUTOR.submit(execute_query, query)
+        client_config_overrides = _get_client_config_overrides()
+        future = QUERY_EXECUTOR.submit(execute_query, query, client_config_overrides)
         timeout_secs = get_mcp_config().query_timeout
         try:
             return await asyncio.wait_for(
@@ -636,24 +644,79 @@ def _format_connection_failure(error: Exception, client_config: dict) -> str:
     return message
 
 
-def create_clickhouse_client():
-    client_config = get_config().get_client_config()
+def _snapshot_client_config_overrides(overrides: Any) -> Optional[dict[str, Any]]:
+    """Validate and copy request-scoped ClickHouse client overrides."""
+    if overrides is None:
+        return None
+    if not isinstance(overrides, dict):
+        raise ToolError(f"{CLIENT_CONFIG_OVERRIDES_KEY} must be a dict")
 
+    snapshot = dict(overrides)
+    for key in _REJECTED_ROLE_OVERRIDE_KEYS:
+        if key in snapshot:
+            raise ToolError(
+                f"{CLIENT_CONFIG_OVERRIDES_KEY}.{key} is not supported; "
+                f"use {CLIENT_CONFIG_OVERRIDES_KEY}.settings.role"
+            )
+    for key in _NESTED_CLIENT_CONFIG_KEYS:
+        if key not in snapshot:
+            continue
+        value = snapshot[key]
+        if not isinstance(value, Mapping):
+            raise ToolError(f"{CLIENT_CONFIG_OVERRIDES_KEY}.{key} must be a mapping")
+        if key == "generic_args":
+            for role_key in _REJECTED_ROLE_OVERRIDE_KEYS:
+                if role_key in value:
+                    raise ToolError(
+                        f"{CLIENT_CONFIG_OVERRIDES_KEY}.generic_args.{role_key} "
+                        "is not supported; "
+                        f"use {CLIENT_CONFIG_OVERRIDES_KEY}.settings.role"
+                    )
+        snapshot[key] = dict(value)
+    return snapshot
+
+
+def _get_client_config_overrides() -> Optional[dict[str, Any]]:
+    """Capture ClickHouse client overrides from the active FastMCP request."""
     try:
         ctx = get_context()
-        session_config_overrides = ctx.get_state(CLIENT_CONFIG_OVERRIDES_KEY)
-        if session_config_overrides and not isinstance(session_config_overrides, dict):
-            logger.warning(
-                f"{CLIENT_CONFIG_OVERRIDES_KEY} must be a dict, got {type(session_config_overrides).__name__}. Ignoring."
-            )
-        elif session_config_overrides:
-            logger.debug(
-                f"Applying session-specific ClickHouse client config overrides: {list(session_config_overrides.keys())}"
-            )
-            client_config.update(session_config_overrides)
     except RuntimeError:
-        # If we're outside a request context, just proceed with the default config
-        pass
+        return None
+    return _snapshot_client_config_overrides(ctx.get_state(CLIENT_CONFIG_OVERRIDES_KEY))
+
+
+def _apply_client_config_overrides(
+    client_config: dict[str, Any], overrides: Optional[dict[str, Any]]
+) -> None:
+    """Merge request-scoped overrides into the base client configuration."""
+    if overrides is None:
+        return
+
+    logger.debug(
+        "Applying request-specific ClickHouse client config override keys: %s",
+        list(overrides.keys()),
+    )
+    remaining_overrides = dict(overrides)
+    for key in _NESTED_CLIENT_CONFIG_KEYS:
+        if key not in remaining_overrides:
+            continue
+        base_value = client_config.get(key, {})
+        if base_value is None:
+            base_value = {}
+        if not isinstance(base_value, Mapping):
+            raise ToolError(f"Base ClickHouse client config {key} must be a mapping")
+        client_config[key] = {**base_value, **remaining_overrides.pop(key)}
+    client_config.update(remaining_overrides)
+
+
+def create_clickhouse_client(client_config_overrides=_CLIENT_CONFIG_OVERRIDES_UNSET):
+    if client_config_overrides is _CLIENT_CONFIG_OVERRIDES_UNSET:
+        overrides = _get_client_config_overrides()
+    else:
+        overrides = _snapshot_client_config_overrides(client_config_overrides)
+
+    client_config = get_config().get_client_config()
+    _apply_client_config_overrides(client_config, overrides)
 
     port = client_config.get("port")
     if port in _NATIVE_PROTOCOL_PORTS:

--- a/tests/test_context_config_override.py
+++ b/tests/test_context_config_override.py
@@ -1,23 +1,54 @@
-"""Tests for context state-based ClickHouse client configuration overrides."""
+"""Tests for request-scoped ClickHouse client configuration overrides."""
+
+import asyncio
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import patch, MagicMock
-
 from fastmcp import Client
-from fastmcp.server.middleware import Middleware, MiddlewareContext, CallNext
+from fastmcp.exceptions import ToolError
 from fastmcp.server.dependencies import get_context
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 
 from mcp_clickhouse.mcp_server import (
-    mcp,
-    create_clickhouse_client,
     CLIENT_CONFIG_OVERRIDES_KEY,
+    _get_client_config_overrides,
+    create_clickhouse_client,
+    mcp,
+    run_query,
+    run_query_async,
 )
 
 
-class ConfigOverrideMiddleware(Middleware):
-    """Test middleware that sets ClickHouse client config overrides."""
+def _base_client_config(**overrides):
+    config = {
+        "host": "localhost",
+        "port": 8123,
+        "username": "default",
+        "password": "secret",
+        "interface": "http",
+        "secure": False,
+        "verify": False,
+        "connect_timeout": 30,
+        "send_receive_timeout": 300,
+        "client_name": "mcp_clickhouse",
+    }
+    config.update(overrides)
+    return config
 
-    def __init__(self, overrides: dict):
+
+def _mock_config(client_config):
+    config = MagicMock()
+    config.get_client_config.return_value = client_config
+    return config
+
+
+class ConfigOverrideMiddleware(Middleware):
+    """Set a fixed ClickHouse client override value for each tool call."""
+
+    def __init__(self, overrides):
         self.overrides = overrides
 
     async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
@@ -26,13 +57,37 @@ class ConfigOverrideMiddleware(Middleware):
         return await call_next(context)
 
 
-class TestConfigOverrideUnit:
-    """Unit tests for the config override merge logic in create_clickhouse_client."""
+class QueryOverrideMiddleware(Middleware):
+    """Set a distinct timeout based on each test query."""
 
+    async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
+        query = context.message.arguments["query"]
+        ctx = get_context()
+        ctx.set_state(CLIENT_CONFIG_OVERRIDES_KEY, {"connect_timeout": int(query.split()[-1])})
+        return await call_next(context)
+
+
+class FakeQueryClient:
+    def __init__(self, connect_timeout, barrier=None):
+        self.connect_timeout = connect_timeout
+        self.barrier = barrier
+        self.server_settings = {}
+        self.server_version = "24.10"
+
+    def query(self, _query, settings):
+        assert settings == {"readonly": "1"}
+        if self.barrier is not None:
+            self.barrier.wait(timeout=2)
+        return SimpleNamespace(
+            column_names=["connect_timeout"],
+            result_rows=[(self.connect_timeout,)],
+        )
+
+
+class TestConfigOverrideUnit:
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
     @patch("mcp_clickhouse.mcp_server.get_context")
     def test_overrides_merged_into_client_config(self, mock_get_context, mock_cc):
-        """Verify overrides from context state are merged into the client config."""
         mock_ctx = MagicMock()
         mock_ctx.get_state.return_value = {"connect_timeout": 99, "send_receive_timeout": 199}
         mock_get_context.return_value = mock_ctx
@@ -40,14 +95,13 @@ class TestConfigOverrideUnit:
 
         create_clickhouse_client()
 
-        call_kwargs = mock_cc.get_client.call_args[1]
+        call_kwargs = mock_cc.get_client.call_args.kwargs
         assert call_kwargs["connect_timeout"] == 99
         assert call_kwargs["send_receive_timeout"] == 199
 
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
     @patch("mcp_clickhouse.mcp_server.get_context")
     def test_empty_overrides_no_change(self, mock_get_context, mock_cc):
-        """Empty overrides dict should not alter the base config."""
         mock_ctx = MagicMock()
         mock_ctx.get_state.return_value = {}
         mock_get_context.return_value = mock_ctx
@@ -55,15 +109,13 @@ class TestConfigOverrideUnit:
 
         create_clickhouse_client()
 
-        call_kwargs = mock_cc.get_client.call_args[1]
-        # Base config values from env should pass through unchanged
+        call_kwargs = mock_cc.get_client.call_args.kwargs
         assert "host" in call_kwargs
         assert "username" in call_kwargs
 
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
     @patch("mcp_clickhouse.mcp_server.get_context")
-    def test_no_overrides_in_context(self, mock_get_context, mock_cc):
-        """When context state has no overrides, base config is used as-is."""
+    def test_none_overrides_no_change(self, mock_get_context, mock_cc):
         mock_ctx = MagicMock()
         mock_ctx.get_state.return_value = None
         mock_get_context.return_value = mock_ctx
@@ -71,26 +123,232 @@ class TestConfigOverrideUnit:
 
         create_clickhouse_client()
 
-        call_kwargs = mock_cc.get_client.call_args[1]
-        assert "host" in call_kwargs
+        assert "host" in mock_cc.get_client.call_args.kwargs
 
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
     def test_no_request_context_falls_back_to_defaults(self, mock_cc):
-        """Outside a request context (RuntimeError), base config is used."""
         mock_cc.get_client.return_value = MagicMock(server_version="24.1")
 
-        # get_context is NOT mocked, so it will raise RuntimeError
-        # since there's no active FastMCP request context
         create_clickhouse_client()
 
-        call_kwargs = mock_cc.get_client.call_args[1]
-        assert "host" in call_kwargs
+        assert "host" in mock_cc.get_client.call_args.kwargs
+
+    @pytest.mark.parametrize("invalid_overrides", [[], "", 0, False])
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    @patch("mcp_clickhouse.mcp_server.get_context")
+    def test_invalid_context_state_fails_before_client_creation(
+        self, mock_get_context, mock_cc, invalid_overrides
+    ):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = invalid_overrides
+        mock_get_context.return_value = mock_ctx
+
+        with pytest.raises(ToolError) as exc_info:
+            create_clickhouse_client()
+
+        assert repr(invalid_overrides) not in str(exc_info.value)
+        assert CLIENT_CONFIG_OVERRIDES_KEY in str(exc_info.value)
+        mock_cc.get_client.assert_not_called()
+
+    @pytest.mark.parametrize("key", ["settings", "generic_args"])
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_invalid_nested_mapping_fails_before_client_creation(self, mock_cc, key):
+        with pytest.raises(ToolError, match=rf"{key} must be a mapping"):
+            create_clickhouse_client({key: "do-not-expose"})
+
+        assert "do-not-expose" not in str(mock_cc.mock_calls)
+        mock_cc.get_client.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("overrides", "rejected_key"),
+        [
+            ({"role": "secret-tenant-a"}, "role"),
+            ({"ch_role": "secret-tenant-b"}, "ch_role"),
+            ({"generic_args": {"role": "secret-tenant-c"}}, "generic_args.role"),
+            ({"generic_args": {"ch_role": "secret-tenant-d"}}, "generic_args.ch_role"),
+        ],
+    )
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_role_aliases_fail_before_config_or_client_creation(
+        self, mock_cc, mock_get_config, overrides, rejected_key
+    ):
+        secret_value = next(
+            value
+            for value in (
+                overrides.get("role"),
+                overrides.get("ch_role"),
+                overrides.get("generic_args", {}).get("role"),
+                overrides.get("generic_args", {}).get("ch_role"),
+            )
+            if value is not None
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            create_clickhouse_client(overrides)
+
+        assert rejected_key in str(exc_info.value)
+        assert secret_value not in str(exc_info.value)
+        mock_get_config.assert_not_called()
+        mock_cc.get_client.assert_not_called()
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_nested_mappings_merge_with_base_config(self, mock_cc, mock_get_config):
+        base_settings = {"role": "tenant_a", "max_block_size": 100}
+        base_generic_args = {"query_limit": 10}
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(settings=base_settings, generic_args=base_generic_args)
+        )
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client(
+            {
+                "settings": {"max_threads": 2},
+                "generic_args": {"compress": False},
+            }
+        )
+
+        call_kwargs = mock_cc.get_client.call_args.kwargs
+        assert call_kwargs["settings"] == {
+            "role": "tenant_a",
+            "max_block_size": 100,
+            "max_threads": 2,
+        }
+        assert call_kwargs["generic_args"] == {"query_limit": 10, "compress": False}
+        assert base_settings == {"role": "tenant_a", "max_block_size": 100}
+        assert base_generic_args == {"query_limit": 10}
+
+    @patch("mcp_clickhouse.mcp_server.get_config")
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_explicit_role_override_replaces_base_role(self, mock_cc, mock_get_config):
+        mock_get_config.return_value = _mock_config(
+            _base_client_config(settings={"role": "tenant_a"})
+        )
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client({"settings": {"role": "tenant_b"}})
+
+        assert mock_cc.get_client.call_args.kwargs["settings"]["role"] == "tenant_b"
+
+    @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
+    def test_opaque_client_object_is_preserved_by_identity(self, mock_cc):
+        class OpaquePoolManager:
+            def __deepcopy__(self, _memo):
+                raise AssertionError("must not be deep-copied")
+
+        pool_manager = OpaquePoolManager()
+        mock_cc.get_client.return_value = MagicMock(server_version="24.1")
+
+        create_clickhouse_client({"pool_mgr": pool_manager})
+
+        assert mock_cc.get_client.call_args.kwargs["pool_mgr"] is pool_manager
+
+    @patch("mcp_clickhouse.mcp_server.get_context")
+    def test_capture_snapshots_mappings_but_preserves_opaque_objects(self, mock_get_context):
+        pool_manager = object()
+        settings = {"max_threads": 2}
+        state = {
+            "connect_timeout": 40,
+            "settings": settings,
+            "pool_mgr": pool_manager,
+        }
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = state
+        mock_get_context.return_value = mock_ctx
+
+        snapshot = _get_client_config_overrides()
+        state["connect_timeout"] = 50
+        settings["max_threads"] = 3
+
+        assert snapshot["connect_timeout"] == 40
+        assert snapshot["settings"] == {"max_threads": 2}
+        assert snapshot["pool_mgr"] is pool_manager
+
+    @patch("mcp_clickhouse.mcp_server.execute_query", return_value="result")
+    @patch("mcp_clickhouse.mcp_server._get_client_config_overrides")
+    def test_sync_run_query_passes_captured_overrides(self, mock_get_overrides, mock_execute):
+        overrides = {"connect_timeout": 41}
+        mock_get_overrides.return_value = overrides
+
+        assert run_query("SELECT 1") == "result"
+
+        mock_execute.assert_called_once_with("SELECT 1", overrides)
+
+    @pytest.mark.asyncio
+    @patch("mcp_clickhouse.mcp_server.execute_query", return_value="result")
+    @patch("mcp_clickhouse.mcp_server._get_client_config_overrides")
+    async def test_async_run_query_passes_captured_overrides(
+        self, mock_get_overrides, mock_execute
+    ):
+        overrides = {"connect_timeout": 42}
+        mock_get_overrides.return_value = overrides
+
+        assert await run_query_async("SELECT 1") == "result"
+
+        mock_execute.assert_called_once_with("SELECT 1", overrides)
 
 
 @pytest.fixture
 def mcp_server():
-    """Return the MCP server instance for testing."""
     return mcp
+
+
+class TestConfigOverrideMcpBoundary:
+    @pytest.mark.asyncio
+    async def test_registered_run_query_receives_context_overrides(self, mcp_server):
+        middleware = ConfigOverrideMiddleware({"connect_timeout": 99})
+        mcp_server.add_middleware(middleware)
+        try:
+            with patch("mcp_clickhouse.mcp_server.clickhouse_connect.get_client") as get_client:
+                get_client.side_effect = lambda **kwargs: FakeQueryClient(
+                    kwargs["connect_timeout"]
+                )
+                async with Client(mcp_server) as client:
+                    result = await client.call_tool("run_query", {"query": "SELECT 1"})
+
+            assert json.loads(result.content[0].text)["rows"] == [[99]]
+            assert get_client.call_args.kwargs["connect_timeout"] == 99
+        finally:
+            mcp_server.middleware.remove(middleware)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_run_queries_keep_overrides_isolated(self, mcp_server):
+        barrier = threading.Barrier(2)
+        middleware = QueryOverrideMiddleware()
+        mcp_server.add_middleware(middleware)
+        try:
+            with patch("mcp_clickhouse.mcp_server.clickhouse_connect.get_client") as get_client:
+                get_client.side_effect = lambda **kwargs: FakeQueryClient(
+                    kwargs["connect_timeout"], barrier
+                )
+                async with Client(mcp_server) as client:
+                    first, second = await asyncio.gather(
+                        client.call_tool("run_query", {"query": "SELECT 11"}),
+                        client.call_tool("run_query", {"query": "SELECT 22"}),
+                    )
+
+            assert json.loads(first.content[0].text)["rows"] == [[11]]
+            assert json.loads(second.content[0].text)["rows"] == [[22]]
+        finally:
+            mcp_server.middleware.remove(middleware)
+
+    @pytest.mark.asyncio
+    async def test_invalid_context_state_is_a_safe_tool_error(self, mcp_server):
+        invalid_value = "do-not-expose"
+        middleware = ConfigOverrideMiddleware(invalid_value)
+        mcp_server.add_middleware(middleware)
+        try:
+            with patch("mcp_clickhouse.mcp_server.clickhouse_connect.get_client") as get_client:
+                async with Client(mcp_server) as client:
+                    with pytest.raises(ToolError) as exc_info:
+                        await client.call_tool("run_query", {"query": "SELECT 1"})
+
+            assert CLIENT_CONFIG_OVERRIDES_KEY in str(exc_info.value)
+            assert invalid_value not in str(exc_info.value)
+            get_client.assert_not_called()
+        finally:
+            mcp_server.middleware.remove(middleware)
 
 
 @pytest.mark.skipif(
@@ -98,11 +356,8 @@ def mcp_server():
     reason="ClickHouse environment variables not set",
 )
 class TestConfigOverrideIntegration:
-    """Integration tests that verify overrides work end-to-end with a real ClickHouse."""
-
     @pytest.mark.asyncio
     async def test_tool_call_with_overrides(self, mcp_server):
-        """Config overrides from middleware are applied during tool execution."""
         middleware = ConfigOverrideMiddleware({"connect_timeout": 99})
         mcp_server.add_middleware(middleware)
         try:
@@ -110,12 +365,10 @@ class TestConfigOverrideIntegration:
                 result = await client.call_tool("list_databases", {})
                 assert len(result.content) >= 1
         finally:
-            if middleware in mcp_server.middleware:
-                mcp_server.middleware.remove(middleware)
+            mcp_server.middleware.remove(middleware)
 
     @pytest.mark.asyncio
     async def test_tool_call_without_overrides(self, mcp_server):
-        """Client creation works normally without any override middleware."""
         async with Client(mcp_server) as client:
             result = await client.call_tool("list_databases", {})
             assert len(result.content) >= 1

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -383,7 +383,7 @@ async def test_concurrent_queries(mcp_server, setup_test_database):
 async def test_run_query_does_not_block_other_mcp_requests(mcp_server):
     """list_tools should complete while a query is in flight."""
 
-    def slow_execute_query(_query: str):
+    def slow_execute_query(_query: str, _client_config_overrides=None):
         time.sleep(0.75)
         return json.dumps({"columns": ["value"], "rows": [[1]]})
 


### PR DESCRIPTION
## Summary

- preserve request-scoped ClickHouse client overrides across the query executor handoff
- fail closed on invalid state and preserve configured roles when merging settings
- support opaque client objects and isolate concurrent requests
- document middleware trust and role-selection constraints

Supersedes #191

Builds on the original fix by @andrei-katkov, thanks!