### PR TITLE
feat: bound run_query result size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `run_query` results are now bounded by `CLICKHOUSE_MCP_MAX_RESULT_ROWS` (default 1000, `0` disables). The query timeout bounds how long a query runs, not how much it returns, so a fast query over a large table could return hundreds of megabytes and exhaust the client's context. Truncated responses carry `"truncated": true` and `"max_result_rows"`; complete responses keep their existing shape. Rows are streamed and the stream is closed once the bound is reached, so the query text is never rewritten. ([#223](https://github.com/ClickHouse/mcp-clickhouse/issues/223))
 - With `CLICKHOUSE_ALLOW_WRITE_ACCESS=true` and `CLICKHOUSE_ALLOW_DROP` unset, the server now runs `SHOW GRANTS` once at first connection and logs a warning if the ClickHouse user holds `ALL`, `DROP`, `TRUNCATE`, `DELETE`, `UPDATE`, or `ALTER` (beyond `ALTER ADD`) privileges, since the destructive-operation gate is not server-enforced. The check is fail-open and never blocks startup or queries. Grants held via roles are not expanded, so the advisory only flags direct grants.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -599,6 +599,17 @@ These variables control the MCP process itself, including transport, authenticat
 * `CLICKHOUSE_MCP_QUERY_TIMEOUT`: Timeout in seconds for query tools
   * Default: `"30"`
   * Increase this if you see `Query timed out after ...` errors for heavy queries
+* `CLICKHOUSE_MCP_MAX_RESULT_ROWS`: Maximum number of rows a single `run_query` result may contain
+  * Default: `"1000"`
+  * Set to `"0"` to return every row (the previous unbounded behavior)
+  * The query timeout bounds how long a query runs, not how much it returns. A fast query over a large
+    table finishes well inside the timeout and can still return hundreds of megabytes, so result size
+    needs its own bound
+  * When the cap is reached the response gains `"truncated": true` and `"max_result_rows"`, and holds
+    only the first rows. Complete results keep exactly the shape they had before
+  * Rows are streamed and the stream is closed once the cap is reached, so the query text is never
+    rewritten and ClickHouse stops sending early
+
 * `CLICKHOUSE_MCP_AUTH_TOKEN`: Static bearer token for HTTP/SSE transports
   * Default: None
   * One of `CLICKHOUSE_MCP_AUTH_TOKEN`, `FASTMCP_SERVER_AUTH`, or `CLICKHOUSE_MCP_AUTH_DISABLED=true` is **required** for HTTP/SSE transports

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -300,6 +300,8 @@ class MCPServerConfig:
         CLICKHOUSE_MCP_BIND_HOST: Bind host for HTTP/SSE (default: 127.0.0.1)
         CLICKHOUSE_MCP_BIND_PORT: Bind port for HTTP/SSE (default: 8000)
         CLICKHOUSE_MCP_QUERY_TIMEOUT: SELECT tool timeout in seconds (default: 30)
+        CLICKHOUSE_MCP_MAX_RESULT_ROWS: Maximum rows returned by run_query
+            (default: 1000). Set to 0 to return every row.
         CLICKHOUSE_MCP_AUTH_TOKEN: Static bearer token for HTTP/SSE transports.
             One authentication mode must be configured for HTTP/SSE; the other two
             options are FASTMCP_SERVER_AUTH (FastMCP OAuth/OIDC providers) and
@@ -327,6 +329,21 @@ class MCPServerConfig:
     @property
     def query_timeout(self) -> int:
         return int(os.getenv("CLICKHOUSE_MCP_QUERY_TIMEOUT", "30"))
+
+    @property
+    def max_result_rows(self) -> int:
+        """Maximum number of rows a single query result may contain.
+
+        A query that is fast but large passes the timeout and then floods the
+        client, so result size needs its own bound. 0 disables the bound and
+        restores the previous unbounded behavior.
+        """
+        value = int(os.getenv("CLICKHOUSE_MCP_MAX_RESULT_ROWS", "1000"))
+        if value < 0:
+            raise ValueError(
+                f"CLICKHOUSE_MCP_MAX_RESULT_ROWS must be 0 or greater, got {value}"
+            )
+        return value
 
     @property
     def auth_token(self) -> Optional[str]:

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -543,6 +543,41 @@ def _validate_query_for_destructive_ops(query: str) -> None:
         )
 
 
+def _stream_bounded_result(
+    client, query: str, query_settings: dict, max_rows: int
+) -> tuple[List[str], List[Any], bool]:
+    """Read at most `max_rows` rows from `query`, closing the stream early.
+
+    Streaming keeps the query text untouched. Rewriting user SQL to append a
+    LIMIT would need to understand the statement, and would misfire on queries
+    that already carry their own LIMIT or FORMAT clause, and on statements that
+    cannot be wrapped in a subquery at all.
+
+    Truncation is proven rather than inferred. The loop stops on the row after
+    the bound, so a result holding exactly `max_rows` rows is reported as
+    complete; comparing the returned count against the bound alone cannot tell
+    those two cases apart.
+
+    Returns:
+        Tuple of (column names, rows, whether the result was truncated)
+    """
+    rows: List[Any] = []
+    truncated = False
+
+    with client.query_row_block_stream(query, settings=query_settings) as stream:
+        for block in stream:
+            for row in block:
+                if len(rows) >= max_rows:
+                    truncated = True
+                    break
+                rows.append(row)
+            if truncated:
+                break
+        column_names = list(stream.source.column_names)
+
+    return column_names, rows, truncated
+
+
 def execute_query(
     query: str, client_config_overrides: Optional[dict[str, Any]] = None
 ) -> str:
@@ -551,9 +586,30 @@ def execute_query(
         _validate_query_for_destructive_ops(query)
 
         query_settings = build_query_settings(client)
-        res = client.query(query, settings=query_settings)
-        logger.info(f"Query returned {len(res.result_rows)} rows")
-        return _serialize_tool_result({"columns": res.column_names, "rows": res.result_rows})
+        max_rows = get_mcp_config().max_result_rows
+
+        if max_rows == 0:
+            res = client.query(query, settings=query_settings)
+            logger.info(f"Query returned {len(res.result_rows)} rows")
+            return _serialize_tool_result({"columns": res.column_names, "rows": res.result_rows})
+
+        columns, rows, truncated = _stream_bounded_result(
+            client, query, query_settings, max_rows
+        )
+
+        result: Dict[str, Any] = {"columns": columns, "rows": rows}
+        if truncated:
+            logger.info(
+                "Query result truncated to %s rows "
+                "(raise or disable with CLICKHOUSE_MCP_MAX_RESULT_ROWS)",
+                max_rows,
+            )
+            result["truncated"] = True
+            result["max_result_rows"] = max_rows
+        else:
+            logger.info(f"Query returned {len(rows)} rows")
+
+        return _serialize_tool_result(result)
     except ToolError:
         raise
     except Exception as err:
@@ -1121,7 +1177,10 @@ if os.getenv("CLICKHOUSE_ENABLED", "true").lower() == "true":
                 "Set CLICKHOUSE_ALLOW_DROP=true to additionally allow destructive operations "
                 "(DROP, TRUNCATE, DELETE, UPDATE, REPLACE TABLE/PARTITION, CREATE OR REPLACE, "
                 "CLEAR COLUMN/INDEX/PROJECTION, DETACH PERMANENTLY). That gate is a best-effort "
-                "accident guard, not a security boundary."
+                "accident guard, not a security boundary. Results are capped at "
+                "CLICKHOUSE_MCP_MAX_RESULT_ROWS rows; when the cap is reached the response carries "
+                "\"truncated\": true and holds only the first rows, so aggregate or filter in SQL "
+                "rather than treating a truncated result as the full table."
             ),
         )
     )

--- a/tests/test_context_config_override.py
+++ b/tests/test_context_config_override.py
@@ -83,6 +83,28 @@ class FakeQueryClient:
             result_rows=[(self.connect_timeout,)],
         )
 
+    def query_row_block_stream(self, _query, settings):
+        """Row-block streaming used by execute_query when a result bound is set."""
+        assert settings == {"readonly": "1"}
+        if self.barrier is not None:
+            self.barrier.wait(timeout=2)
+        return _FakeRowBlockStream([[(self.connect_timeout,)]], ["connect_timeout"])
+
+
+class _FakeRowBlockStream:
+    def __init__(self, blocks, column_names):
+        self._blocks = blocks
+        self.source = SimpleNamespace(column_names=column_names)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def __iter__(self):
+        return iter(self._blocks)
+
 
 class TestConfigOverrideUnit:
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")

--- a/tests/test_result_limits.py
+++ b/tests/test_result_limits.py
@@ -1,0 +1,193 @@
+"""Tests for the result-size bound on run_query.
+
+`CLICKHOUSE_MCP_MAX_RESULT_ROWS` bounds how many rows a single query result may
+contain. The query timeout bounds how long a query runs, but a fast query over a
+large table finishes well inside the timeout and then floods the client, so size
+needs its own bound.
+"""
+
+import json
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from dotenv import load_dotenv
+
+from mcp_clickhouse import create_clickhouse_client, run_query
+from mcp_clickhouse.mcp_server import _stream_bounded_result
+
+load_dotenv()
+
+TOTAL_ROWS = 250
+
+
+class _FakeStream:
+    """Minimal stand-in for clickhouse-connect's row block stream."""
+
+    def __init__(self, blocks, column_names=("a", "b")):
+        self._blocks = blocks
+        self.source = SimpleNamespace(column_names=column_names)
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        self.closed = True
+        return False
+
+    def __iter__(self):
+        return iter(self._blocks)
+
+
+class _FakeClient:
+    def __init__(self, blocks, column_names=("a", "b")):
+        self.stream = _FakeStream(blocks, column_names)
+        self.queries = []
+
+    def query_row_block_stream(self, query, settings=None):
+        self.queries.append((query, settings))
+        return self.stream
+
+
+def _rows(start, count):
+    return [(i, f"v{i}") for i in range(start, start + count)]
+
+
+@pytest.mark.parametrize(
+    "blocks,max_rows,expected_rows,expected_truncated",
+    [
+        # Fewer rows than the bound.
+        ([_rows(0, 3)], 10, 3, False),
+        # Exactly the bound: complete, not truncated. This is the case a naive
+        # "returned == max_rows" check gets wrong.
+        ([_rows(0, 10)], 10, 10, False),
+        # One row past the bound.
+        ([_rows(0, 11)], 10, 10, True),
+        # Bound falls inside a later block.
+        ([_rows(0, 4), _rows(4, 4), _rows(8, 4)], 10, 10, True),
+        # Bound falls exactly on a block boundary with more blocks behind it.
+        ([_rows(0, 5), _rows(5, 5), _rows(10, 5)], 10, 10, True),
+        # Empty result.
+        ([], 10, 0, False),
+        # Bound of one.
+        ([_rows(0, 100)], 1, 1, True),
+    ],
+)
+def test_stream_bounded_result(blocks, max_rows, expected_rows, expected_truncated):
+    client = _FakeClient(blocks)
+
+    columns, rows, truncated = _stream_bounded_result(client, "SELECT 1", {}, max_rows)
+
+    assert len(rows) == expected_rows
+    assert truncated is expected_truncated
+    assert columns == ["a", "b"]
+
+
+def test_stream_closes_even_when_stopping_early():
+    client = _FakeClient([_rows(0, 100)])
+
+    _stream_bounded_result(client, "SELECT 1", {}, 5)
+
+    assert client.stream.closed
+
+
+def test_stream_passes_query_settings_through():
+    client = _FakeClient([_rows(0, 1)])
+
+    _stream_bounded_result(client, "SELECT 1", {"readonly": "1"}, 10)
+
+    assert client.queries == [("SELECT 1", {"readonly": "1"})]
+
+
+class TestResultRowLimit(unittest.TestCase):
+    """Integration coverage against a real ClickHouse server."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.client = create_clickhouse_client()
+        cls.test_db = "test_result_limit_db"
+        cls.test_table = "rows"
+        cls.total_rows = TOTAL_ROWS
+
+        cls.client.command(f"DROP DATABASE IF EXISTS {cls.test_db}")
+        cls.client.command(f"CREATE DATABASE {cls.test_db}")
+        cls.client.command(f"""
+            CREATE TABLE {cls.test_db}.{cls.test_table} (
+                id UInt32,
+                value String
+            ) ENGINE = MergeTree()
+            ORDER BY id
+        """)
+        cls.client.command(f"""
+            INSERT INTO {cls.test_db}.{cls.test_table}
+            SELECT number, concat('v', toString(number)) FROM numbers({cls.total_rows})
+        """)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.command(f"DROP DATABASE IF EXISTS {cls.test_db}")
+
+    def _select_all(self):
+        return f"SELECT * FROM {self.test_db}.{self.test_table} ORDER BY id"
+
+    @patch.dict(os.environ, {"CLICKHOUSE_MCP_MAX_RESULT_ROWS": "50"})
+    def test_large_result_is_truncated_and_flagged(self):
+        result = json.loads(run_query(self._select_all()))
+
+        self.assertEqual(len(result["rows"]), 50)
+        self.assertTrue(result["truncated"])
+        self.assertEqual(result["max_result_rows"], 50)
+        self.assertEqual(result["columns"], ["id", "value"])
+
+    @patch.dict(os.environ, {"CLICKHOUSE_MCP_MAX_RESULT_ROWS": "50"})
+    def test_truncation_returns_the_first_rows(self):
+        result = json.loads(run_query(self._select_all()))
+
+        self.assertEqual([row[0] for row in result["rows"]], list(range(50)))
+
+    @patch.dict(os.environ, {"CLICKHOUSE_MCP_MAX_RESULT_ROWS": "1000"})
+    def test_small_result_is_not_flagged(self):
+        result = json.loads(run_query(self._select_all()))
+
+        self.assertEqual(len(result["rows"]), self.total_rows)
+        self.assertNotIn("truncated", result)
+        self.assertNotIn("max_result_rows", result)
+
+    @patch.dict(os.environ, {"CLICKHOUSE_MCP_MAX_RESULT_ROWS": str(TOTAL_ROWS)})
+    def test_result_exactly_at_the_bound_is_not_truncated(self):
+        """A table holding exactly max_result_rows rows is complete, not truncated."""
+        result = json.loads(run_query(self._select_all()))
+
+        self.assertEqual(len(result["rows"]), self.total_rows)
+        self.assertNotIn("truncated", result)
+
+    @patch.dict(os.environ, {"CLICKHOUSE_MCP_MAX_RESULT_ROWS": "0"})
+    def test_zero_disables_the_bound(self):
+        result = json.loads(run_query(self._select_all()))
+
+        self.assertEqual(len(result["rows"]), self.total_rows)
+        self.assertNotIn("truncated", result)
+
+    @patch.dict(os.environ, {"CLICKHOUSE_MCP_MAX_RESULT_ROWS": "10"})
+    def test_empty_result_is_not_flagged(self):
+        query = f"SELECT * FROM {self.test_db}.{self.test_table} WHERE id = 999999"
+
+        result = json.loads(run_query(query))
+
+        self.assertEqual(result["rows"], [])
+        self.assertNotIn("truncated", result)
+
+    @patch.dict(os.environ, {"CLICKHOUSE_MCP_MAX_RESULT_ROWS": "10"})
+    def test_column_names_survive_aliasing(self):
+        query = f"SELECT id AS renamed, value FROM {self.test_db}.{self.test_table} LIMIT 3"
+
+        result = json.loads(run_query(query))
+
+        self.assertEqual(result["columns"], ["renamed", "value"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Draft implementation for #223, opened to make that discussion concrete rather than to pre-empt it. The open questions in the issue are still open, and I will happily rework the shape.

## What it does

Adds `CLICKHOUSE_MCP_MAX_RESULT_ROWS`, default `1000`, `0` restores the previous unbounded behavior.

Same 3M row table from the issue, same query, same default 30s timeout:

```
                  before          after
elapsed           5.2s            0.12s
returned rows     3,000,000       1,000
payload           231.6 MiB       0.08 MiB
rough tokens      60,700,916      ~20,000
```

The query is also aborted early, so ClickHouse stops sending rather than serializing 3M rows that get discarded.

## Implementation notes

**Streaming instead of LIMIT injection.** Rows are read with `query_row_block_stream` and the stream is closed once the bound is reached. The query text is never touched. Appending a `LIMIT` would need to understand the statement, and would misfire on queries that already carry their own `LIMIT` or `FORMAT` clause, and on statements that cannot be wrapped in a subquery at all. Several MCP servers in other ecosystems gate `LIMIT` injection on a substring test like `"LIMIT" not in query.upper()`, which a column named `limit_amount` defeats. Not rewriting SQL avoids the whole class.

**Truncation is proven, not inferred.** The read stops on the row *after* the bound. A result holding exactly `max_result_rows` rows is reported as complete, because `returned == max_result_rows` on its own cannot distinguish a full result of that size from a truncated one. There is a regression test for exactly this case.

**Backward compatible response shape.** Complete results keep exactly the shape they have today. `truncated` and `max_result_rows` appear only when truncation actually happened, so complete results pay nothing for the metadata.

**Why not ClickHouse's own `max_result_rows`.** It is enforced per block, so it is not a cap a user can reason about. Measured on the same table:

```
asked max_result_rows=10      -> got  16,384 rows
asked max_result_rows=100     -> got  16,384 rows
asked max_result_rows=1000    -> got  16,384 rows
asked max_result_rows=50000   -> got  65,536 rows
```

`result_overflow_mode='throw'` is exact but turns a large result into `Code: 396` instead of a usable prefix. It could still be worth layering underneath as a coarse server-side backstop; I left it out to keep this change small.

**Tool description.** `run_query`'s description now states that results are capped and that a truncated response holds only the first rows, so the model aggregates in SQL instead of treating a prefix as the whole table. Truncating silently is the failure mode worth avoiding: a partial answer presented as a complete one is worse than either a complete answer or an explicit error.

## On the default

I picked `1000` rather than something larger after measuring: 10,000 rows of that table is still ~200k tokens, which is a whole context window for many clients. `1000` is roughly 20k tokens there. This is question 1 in the issue and entirely yours to call, including making it opt-in with `0` if you would rather not change observable behavior in a patch release.

## Tests

New `tests/test_result_limits.py`: 9 parametrized unit tests for the streaming helper covering the exact-boundary case, block boundaries, empty results, early stream closure, and settings passthrough; plus 7 integration tests against a real server covering truncation, flag absence on complete results, `0` disabling the bound, empty results, and column aliasing.

`FakeQueryClient` in `tests/test_context_config_override.py` gains a `query_row_block_stream` method so the double matches the API `execute_query` now uses. Its assertions are unchanged.

Full suite locally: 307 passed. The one failure, `test_system_database_access`, is pre-existing and unrelated; it fails on an unmodified checkout too, because it asserts `system.tables` appears in the first 100 tables of `system`, which stopped holding on ClickHouse newer than the 24.10 used in CI.

## Not included

- A byte bound. 1,000 rows of wide `String` columns is a very different payload from 1,000 rows of `UInt8`. This is question 2 in the issue; happy to add it here or leave it for a follow-up.
- Any change to `list_tables` (question 4).
