### PR TITLE
migrate to fastmcp4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.6.0 - Unreleased
+
+### Added
+- MCP handling through FastMCP 4 for modern `2026-07-28` clients and legacy clients using `2024-11-05` through `2025-11-25`. The modern path includes `server/discover`, sessionless requests, response caching hints, and request metadata validation. ([#218](https://github.com/ClickHouse/mcp-clickhouse/issues/218))
+
+### Changed
+- The FastMCP dependency is now `>=4.0.0,<4.1.0`. The upper bound pins the FastMCP 4.0 request-state API used to keep ClickHouse client overrides request-scoped. A session-scoped override now fails the affected tool call. Custom middleware must await `Context.set_state()` and use `serializable=False` for these overrides.
+- The standalone HTTP+SSE transport remains available but is deprecated and logs a warning. Use `CLICKHOUSE_MCP_SERVER_TRANSPORT=http` for Streamable HTTP in new deployments.
+- OAuth/OIDC provider environment loading is now handled by mcp-clickhouse because FastMCP 4 removed its automatic `FASTMCP_SERVER_AUTH` loader. Existing built-in provider process variables keep their FastMCP 2.14.7 names and process-first precedence. The working-directory `.env` fallback for missing provider fields is preserved. Provider selection from the package-discovered `.env` and a process-set `FASTMCP_ENV_FILE` is new. Those files may also supply provider fields. Custom providers must support no-argument construction. Supabase HS256 is no longer supported by FastMCP and must move to RS256 or ES256. Clients using FastMCP 2's default OAuth proxy storage must register and authorize again. Compatible custom storage, static tokens, and JWT verification are unaffected.
+- `.env` discovery now starts at the installed `mcp_clickhouse` package directory and walks upward to the filesystem root in every launch mode. `python -m mcp_clickhouse.main`, `python -c`, debugger, and frozen launches no longer read `.env` from the working directory, so a working-directory `.env` cannot select the auth provider from those launch modes.
+- ClickHouse metadata tools now use a separate worker pool with `min(4, CLICKHOUSE_MCP_MAX_WORKERS)` threads so concurrent schema discovery cannot delay query execution.
+- Protocol responses now report the installed mcp-clickhouse package version, or `unknown` when distribution metadata is unavailable, instead of the FastMCP version.
+
+### Compatibility
+- FastMCP 4.0.0 and MCP Python SDK 2.1.1 route HTTP requests without `MCP-Protocol-Version` through legacy handling. MCP `2026-07-28` permits this for servers that support clients from before `2025-06-18`. Modern clients should send the header on every POST request.
+
 ## 0.5.0 - 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.6.0 - Unreleased
+## 0.6.0 - 2026-09-03
 
 ### Added
 - MCP handling through FastMCP 4 for modern `2026-07-28` clients and legacy clients using `2024-11-05` through `2025-11-25`. The modern path includes `server/discover`, sessionless requests, response caching hints, and request metadata validation. ([#218](https://github.com/ClickHouse/mcp-clickhouse/issues/218))

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ An MCP server for ClickHouse.
 
 <a href="https://glama.ai/mcp/servers/yvjy4csvo1"><img width="380" height="200" src="https://glama.ai/mcp/servers/yvjy4csvo1/badge" alt="mcp-clickhouse MCP server" /></a>
 
+The server implements MCP `2026-07-28` and supports legacy initialize handshakes from
+`2024-11-05` through `2025-11-25`. Modern clients use sessionless requests and
+`server/discover`. Existing clients can continue to negotiate the legacy protocol.
+
+> [!NOTE]
+> HTTP requests without `MCP-Protocol-Version` are routed through legacy handling so
+> clients from before `2025-06-18` can continue to connect. MCP `2026-07-28` permits
+> this behavior on servers that support those clients. Modern clients should send the
+> header on every POST request.
+
 ## Features
 
 ### ClickHouse Tools
@@ -30,12 +40,12 @@ integers and booleans keep their JSON types.
   * Required input: `database` (string).
   * Optional inputs:
     * `like` / `not_like` (string): Apply `LIKE` or `NOT LIKE` filters to table names.
-    * `page_token` (string): Token returned by a previous call for fetching the next page.
+    * `page_token` (string): Single-use token returned by a previous call. It is retained for up to one hour.
     * `page_size` (int, default `50`): Number of tables returned per page; must be greater than `0`.
     * `include_detailed_columns` (bool, default `true`): When `false`, omits column metadata for lighter responses while keeping the full `create_table_query`.
   * Response shape:
     * `tables`: Array of table objects for the current page.
-    * `next_page_token`: Pass this value back to fetch the next page, or `null` when there are no more tables.
+    * `next_page_token`: Pass this single-use value back before it expires to fetch the next page, or `null` when there are no more tables.
     * `total_tables`: Total count of tables that match the supplied filters.
 
 ### chDB Tools
@@ -123,9 +133,62 @@ export FASTMCP_SERVER_AUTH=fastmcp.server.auth.providers.azure.AzureProvider
 export FASTMCP_SERVER_AUTH_AZURE_TENANT_ID="<tenant-id>"
 export FASTMCP_SERVER_AUTH_AZURE_CLIENT_ID="<client-id>"
 export FASTMCP_SERVER_AUTH_AZURE_CLIENT_SECRET="<client-secret>"
+export FASTMCP_SERVER_AUTH_AZURE_BASE_URL="https://mcp.example.com"
+export FASTMCP_SERVER_AUTH_AZURE_REQUIRED_SCOPES="read access_as_user"
 ```
 
-See the [FastMCP docs](https://gofastmcp.com/servers/auth) for the full list of providers and their required environment variables.
+mcp-clickhouse retains these FastMCP 2.14.7 environment prefixes for the FastMCP 4.0.0
+built-in providers:
+
+| Provider class path | Provider variable prefix |
+|---------------------|--------------------------|
+| `fastmcp.server.auth.providers.auth0.Auth0Provider` | `FASTMCP_SERVER_AUTH_AUTH0_` |
+| `fastmcp.server.auth.providers.aws.AWSCognitoProvider` | `FASTMCP_SERVER_AUTH_AWS_COGNITO_` |
+| `fastmcp.server.auth.providers.azure.AzureProvider` | `FASTMCP_SERVER_AUTH_AZURE_` |
+| `fastmcp.server.auth.providers.descope.DescopeProvider` | `FASTMCP_SERVER_AUTH_DESCOPEPROVIDER_` |
+| `fastmcp.server.auth.providers.discord.DiscordProvider` | `FASTMCP_SERVER_AUTH_DISCORD_` |
+| `fastmcp.server.auth.providers.github.GitHubProvider` | `FASTMCP_SERVER_AUTH_GITHUB_` |
+| `fastmcp.server.auth.providers.google.GoogleProvider` | `FASTMCP_SERVER_AUTH_GOOGLE_` |
+| `fastmcp.server.auth.providers.introspection.IntrospectionTokenVerifier` | `FASTMCP_SERVER_AUTH_INTROSPECTION_` |
+| `fastmcp.server.auth.providers.jwt.JWTVerifier` | `FASTMCP_SERVER_AUTH_JWT_` |
+| `fastmcp.server.auth.providers.oci.OCIProvider` | `FASTMCP_SERVER_AUTH_OCI_` |
+| `fastmcp.server.auth.providers.scalekit.ScalekitProvider` | `FASTMCP_SERVER_AUTH_SCALEKITPROVIDER_` |
+| `fastmcp.server.auth.providers.supabase.SupabaseProvider` | `FASTMCP_SERVER_AUTH_SUPABASE_` |
+| `fastmcp.server.auth.providers.workos.WorkOSProvider` | `FASTMCP_SERVER_AUTH_WORKOS_` |
+| `fastmcp.server.auth.providers.workos.AuthKitProvider` | `FASTMCP_SERVER_AUTH_AUTHKITPROVIDER_` |
+
+Append the uppercase provider field name to the prefix. See the
+[FastMCP docs](https://gofastmcp.com/servers/auth) for each provider's configuration
+requirements.
+
+Auth values set directly in the process environment take precedence case-insensitively.
+The default `.env` load starts at the installed `mcp_clickhouse` package directory,
+resolves symlinks first, and walks upward to the filesystem root. It loads the first
+`.env` it finds and loads nothing if there is none. It never reads the working
+directory, regardless of how the server is launched. A source checkout normally finds
+the repository root `.env`. That file may also provide `FASTMCP_SERVER_AUTH` and its
+provider fields. Its values take precedence over the explicit or compatibility auth
+file.
+For FastMCP 2 compatibility, mcp-clickhouse reads missing provider fields from `.env`
+in the working directory, but that compatibility fallback cannot select
+`FASTMCP_SERVER_AUTH`. A process-set `FASTMCP_ENV_FILE` replaces that compatibility
+fallback and may provide both the selector and provider fields. Set it before startup.
+The mcp-clickhouse compatibility loader reads only `FASTMCP_SERVER_AUTH` and
+`FASTMCP_SERVER_AUTH_*` from that file, so it cannot inject `CLICKHOUSE_*` settings.
+FastMCP 4 may use the same file for its own broader settings. A custom provider receives
+no environment-derived constructor arguments and must support no-argument construction.
+
+Treat both discovered and working-directory `.env` files as trusted authentication
+configuration. Anyone who can create or write a `.env` in any directory from the package
+directory up to the filesystem root can control which file is discovered, select the
+provider, and set its fields. Anyone who can write the working-directory file controls every provider
+field absent from the process and discovered configuration, including signing keys,
+issuers and endpoints, and client secrets. A process-set `FASTMCP_ENV_FILE` that points
+to an operator-owned file disables the working-directory fallback.
+
+FastMCP 4 changed the default OAuth proxy client store. Deployments that relied on
+FastMCP 2's default OAuth proxy storage must have clients register and authorize again.
+Compatible custom storage, static bearer tokens, and JWT verification are unaffected.
 
 #### Development Mode (Disabling Authentication)
 
@@ -454,13 +517,22 @@ Middleware can override ClickHouse client configuration on a per-request basis u
 
 ```python
 from fastmcp.server.dependencies import get_context
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from mcp_clickhouse.mcp_server import CLIENT_CONFIG_OVERRIDES_KEY
 
-ctx = get_context()
-ctx.set_state(CLIENT_CONFIG_OVERRIDES_KEY, {
-    "connect_timeout": 60,
-    "send_receive_timeout": 120
-})
+
+class ClientConfigMiddleware(Middleware):
+    async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
+        ctx = get_context()
+        await ctx.set_state(
+            CLIENT_CONFIG_OVERRIDES_KEY,
+            {
+                "connect_timeout": 60,
+                "send_receive_timeout": 120,
+            },
+            serializable=False,
+        )
+        return await call_next(context)
 ```
 
 This enables advanced use cases like dynamic timeout adjustments, tenant-specific routing, or per-user connection settings.
@@ -472,9 +544,14 @@ supplies `settings.role`. Top-level `role` and `ch_role` keys, plus the same key
 `generic_args`, are rejected.
 
 Treat these overrides as trusted middleware input. Middleware must authenticate and authorize
-request-derived values before setting them. A per-request ClickHouse role is connection
-configuration, not a tenant authorization boundary. Enforce tenant isolation with ClickHouse
-users, roles, and grants.
+request-derived values before setting them. Use `serializable=False` so FastMCP keeps the
+value in request-local state. The default `serializable=True` stores session state and is
+rejected by the server. The server snapshots the value before dispatching blocking database
+work. Do not store tenant data in session-scoped Context state. A rejected session-scoped
+override remains attached to a legacy MCP session and causes later tool calls in that session
+to fail until the client reconnects. A per-request ClickHouse role is connection configuration,
+not a tenant authorization boundary. Enforce tenant isolation with ClickHouse users, roles,
+and grants.
 
 ## Development
 
@@ -493,7 +570,7 @@ CLICKHOUSE_PASSWORD=clickhouse
 
 3. Run `uv sync` to install the dependencies. To install `uv` follow the instructions [here](https://docs.astral.sh/uv/). Then do `source .venv/bin/activate`.
 
-4. For easy testing with the MCP Inspector, run `fastmcp dev mcp_clickhouse/mcp_server.py` to start the MCP server.
+4. For easy testing with the MCP Inspector, run `uv run fastmcp dev inspector mcp_clickhouse/mcp_server.py:mcp` to start the MCP server.
 
 5. To test with HTTP transport and the health check endpoint:
    ```bash
@@ -514,7 +591,7 @@ Configuration is split into **independent** groups. Mixing them up is a common c
 | Group | Variables | Controls |
 |-------|-----------|----------|
 | **ClickHouse database connection** | `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_SECURE`, `CLICKHOUSE_VERIFY`, … | How **this MCP server** connects to your ClickHouse cluster over the **HTTP interface** |
-| **MCP server / transport** | `CLICKHOUSE_MCP_*`, `FASTMCP_SERVER_AUTH`, `FASTMCP_SERVER_AUTH_*` | MCP transport, authentication, and query-tool execution limits |
+| **MCP server / transport** | `CLICKHOUSE_MCP_*`, `FASTMCP_SERVER_AUTH`, `FASTMCP_SERVER_AUTH_*`, `FASTMCP_ENV_FILE` | MCP transport, authentication, and query-tool execution limits |
 | **Middleware / chDB** | `MCP_MIDDLEWARE_MODULE`, `CHDB_*` | Optional extensions |
 
 > [!IMPORTANT]
@@ -592,6 +669,7 @@ These variables control the MCP process itself, including transport, authenticat
   * Default: `"stdio"`
   * Valid options: `"stdio"`, `"http"`, `"sse"`. This is useful for local development with tools like MCP Inspector.
   * `stdio` is typical for Claude Desktop; `http`/`sse` expose a network listener (bind host/port below)
+  * `"sse"` selects the deprecated standalone HTTP+SSE transport and logs a warning. Use `"http"` for Streamable HTTP in new deployments.
 * `CLICKHOUSE_MCP_BIND_HOST`: Host to bind the MCP server to when using HTTP or SSE transport
   * Default: `"127.0.0.1"`
   * Set to `"0.0.0.0"` to bind to all network interfaces (useful for Docker or remote access)
@@ -607,6 +685,7 @@ These variables control the MCP process itself, including transport, authenticat
 * `CLICKHOUSE_MCP_MAX_WORKERS`: Maximum number of concurrent query worker threads
   * Default: `"10"`
   * Increase if your workload requires many concurrent tool calls
+  * Metadata tools use a separate pool with `min(4, CLICKHOUSE_MCP_MAX_WORKERS)` threads so schema discovery cannot delay queries
 * `CLICKHOUSE_MCP_AUTH_TOKEN`: Static bearer token for HTTP/SSE transports
   * Default: None
   * One of `CLICKHOUSE_MCP_AUTH_TOKEN`, `FASTMCP_SERVER_AUTH`, or `CLICKHOUSE_MCP_AUTH_DISABLED=true` is **required** for HTTP/SSE transports
@@ -615,7 +694,16 @@ These variables control the MCP process itself, including transport, authenticat
 * `FASTMCP_SERVER_AUTH`: Delegate authentication to a [FastMCP auth provider](https://gofastmcp.com/servers/auth)
   * Default: None
   * Value is the **full class path** of an AuthProvider subclass, e.g. `fastmcp.server.auth.providers.azure.AzureProvider` or `fastmcp.server.auth.providers.google.GoogleProvider`
-  * When set, FastMCP auto-loads the provider from its own `FASTMCP_SERVER_AUTH_*` environment variables; leave `CLICKHOUSE_MCP_AUTH_TOKEN` unset in this mode
+  * When set, mcp-clickhouse loads the provider from the existing `FASTMCP_SERVER_AUTH_*` environment variables; leave `CLICKHOUSE_MCP_AUTH_TOKEN` unset in this mode
+  * Custom providers receive no environment-derived constructor arguments and must support no-argument construction
+  * FastMCP 4 no longer supports Supabase HS256 verification. Supabase deployments must use RS256 or ES256.
+* `FASTMCP_ENV_FILE`: Optional file containing `FASTMCP_SERVER_AUTH` and provider-specific environment variables
+  * Default: None. When unset, the compatibility loader reads missing provider fields from `.env` in the working directory. It does not read `FASTMCP_SERVER_AUTH` from that fallback
+  * Set it in the process environment before startup. A value loaded from the default `.env` cannot redirect the compatibility loader
+  * If process-set, this file may provide both `FASTMCP_SERVER_AUTH` and provider fields and replaces the working-directory fallback
+  * Process environment values take precedence case-insensitively
+  * The mcp-clickhouse compatibility loader reads this file only when building HTTP/SSE authentication and reads only `FASTMCP_SERVER_AUTH` and `FASTMCP_SERVER_AUTH_*` entries. FastMCP 4 may read the same file for its broader settings
+  * The default `.env` load is separate. It starts at the installed `mcp_clickhouse` package directory, resolves symlinks, walks upward to the filesystem root, and loads the first `.env` found or nothing. It never reads the working directory, regardless of launch method. That file may provide `FASTMCP_SERVER_AUTH` and provider fields along with other server settings. A source checkout normally finds the repository root `.env`
 * `CLICKHOUSE_MCP_AUTH_DISABLED`: Disable authentication for HTTP/SSE transports
   * Default: `"false"` (authentication is enabled)
   * Set to `"true"` to disable authentication for local development/testing only
@@ -629,6 +717,7 @@ These variables control the MCP process itself, including transport, authenticat
   * The `host:*` form matches only values that carry a port. A port-less Host (a standard-port deployment where the client omits `:80`/`:443`) must be listed as a bare exact entry (`example.com`) as well.
   * Requests with a non-matching or missing `Host` header get `421 Misdirected Request`. GET and HEAD requests to `/health` are exempt from Host and Origin validation so orchestrator probes keep working.
   * Behind a reverse proxy, prefer preserving the original `Host` header. You can instead list the upstream `Host` value the proxy sends. Set an explicit list when a launcher such as `fastmcp run` overrides the bind address for remote access.
+  * mcp-clickhouse forces FastMCP's separate Host and Origin guard off. `FASTMCP_HTTP_HOST_ORIGIN_PROTECTION`, `FASTMCP_HTTP_ALLOWED_HOSTS`, and `FASTMCP_HTTP_ALLOWED_ORIGINS` do not apply. `CLICKHOUSE_MCP_ALLOWED_HOSTS` and `CLICKHOUSE_MCP_ALLOWED_ORIGINS` are authoritative.
 * `CLICKHOUSE_MCP_TRUSTED_PROXIES`: Proxy IP addresses or CIDR networks whose `X-Forwarded-*` headers are trusted
   * Default: None. `X-Forwarded-Host` is ignored. Existing Uvicorn handling of `X-Forwarded-For` and `X-Forwarded-Proto` is unchanged.
   * Entries must be IP addresses or CIDR networks, such as `127.0.0.1,10.20.0.0/24,2001:db8::1`. CIDRs must use their network address, so `10.20.0.1/24` is rejected. Host names, scoped IPv6 addresses, `*`, `0.0.0.0/0`, and `::/0` are also rejected.

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -1039,6 +1039,19 @@ async def list_databases_async() -> str:
 table_pagination_cache: TTLCache = TTLCache(maxsize=100, ttl=3600)  # 3600 seconds = 1 hour
 _table_pagination_cache_lock = threading.Lock()
 _PAGE_TOKEN_EXPIRES_AT = "_expires_at"
+_CLAIM_PAGE_TOKEN_IN_WORKER = object()
+
+
+@dataclass(frozen=True)
+class _PendingPageToken:
+    token: str
+    state: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _PreparedListTablesResult:
+    response: str
+    pending_page_token: Optional[_PendingPageToken]
 
 
 def fetch_table_names_from_system(
@@ -1150,31 +1163,82 @@ def create_page_token(
     Returns:
         New page token
     """
-    token = str(uuid.uuid4())
-    with _table_pagination_cache_lock:
-        expires_at = table_pagination_cache.timer() + table_pagination_cache.ttl
-        table_pagination_cache[token] = {
+    pending_page_token = _prepare_page_token(
+        database,
+        like,
+        not_like,
+        table_names,
+        end_idx,
+        include_detailed_columns,
+    )
+    _commit_page_token(pending_page_token)
+    return pending_page_token.token
+
+
+def _prepare_page_token(
+    database: str,
+    like: Optional[str],
+    not_like: Optional[str],
+    table_names: List[str],
+    end_idx: int,
+    include_detailed_columns: bool,
+) -> _PendingPageToken:
+    """Prepare a page token without making it available to clients."""
+    return _PendingPageToken(
+        token=str(uuid.uuid4()),
+        state={
             "database": database,
             "like": like,
             "not_like": not_like,
             "table_names": table_names,
             "start_idx": end_idx,
             "include_detailed_columns": include_detailed_columns,
-            _PAGE_TOKEN_EXPIRES_AT: expires_at,
-        }
-    return token
+        },
+    )
 
 
-def _claim_page_token(page_token: str) -> Optional[dict[str, Any]]:
-    """Atomically claim a single-use pagination token."""
+def _commit_page_token(pending_page_token: _PendingPageToken) -> None:
+    """Make a prepared page token available for one hour."""
     with _table_pagination_cache_lock:
-        state = table_pagination_cache.pop(page_token, None)
+        expires_at = table_pagination_cache.timer() + table_pagination_cache.ttl
+        state = dict(pending_page_token.state)
+        state[_PAGE_TOKEN_EXPIRES_AT] = expires_at
+        table_pagination_cache[pending_page_token.token] = state
+
+
+def _claim_page_token_for_request(
+    page_token: str,
+    database: str,
+    like: Optional[str],
+    not_like: Optional[str],
+    include_detailed_columns: bool,
+) -> Optional[dict[str, Any]]:
+    """Claim a matching page token and leave a mismatched token untouched."""
+    mismatch = False
+    with _table_pagination_cache_lock:
+        state = table_pagination_cache.get(page_token)
         if state is None:
             return None
         expires_at = state.get(_PAGE_TOKEN_EXPIRES_AT)
         if expires_at is not None and expires_at <= table_pagination_cache.timer():
+            table_pagination_cache.pop(page_token, None)
             return None
-        return state
+        cached_include_detailed = state.get("include_detailed_columns", True)
+        mismatch = (
+            state["database"] != database
+            or state["like"] != like
+            or state["not_like"] != not_like
+            or cached_include_detailed != include_detailed_columns
+        )
+        if not mismatch:
+            return table_pagination_cache.pop(page_token)
+
+    logger.warning(
+        "Page token %s is for a different database, filter, or metadata setting. "
+        "Ignoring token and starting from beginning.",
+        page_token,
+    )
+    return None
 
 
 def _restore_page_token(page_token: str, state: dict[str, Any]) -> None:
@@ -1239,27 +1303,25 @@ def _list_tables_with_config(
     page_token: Optional[str],
     page_size: int,
     include_detailed_columns: bool,
-) -> str:
+    claimed_page_state: object = _CLAIM_PAGE_TOKEN_IN_WORKER,
+) -> str | _PreparedListTablesResult:
     """List tables with a resolved client configuration."""
     if page_size <= 0:
         raise ToolError("page_size must be greater than 0")
 
-    claimed_page_state = _claim_page_token(page_token) if page_token else None
-    if claimed_page_state is not None:
-        cached_include_detailed = claimed_page_state.get("include_detailed_columns", True)
-        if (
-            claimed_page_state["database"] != database
-            or claimed_page_state["like"] != like
-            or claimed_page_state["not_like"] != not_like
-            or cached_include_detailed != include_detailed_columns
-        ):
-            _restore_page_token(page_token, claimed_page_state)
-            claimed_page_state = None
-            logger.warning(
-                "Page token %s is for a different database, filter, or metadata setting. "
-                "Ignoring token and starting from beginning.",
+    owns_page_token_transaction = claimed_page_state is _CLAIM_PAGE_TOKEN_IN_WORKER
+    if owns_page_token_transaction:
+        claimed_page_state = (
+            _claim_page_token_for_request(
                 page_token,
+                database,
+                like,
+                not_like,
+                include_detailed_columns,
             )
+            if page_token
+            else None
+        )
 
     logger.info(
         "Listing tables in database '%s' with like=%s, not_like=%s, "
@@ -1272,28 +1334,48 @@ def _list_tables_with_config(
         include_detailed_columns,
     )
 
-    for attempt in range(2):
-        entry = None
-        try:
-            entry = _acquire_clickhouse_client(config)
-            client = entry.client
-            return _list_tables_impl(
-                client, database, like, not_like, page_token,
-                page_size, include_detailed_columns, claimed_page_state,
-            )
-        except Exception as err:
-            if attempt == 0 and _is_connection_error(err):
-                logger.warning("list_tables connection error, retrying: %s", err)
+    try:
+        for attempt in range(2):
+            entry = None
+            try:
+                entry = _acquire_clickhouse_client(config)
+                client = entry.client
+                prepared_result = _list_tables_impl(
+                    client,
+                    database,
+                    like,
+                    not_like,
+                    page_token,
+                    page_size,
+                    include_detailed_columns,
+                    claimed_page_state,
+                )
+                break
+            except Exception as err:
+                if attempt == 0 and _is_connection_error(err):
+                    logger.warning("list_tables connection error, retrying: %s", err)
+                    if entry is not None:
+                        _evict_cached_client(config, entry.client)
+                    continue
+                raise
+            finally:
                 if entry is not None:
-                    _evict_cached_client(config, entry.client)
-                continue
-            if page_token and claimed_page_state is not None:
-                _restore_page_token(page_token, claimed_page_state)
-                claimed_page_state = None
-            raise
-        finally:
-            if entry is not None:
-                _release_client_entry(entry)
+                    _release_client_entry(entry)
+    except BaseException:
+        if owns_page_token_transaction and page_token and claimed_page_state is not None:
+            _restore_page_token(page_token, claimed_page_state)
+        raise
+
+    try:
+        if not owns_page_token_transaction:
+            return prepared_result
+        if prepared_result.pending_page_token is not None:
+            _commit_page_token(prepared_result.pending_page_token)
+        return prepared_result.response
+    except BaseException:
+        if owns_page_token_transaction and page_token and claimed_page_state is not None:
+            _restore_page_token(page_token, claimed_page_state)
+        raise
 
 
 @wraps(list_tables)
@@ -1307,17 +1389,41 @@ async def list_tables_async(
 ) -> str:
     overrides = await _get_client_config_overrides_for_tool()
     config = _resolve_client_config(overrides)
-    future = METADATA_EXECUTOR.submit(
-        _list_tables_with_config,
-        config,
-        database,
-        like,
-        not_like,
-        page_token,
-        page_size,
-        include_detailed_columns,
+    claimed_page_state = (
+        _claim_page_token_for_request(
+            page_token,
+            database,
+            like,
+            not_like,
+            include_detailed_columns,
+        )
+        if page_token
+        else None
     )
-    return await asyncio.wrap_future(future)
+    completed = False
+    try:
+        future = METADATA_EXECUTOR.submit(
+            _list_tables_with_config,
+            config,
+            database,
+            like,
+            not_like,
+            page_token,
+            page_size,
+            include_detailed_columns,
+            claimed_page_state,
+        )
+        prepared_result = await asyncio.wrap_future(future)
+        if isinstance(prepared_result, str):
+            completed = True
+            return prepared_result
+        if prepared_result.pending_page_token is not None:
+            _commit_page_token(prepared_result.pending_page_token)
+        completed = True
+        return prepared_result.response
+    finally:
+        if not completed and page_token and claimed_page_state is not None:
+            _restore_page_token(page_token, claimed_page_state)
 
 
 def _list_tables_impl(
@@ -1328,8 +1434,8 @@ def _list_tables_impl(
     page_token: Optional[str],
     page_size: int,
     include_detailed_columns: bool,
-    claimed_page_state: Optional[dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    claimed_page_state: object = None,
+) -> _PreparedListTablesResult:
     """Inner implementation of list_tables, separated for retry logic."""
     if claimed_page_state is not None:
         table_names = claimed_page_state["table_names"]
@@ -1344,11 +1450,12 @@ def _list_tables_impl(
             include_detailed_columns,
         )
 
-        next_page_token = None
+        pending_page_token = None
         if has_more:
-            next_page_token = create_page_token(
+            pending_page_token = _prepare_page_token(
                 database, like, not_like, table_names, end_idx, include_detailed_columns
             )
+        next_page_token = pending_page_token.token if pending_page_token else None
 
         logger.info(
             "Returned page with %s tables (total: %s), next_page_token=%s",
@@ -1356,11 +1463,14 @@ def _list_tables_impl(
             len(table_names),
             next_page_token,
         )
-        return _serialize_tool_result({
-            "tables": [asdict(table) for table in tables],
-            "next_page_token": next_page_token,
-            "total_tables": len(table_names),
-        })
+        return _PreparedListTablesResult(
+            response=_serialize_tool_result({
+                "tables": [asdict(table) for table in tables],
+                "next_page_token": next_page_token,
+                "total_tables": len(table_names),
+            }),
+            pending_page_token=pending_page_token,
+        )
 
     table_names = fetch_table_names_from_system(client, database, like, not_like)
 
@@ -1374,11 +1484,12 @@ def _list_tables_impl(
         include_detailed_columns,
     )
 
-    next_page_token = None
+    pending_page_token = None
     if has_more:
-        next_page_token = create_page_token(
+        pending_page_token = _prepare_page_token(
             database, like, not_like, table_names, end_idx, include_detailed_columns
         )
+    next_page_token = pending_page_token.token if pending_page_token else None
 
     logger.info(
         "Found %s tables, returning %s with next_page_token=%s",
@@ -1387,11 +1498,14 @@ def _list_tables_impl(
         next_page_token,
     )
 
-    return _serialize_tool_result({
-        "tables": [asdict(table) for table in tables],
-        "next_page_token": next_page_token,
-        "total_tables": len(table_names),
-    })
+    return _PreparedListTablesResult(
+        response=_serialize_tool_result({
+            "tables": [asdict(table) for table in tables],
+            "next_page_token": next_page_token,
+            "total_tables": len(table_names),
+        }),
+        pending_page_token=pending_page_token,
+    )
 
 
 # SQL comments and quoted text, blanked out before destructive-keyword matching.

--- a/mcp_clickhouse/mcp_server.py
+++ b/mcp_clickhouse/mcp_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import atexit
 import concurrent.futures
+import importlib
 import inspect
 import json
 import logging
@@ -14,6 +15,8 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass, field
+from functools import wraps
+from importlib.metadata import PackageNotFoundError, version as package_version
 from ipaddress import IPv4Network, IPv6Network
 from typing import Annotated, Any, Dict, List, Optional, Tuple
 
@@ -22,14 +25,17 @@ import simplejson
 from cachetools import TTLCache
 from clickhouse_connect.driver.binding import format_query_value
 from clickhouse_connect.driver.exceptions import OperationalError
-from dotenv import load_dotenv
-from fastmcp import FastMCP
+from dotenv import dotenv_values, load_dotenv
+from fastmcp import FastMCP, settings as fastmcp_settings
 from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Prompt
+from fastmcp.server.auth import AuthProvider
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from fastmcp.server.dependencies import get_context
+from fastmcp.server.http import create_sse_app
 from fastmcp.tools import Tool
-from pydantic import Field
+from fastmcp.utilities.auth import parse_scopes
+from pydantic import Field, TypeAdapter
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
@@ -88,7 +94,58 @@ class _ActiveQueryState:
     cancelled: bool = False
 
 
+def _get_mcp_server_version() -> str:
+    """Return the installed package version or an explicit unknown marker."""
+    try:
+        return package_version("mcp-clickhouse")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _is_legacy_auth_name(name: str) -> bool:
+    return name.casefold().startswith("fastmcp_server_auth")
+
+
+def _find_default_dotenv() -> str:
+    """Find the nearest .env at or above the installed package directory."""
+    directory = os.path.dirname(os.path.realpath(__file__))
+    while True:
+        env_file = os.path.join(directory, ".env")
+        if os.path.isfile(env_file):
+            return env_file
+        parent = os.path.dirname(directory)
+        if parent == directory:
+            return ""
+        directory = parent
+
+
+def _load_default_dotenv() -> None:
+    """Load repository settings while preserving process auth precedence."""
+    auth_snapshot = {
+        name: value
+        for name, value in os.environ.items()
+        if _is_legacy_auth_name(name)
+    }
+    auth_process_names = {name.casefold() for name in auth_snapshot}
+    env_file_snapshot = {
+        name: value
+        for name, value in os.environ.items()
+        if name.casefold() == "fastmcp_env_file"
+    }
+    try:
+        load_dotenv(dotenv_path=_find_default_dotenv())
+    finally:
+        for name in tuple(os.environ):
+            if name.casefold() == "fastmcp_env_file" or (
+                _is_legacy_auth_name(name) and name.casefold() in auth_process_names
+            ):
+                del os.environ[name]
+        os.environ.update(auth_snapshot)
+        os.environ.update(env_file_snapshot)
+
+
 MCP_SERVER_NAME = "mcp-clickhouse"
+MCP_SERVER_VERSION = _get_mcp_server_version()
 CLIENT_CONFIG_OVERRIDES_KEY = "clickhouse_client_config_overrides"
 _CLIENT_CONFIG_OVERRIDES_UNSET = object()
 _NESTED_CLIENT_CONFIG_KEYS = ("settings", "generic_args")
@@ -100,10 +157,12 @@ logging.basicConfig(
 )
 logger = logging.getLogger(MCP_SERVER_NAME)
 
-load_dotenv()
+_load_default_dotenv()
 
 _max_workers = get_mcp_config().max_workers
 QUERY_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=_max_workers)
+_METADATA_MAX_WORKERS = max(1, min(4, _max_workers))
+METADATA_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=_METADATA_MAX_WORKERS)
 CANCELLATION_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=2)
 HEALTH_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 _QUERY_CANCELLATION_WAIT_SECONDS = 1.0
@@ -123,23 +182,380 @@ _logged_health_probe_futures: weakref.WeakSet[concurrent.futures.Future] = weakr
 
 _HTTP_TRANSPORTS = (TransportType.HTTP.value, "streamable-http", TransportType.SSE.value)
 _BUILTIN_HTTP_RAW_CLIENT = ContextVar("builtin_http_raw_client", default=False)
+_SSE_DEPRECATION_MESSAGE = (
+    "The legacy HTTP+SSE transport is deprecated. Use "
+    "CLICKHOUSE_MCP_SERVER_TRANSPORT=http for Streamable HTTP."
+)
+
+_LEGACY_AUTH_PROVIDER_ENV: dict[str, tuple[str, tuple[str, ...]]] = {
+    "fastmcp.server.auth.providers.auth0.Auth0Provider": (
+        "AUTH0_",
+        (
+            "config_url",
+            "client_id",
+            "client_secret",
+            "audience",
+            "base_url",
+            "issuer_url",
+            "redirect_path",
+            "required_scopes",
+            "allowed_client_redirect_uris",
+            "jwt_signing_key",
+        ),
+    ),
+    "fastmcp.server.auth.providers.aws.AWSCognitoProvider": (
+        "AWS_COGNITO_",
+        (
+            "user_pool_id",
+            "aws_region",
+            "client_id",
+            "client_secret",
+            "base_url",
+            "issuer_url",
+            "redirect_path",
+            "required_scopes",
+            "allowed_client_redirect_uris",
+            "jwt_signing_key",
+        ),
+    ),
+    "fastmcp.server.auth.providers.azure.AzureProvider": (
+        "AZURE_",
+        (
+            "client_id",
+            "client_secret",
+            "tenant_id",
+            "identifier_uri",
+            "base_url",
+            "issuer_url",
+            "redirect_path",
+            "required_scopes",
+            "additional_authorize_scopes",
+            "allowed_client_redirect_uris",
+            "jwt_signing_key",
+            "base_authority",
+        ),
+    ),
+    "fastmcp.server.auth.providers.descope.DescopeProvider": (
+        "DESCOPEPROVIDER_",
+        ("config_url", "project_id", "descope_base_url", "base_url", "required_scopes"),
+    ),
+    "fastmcp.server.auth.providers.discord.DiscordProvider": (
+        "DISCORD_",
+        (
+            "client_id",
+            "client_secret",
+            "base_url",
+            "issuer_url",
+            "redirect_path",
+            "required_scopes",
+            "timeout_seconds",
+            "allowed_client_redirect_uris",
+            "jwt_signing_key",
+        ),
+    ),
+    "fastmcp.server.auth.providers.github.GitHubProvider": (
+        "GITHUB_",
+        (
+            "client_id",
+            "client_secret",
+            "base_url",
+            "issuer_url",
+            "redirect_path",
+            "required_scopes",
+            "timeout_seconds",
+            "allowed_client_redirect_uris",
+            "jwt_signing_key",
+        ),
+    ),
+    "fastmcp.server.auth.providers.google.GoogleProvider": (
+        "GOOGLE_",
+        (
+            "client_id",
+            "client_secret",
+            "base_url",
+            "issuer_url",
+            "redirect_path",
+            "required_scopes",
+            "timeout_seconds",
+            "allowed_client_redirect_uris",
+            "jwt_signing_key",
+        ),
+    ),
+    "fastmcp.server.auth.providers.introspection.IntrospectionTokenVerifier": (
+        "INTROSPECTION_",
+        (
+            "introspection_url",
+            "client_id",
+            "client_secret",
+            "timeout_seconds",
+            "required_scopes",
+            "base_url",
+        ),
+    ),
+    "fastmcp.server.auth.providers.jwt.JWTVerifier": (
+        "JWT_",
+        (
+            "public_key",
+            "jwks_uri",
+            "issuer",
+            "algorithm",
+            "audience",
+            "required_scopes",
+            "base_url",
+        ),
+    ),
+    "fastmcp.server.auth.providers.oci.OCIProvider": (
+        "OCI_",
+        (
+            "config_url",
+            "client_id",
+            "client_secret",
+            "audience",
+            "base_url",
+            "issuer_url",
+            "redirect_path",
+            "required_scopes",
+            "allowed_client_redirect_uris",
+            "jwt_signing_key",
+        ),
+    ),
+    "fastmcp.server.auth.providers.scalekit.ScalekitProvider": (
+        "SCALEKITPROVIDER_",
+        ("environment_url", "resource_id", "base_url", "mcp_url", "required_scopes"),
+    ),
+    "fastmcp.server.auth.providers.supabase.SupabaseProvider": (
+        "SUPABASE_",
+        ("project_url", "base_url", "auth_route", "algorithm", "required_scopes"),
+    ),
+    "fastmcp.server.auth.providers.workos.WorkOSProvider": (
+        "WORKOS_",
+        (
+            "client_id",
+            "client_secret",
+            "authkit_domain",
+            "base_url",
+            "issuer_url",
+            "redirect_path",
+            "required_scopes",
+            "timeout_seconds",
+            "allowed_client_redirect_uris",
+            "jwt_signing_key",
+        ),
+    ),
+    "fastmcp.server.auth.providers.workos.AuthKitProvider": (
+        "AUTHKITPROVIDER_",
+        ("authkit_domain", "base_url", "required_scopes"),
+    ),
+}
+_AUTH_SCOPE_FIELDS = frozenset({"required_scopes", "additional_authorize_scopes"})
+_AUTH_JSON_LIST_FIELDS = frozenset({"allowed_client_redirect_uris"})
+_AUTH_INT_FIELDS = frozenset({"timeout_seconds"})
+_AUTH_INT_ADAPTER = TypeAdapter(int)
+_LEGACY_AUTH_SCOPE_DEFAULTS = {
+    "fastmcp.server.auth.providers.auth0.Auth0Provider": ["openid"],
+    "fastmcp.server.auth.providers.aws.AWSCognitoProvider": ["openid"],
+    "fastmcp.server.auth.providers.discord.DiscordProvider": ["identify"],
+    "fastmcp.server.auth.providers.github.GitHubProvider": ["user"],
+    "fastmcp.server.auth.providers.google.GoogleProvider": ["openid"],
+    "fastmcp.server.auth.providers.oci.OCIProvider": ["openid"],
+}
+_LEGACY_ZERO_TIMEOUT_DEFAULTS = frozenset(
+    {
+        "fastmcp.server.auth.providers.discord.DiscordProvider",
+        "fastmcp.server.auth.providers.github.GitHubProvider",
+        "fastmcp.server.auth.providers.google.GoogleProvider",
+        "fastmcp.server.auth.providers.workos.WorkOSProvider",
+    }
+)
+
+
+def _get_case_insensitive_value(
+    values: Mapping[str, Optional[str]], env_name: str
+) -> Optional[str]:
+    normalized_name = env_name.casefold()
+    matched_value = None
+    for configured_name, value in values.items():
+        if configured_name.casefold() == normalized_name:
+            matched_value = value
+    return matched_value
+
+
+def _get_legacy_auth_file_values() -> dict[str, Optional[str]]:
+    """Read FastMCP 2 auth settings without mutating the process environment."""
+    env_file = _get_case_insensitive_value(os.environ, "FASTMCP_ENV_FILE")
+    explicit_env_file = env_file is not None
+    values = dotenv_values(env_file if explicit_env_file else ".env")
+    return {
+        name: value
+        for name, value in values.items()
+        if _is_legacy_auth_name(name)
+        and (explicit_env_file or name.casefold() != "fastmcp_server_auth")
+    }
+
+
+def _get_legacy_auth_env(
+    env_name: str,
+    auth_file_values: Optional[Mapping[str, Optional[str]]] = None,
+) -> Optional[str]:
+    """Read a FastMCP 2 auth variable with process-first precedence."""
+    process_value = _get_case_insensitive_value(os.environ, env_name)
+    if process_value is not None:
+        return process_value
+    file_values = (
+        auth_file_values
+        if auth_file_values is not None
+        else _get_legacy_auth_file_values()
+    )
+    return _get_case_insensitive_value(file_values, env_name)
+
+
+def _parse_auth_provider_env_value(
+    provider_path: str,
+    field_name: str,
+    env_name: str,
+    value: str,
+) -> Any:
+    """Parse one legacy FastMCP auth provider environment value."""
+    try:
+        if field_name in _AUTH_SCOPE_FIELDS:
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                return parse_scopes(value)
+            if parsed is None:
+                return None
+            if isinstance(parsed, str) or (
+                isinstance(parsed, list)
+                and all(isinstance(item, str) for item in parsed)
+            ):
+                return parse_scopes(parsed)
+            raise ValueError
+        if field_name in _AUTH_JSON_LIST_FIELDS:
+            parsed = json.loads(value)
+            if parsed is None:
+                return None
+            if not isinstance(parsed, list) or not all(
+                isinstance(item, str) for item in parsed
+            ):
+                raise ValueError
+            return parsed
+        if (
+            provider_path == "fastmcp.server.auth.providers.jwt.JWTVerifier"
+            and field_name in {"issuer", "audience"}
+        ):
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                return value
+            if parsed is None:
+                return None
+            if isinstance(parsed, str):
+                return parsed
+            if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
+                raise ValueError
+            return parsed
+        if field_name in _AUTH_INT_FIELDS:
+            return _AUTH_INT_ADAPTER.validate_python(value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        raise ValueError(
+            f"Invalid {env_name} value for FastMCP auth provider {provider_path}"
+        ) from None
+    return value
+
+
+def _load_fastmcp_auth_provider(
+    provider_path: str,
+    *,
+    auth_file_values: Optional[Mapping[str, Optional[str]]] = None,
+) -> AuthProvider:
+    """Load a FastMCP 2 style auth provider configuration under FastMCP 4."""
+    if auth_file_values is None:
+        auth_file_values = _get_legacy_auth_file_values()
+
+    module_name, separator, class_name = provider_path.rpartition(".")
+    if not separator:
+        raise ValueError("FASTMCP_SERVER_AUTH must be a full AuthProvider class path")
+    try:
+        provider_class = getattr(importlib.import_module(module_name), class_name)
+    except (AttributeError, ImportError):
+        raise ValueError(f"Could not import FASTMCP_SERVER_AUTH provider {provider_path}") from None
+    if not inspect.isclass(provider_class) or not issubclass(provider_class, AuthProvider):
+        raise ValueError(f"FASTMCP_SERVER_AUTH provider {provider_path} is not an AuthProvider")
+
+    provider_config = _LEGACY_AUTH_PROVIDER_ENV.get(provider_path)
+    kwargs: dict[str, Any] = {}
+    if provider_config is not None:
+        prefix, fields = provider_config
+        for field_name in fields:
+            env_name = f"FASTMCP_SERVER_AUTH_{prefix}{field_name.upper()}"
+            value = _get_legacy_auth_env(env_name, auth_file_values)
+            if value is None:
+                continue
+            kwargs[field_name] = _parse_auth_provider_env_value(
+                provider_path,
+                field_name,
+                env_name,
+                value,
+            )
+
+    scope_default = _LEGACY_AUTH_SCOPE_DEFAULTS.get(provider_path)
+    if scope_default is not None and not kwargs.get("required_scopes"):
+        kwargs["required_scopes"] = scope_default
+    if provider_path in _LEGACY_ZERO_TIMEOUT_DEFAULTS and kwargs.get("timeout_seconds") == 0:
+        kwargs["timeout_seconds"] = 10
+    if (
+        provider_path == "fastmcp.server.auth.providers.aws.AWSCognitoProvider"
+        and kwargs.get("aws_region") == ""
+    ):
+        kwargs["aws_region"] = "eu-central-1"
+    if provider_path == (
+        "fastmcp.server.auth.providers.introspection.IntrospectionTokenVerifier"
+    ):
+        prefix = _LEGACY_AUTH_PROVIDER_ENV[provider_path][0]
+        for required_field in ("introspection_url", "client_id", "client_secret"):
+            if not kwargs.get(required_field):
+                env_name = f"FASTMCP_SERVER_AUTH_{prefix}{required_field.upper()}"
+                raise ValueError(
+                    f"{env_name} is required for FastMCP auth provider {provider_path}"
+                )
+
+    if (
+        provider_path == "fastmcp.server.auth.providers.supabase.SupabaseProvider"
+        and str(kwargs.get("algorithm", "")).upper() == "HS256"
+    ):
+        raise ValueError(
+            "FASTMCP_SERVER_AUTH_SUPABASE_ALGORITHM=HS256 is not supported by FastMCP 4. "
+            "Configure RS256 or ES256."
+        )
+
+    try:
+        provider = provider_class(**kwargs)
+    except Exception as exc:
+        raise ValueError(
+            f"Invalid FASTMCP_SERVER_AUTH configuration for provider {provider_path} "
+            f"({type(exc).__name__})"
+        ) from None
+    return provider
 
 
 def _resolve_auth(mcp_config, transport: Optional[str] = None) -> Dict[str, Any]:
     """Resolve FastMCP auth kwargs for the requested transport.
 
-    An empty return dict omits the `auth` kwarg so FastMCP auto-detects its
-    provider from FASTMCP_SERVER_AUTH / FASTMCP_SERVER_AUTH_* env vars.
-    Returning {"auth": None} instead explicitly disables auth.
+    Returning {"auth": None} explicitly disables auth. FastMCP 4 removed
+    environment provider loading, so this server retains the documented
+    FastMCP 2 environment contract through a compatibility loader.
     """
     transport = transport or mcp_config.server_transport
     if transport not in _HTTP_TRANSPORTS:
         return {}
 
+    auth_file_values = _get_legacy_auth_file_values()
+    provider_path = _get_legacy_auth_env("FASTMCP_SERVER_AUTH", auth_file_values)
+
     configured = {
         "CLICKHOUSE_MCP_AUTH_DISABLED": mcp_config.auth_disabled,
         "CLICKHOUSE_MCP_AUTH_TOKEN": bool(mcp_config.auth_token),
-        "FASTMCP_SERVER_AUTH": bool(os.getenv("FASTMCP_SERVER_AUTH")),
+        "FASTMCP_SERVER_AUTH": bool(provider_path),
     }
     active = [name for name, is_set in configured.items() if is_set]
 
@@ -172,11 +588,14 @@ def _resolve_auth(mcp_config, transport: Optional[str] = None) -> Dict[str, Any]
         logger.info("Authentication enabled for HTTP/SSE transport (static bearer token)")
         return {"auth": verifier}
 
-    logger.info(
-        "Authentication delegated to FastMCP provider: %s", os.getenv("FASTMCP_SERVER_AUTH")
-    )
-    # Return empty kwargs so FastMCP auto-loads from FASTMCP_SERVER_AUTH_* env vars.
-    return {}
+    assert provider_path is not None
+    logger.info("Authentication delegated to FastMCP provider: %s", provider_path)
+    return {
+        "auth": _load_fastmcp_auth_provider(
+            provider_path,
+            auth_file_values=auth_file_values,
+        )
+    }
 
 
 def _proxy_header_trusted_hosts(
@@ -208,6 +627,8 @@ class ClickHouseFastMCP(FastMCP):
         upstream_http_app = super().http_app
         bound_args = inspect.signature(upstream_http_app).bind_partial(*args, **kwargs)
         transport = bound_args.arguments.get("transport", TransportType.HTTP.value)
+        if transport == TransportType.SSE.value:
+            logger.warning(_SSE_DEPRECATION_MESSAGE)
         mcp_config = get_mcp_config()
         trusted_proxies = mcp_config.trusted_proxies
         if _BUILTIN_HTTP_RAW_CLIENT.get():
@@ -231,9 +652,10 @@ class ClickHouseFastMCP(FastMCP):
         else:
             app_auth = original_auth
 
+        bound_args.arguments["host_origin_protection"] = False
         self.auth = app_auth
         try:
-            app = upstream_http_app(*args, **kwargs)
+            app = upstream_http_app(*bound_args.args, **bound_args.kwargs)
         finally:
             self.auth = original_auth
         if getattr(app.state, "path", None) == "/health":
@@ -258,26 +680,45 @@ class ClickHouseFastMCP(FastMCP):
         *,
         raw_client_address_preserved: bool = False,
     ) -> Any:
-        """Create a secured SSE app.
-
-        FastMCP 2.12 and 2.13 build this app without going through http_app,
-        skipping auth and transport validation. Deprecated upstream; prefer
-        http_app(transport="sse"). Intended for startup-time construction: the
-        temporary message_path settings mutation is not concurrency-safe.
-        """
-        settings = self._deprecated_settings
-        original_message_path = settings.message_path
-        if message_path is not None:
-            settings.message_path = message_path
-        try:
-            return self.http_app(
-                path=path,
-                middleware=middleware,
-                transport=TransportType.SSE.value,
-                raw_client_address_preserved=raw_client_address_preserved,
+        """Create a secured legacy SSE app."""
+        logger.warning(_SSE_DEPRECATION_MESSAGE)
+        mcp_config = get_mcp_config()
+        trusted_proxies = mcp_config.trusted_proxies
+        if trusted_proxies and not raw_client_address_preserved:
+            raise ValueError(
+                "CLICKHOUSE_MCP_TRUSTED_PROXIES requires a raw ASGI client address. "
+                "Disable proxy-header processing in the outer ASGI server and pass "
+                "raw_client_address_preserved=True."
             )
-        finally:
-            settings.message_path = original_message_path
+
+        sse_path = path or fastmcp_settings.sse_path
+        resolved_message_path = message_path or fastmcp_settings.message_path
+        if sse_path == "/health" or resolved_message_path == "/health":
+            raise ValueError(
+                "MCP transport path cannot be /health because that path is reserved "
+                "for the public health endpoint"
+            )
+        auth_kwargs = _resolve_auth(mcp_config, transport=TransportType.SSE.value)
+        app_auth = auth_kwargs.get("auth", self.auth)
+        if app_auth is None and "auth" not in auth_kwargs:
+            raise ValueError("FASTMCP_SERVER_AUTH did not create an authentication provider")
+
+        app = create_sse_app(
+            server=self,
+            message_path=resolved_message_path,
+            sse_path=sse_path,
+            auth=app_auth,
+            debug=fastmcp_settings.debug,
+            middleware=middleware,
+        )
+        if trusted_proxies:
+            app.add_middleware(
+                ProxyHeadersMiddleware,
+                trusted_hosts=_proxy_header_trusted_hosts(trusted_proxies),
+            )
+        for configured_middleware in transport_security_middleware(mcp_config):
+            app.add_middleware(configured_middleware.cls, **configured_middleware.kwargs)
+        return app
 
     def streamable_http_app(
         self,
@@ -333,6 +774,7 @@ class ClickHouseFastMCP(FastMCP):
 
 mcp = ClickHouseFastMCP(
     name=MCP_SERVER_NAME,
+    version=MCP_SERVER_VERSION,
     instructions=CLICKHOUSE_SERVER_INSTRUCTIONS,
 )
 _chdb_client = None
@@ -550,8 +992,12 @@ else:
 
 def list_databases() -> str:
     """List available ClickHouse databases"""
+    return _list_databases_with_config(_resolve_client_config())
+
+
+def _list_databases_with_config(config: dict[str, Any]) -> str:
+    """List databases with a resolved client configuration."""
     logger.info("Listing all databases")
-    config = _resolve_client_config()
 
     for attempt in range(2):
         entry = None
@@ -581,9 +1027,18 @@ def list_databases() -> str:
     return _serialize_tool_result(databases)
 
 
-# Store pagination state for list_tables with 1-hour expiry
-# Using TTLCache from cachetools to automatically expire entries after 1 hour
+@wraps(list_databases)
+async def list_databases_async() -> str:
+    overrides = await _get_client_config_overrides_for_tool()
+    config = _resolve_client_config(overrides)
+    future = METADATA_EXECUTOR.submit(_list_databases_with_config, config)
+    return await asyncio.wrap_future(future)
+
+
+# Store pagination state for list_tables with an absolute 1-hour expiry.
 table_pagination_cache: TTLCache = TTLCache(maxsize=100, ttl=3600)  # 3600 seconds = 1 hour
+_table_pagination_cache_lock = threading.Lock()
+_PAGE_TOKEN_EXPIRES_AT = "_expires_at"
 
 
 def fetch_table_names_from_system(
@@ -696,15 +1151,39 @@ def create_page_token(
         New page token
     """
     token = str(uuid.uuid4())
-    table_pagination_cache[token] = {
-        "database": database,
-        "like": like,
-        "not_like": not_like,
-        "table_names": table_names,
-        "start_idx": end_idx,
-        "include_detailed_columns": include_detailed_columns,
-    }
+    with _table_pagination_cache_lock:
+        expires_at = table_pagination_cache.timer() + table_pagination_cache.ttl
+        table_pagination_cache[token] = {
+            "database": database,
+            "like": like,
+            "not_like": not_like,
+            "table_names": table_names,
+            "start_idx": end_idx,
+            "include_detailed_columns": include_detailed_columns,
+            _PAGE_TOKEN_EXPIRES_AT: expires_at,
+        }
     return token
+
+
+def _claim_page_token(page_token: str) -> Optional[dict[str, Any]]:
+    """Atomically claim a single-use pagination token."""
+    with _table_pagination_cache_lock:
+        state = table_pagination_cache.pop(page_token, None)
+        if state is None:
+            return None
+        expires_at = state.get(_PAGE_TOKEN_EXPIRES_AT)
+        if expires_at is not None and expires_at <= table_pagination_cache.timer():
+            return None
+        return state
+
+
+def _restore_page_token(page_token: str, state: dict[str, Any]) -> None:
+    """Restore a claimed pagination token unless another value already exists."""
+    with _table_pagination_cache_lock:
+        expires_at = state.get(_PAGE_TOKEN_EXPIRES_AT)
+        if expires_at is not None and expires_at <= table_pagination_cache.timer():
+            return
+        table_pagination_cache.setdefault(page_token, state)
 
 
 def list_tables(
@@ -720,12 +1199,13 @@ def list_tables(
 
     Integers outside [-9007199254740991, 9007199254740991] in table metadata are
     returned as decimal strings.
+    Pagination tokens are single-use and retained for up to one hour.
 
     Args:
         database: The database to list tables from
         like: Optional LIKE pattern to filter table names
         not_like: Optional NOT LIKE pattern to exclude table names
-        page_token: Token for pagination, obtained from a previous call
+        page_token: Single-use token from a previous call, retained for up to one hour
         page_size: Number of tables to return per page (default: 50, must be greater than 0)
         include_detailed_columns: Whether to include detailed column metadata (default: True).
             When False, the columns array will be empty but create_table_query still contains
@@ -740,6 +1220,47 @@ def list_tables(
     if page_size <= 0:
         raise ToolError("page_size must be greater than 0")
 
+    return _list_tables_with_config(
+        _resolve_client_config(),
+        database,
+        like,
+        not_like,
+        page_token,
+        page_size,
+        include_detailed_columns,
+    )
+
+
+def _list_tables_with_config(
+    config: dict[str, Any],
+    database: str,
+    like: Optional[str],
+    not_like: Optional[str],
+    page_token: Optional[str],
+    page_size: int,
+    include_detailed_columns: bool,
+) -> str:
+    """List tables with a resolved client configuration."""
+    if page_size <= 0:
+        raise ToolError("page_size must be greater than 0")
+
+    claimed_page_state = _claim_page_token(page_token) if page_token else None
+    if claimed_page_state is not None:
+        cached_include_detailed = claimed_page_state.get("include_detailed_columns", True)
+        if (
+            claimed_page_state["database"] != database
+            or claimed_page_state["like"] != like
+            or claimed_page_state["not_like"] != not_like
+            or cached_include_detailed != include_detailed_columns
+        ):
+            _restore_page_token(page_token, claimed_page_state)
+            claimed_page_state = None
+            logger.warning(
+                "Page token %s is for a different database, filter, or metadata setting. "
+                "Ignoring token and starting from beginning.",
+                page_token,
+            )
+
     logger.info(
         "Listing tables in database '%s' with like=%s, not_like=%s, "
         "page_token=%s, page_size=%s, include_detailed_columns=%s",
@@ -750,7 +1271,6 @@ def list_tables(
         page_size,
         include_detailed_columns,
     )
-    config = _resolve_client_config()
 
     for attempt in range(2):
         entry = None
@@ -759,7 +1279,7 @@ def list_tables(
             client = entry.client
             return _list_tables_impl(
                 client, database, like, not_like, page_token,
-                page_size, include_detailed_columns,
+                page_size, include_detailed_columns, claimed_page_state,
             )
         except Exception as err:
             if attempt == 0 and _is_connection_error(err):
@@ -767,10 +1287,37 @@ def list_tables(
                 if entry is not None:
                     _evict_cached_client(config, entry.client)
                 continue
+            if page_token and claimed_page_state is not None:
+                _restore_page_token(page_token, claimed_page_state)
+                claimed_page_state = None
             raise
         finally:
             if entry is not None:
                 _release_client_entry(entry)
+
+
+@wraps(list_tables)
+async def list_tables_async(
+    database: str,
+    like: Optional[str] = None,
+    not_like: Optional[str] = None,
+    page_token: Optional[str] = None,
+    page_size: Annotated[int, Field(gt=0)] = 50,
+    include_detailed_columns: bool = True,
+) -> str:
+    overrides = await _get_client_config_overrides_for_tool()
+    config = _resolve_client_config(overrides)
+    future = METADATA_EXECUTOR.submit(
+        _list_tables_with_config,
+        config,
+        database,
+        like,
+        not_like,
+        page_token,
+        page_size,
+        include_detailed_columns,
+    )
+    return await asyncio.wrap_future(future)
 
 
 def _list_tables_impl(
@@ -781,56 +1328,39 @@ def _list_tables_impl(
     page_token: Optional[str],
     page_size: int,
     include_detailed_columns: bool,
+    claimed_page_state: Optional[dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Inner implementation of list_tables, separated for retry logic."""
-    if page_token and page_token in table_pagination_cache:
-        cached_state = table_pagination_cache[page_token]
-        cached_include_detailed = cached_state.get("include_detailed_columns", True)
+    if claimed_page_state is not None:
+        table_names = claimed_page_state["table_names"]
+        start_idx = claimed_page_state["start_idx"]
 
-        if (
-            cached_state["database"] != database
-            or cached_state["like"] != like
-            or cached_state["not_like"] != not_like
-            or cached_include_detailed != include_detailed_columns
-        ):
-            logger.warning(
-                "Page token %s is for a different database, filter, or metadata setting. "
-                "Ignoring token and starting from beginning.",
-                page_token,
-            )
-            page_token = None
-        else:
-            table_names = cached_state["table_names"]
-            start_idx = cached_state["start_idx"]
+        tables, end_idx, has_more = get_paginated_table_data(
+            client,
+            database,
+            table_names,
+            start_idx,
+            page_size,
+            include_detailed_columns,
+        )
 
-            tables, end_idx, has_more = get_paginated_table_data(
-                client,
-                database,
-                table_names,
-                start_idx,
-                page_size,
-                include_detailed_columns,
+        next_page_token = None
+        if has_more:
+            next_page_token = create_page_token(
+                database, like, not_like, table_names, end_idx, include_detailed_columns
             )
 
-            next_page_token = None
-            if has_more:
-                next_page_token = create_page_token(
-                    database, like, not_like, table_names, end_idx, include_detailed_columns
-                )
-
-            del table_pagination_cache[page_token]
-
-            logger.info(
-                "Returned page with %s tables (total: %s), next_page_token=%s",
-                len(tables),
-                len(table_names),
-                next_page_token,
-            )
-            return _serialize_tool_result({
-                "tables": [asdict(table) for table in tables],
-                "next_page_token": next_page_token,
-                "total_tables": len(table_names),
-            })
+        logger.info(
+            "Returned page with %s tables (total: %s), next_page_token=%s",
+            len(tables),
+            len(table_names),
+            next_page_token,
+        )
+        return _serialize_tool_result({
+            "tables": [asdict(table) for table in tables],
+            "next_page_token": next_page_token,
+            "total_tables": len(table_names),
+        })
 
     table_names = fetch_table_names_from_system(client, database, like, not_like)
 
@@ -1198,7 +1728,8 @@ async def run_query_async(query: str) -> str:
     """
     logger.info(f"Executing query: {query}")
 
-    client_config = _resolve_client_config()
+    overrides = await _get_client_config_overrides_for_tool()
+    client_config = _resolve_client_config(overrides)
     query_id = str(uuid.uuid4())
     state = _register_active_query(query_id, query)
 
@@ -1417,13 +1948,45 @@ def _snapshot_client_config_overrides(overrides: Any) -> Optional[dict[str, Any]
     return snapshot
 
 
+def _request_client_config_overrides(ctx: Any) -> Optional[dict[str, Any]]:
+    """Read request-local ClickHouse overrides from a FastMCP context."""
+    request_state = getattr(ctx, "_request_state", None)
+    make_state_key = getattr(ctx, "_make_state_key", None)
+    if not isinstance(request_state, Mapping) or not callable(make_state_key):
+        raise RuntimeError(
+            "FastMCP request-local state API is unavailable; validate the FastMCP version"
+        )
+    overrides = request_state.get(make_state_key(CLIENT_CONFIG_OVERRIDES_KEY))
+    return _snapshot_client_config_overrides(overrides)
+
+
 def _get_client_config_overrides() -> Optional[dict[str, Any]]:
     """Capture ClickHouse client overrides from the active FastMCP request."""
     try:
         ctx = get_context()
     except RuntimeError:
         return None
-    return _snapshot_client_config_overrides(ctx.get_state(CLIENT_CONFIG_OVERRIDES_KEY))
+    # FastMCP 4.0 get_state() falls back to session state. There is no public
+    # request-only accessor. Validate this private adapter before a minor upgrade.
+    return _request_client_config_overrides(ctx)
+
+
+async def _get_client_config_overrides_for_tool() -> Optional[dict[str, Any]]:
+    """Reject session-scoped overrides before an MCP-facing tool dispatch."""
+    try:
+        ctx = get_context()
+    except RuntimeError:
+        return None
+    overrides = _request_client_config_overrides(ctx)
+    if overrides is not None:
+        return overrides
+    session_value = await ctx.get_state(CLIENT_CONFIG_OVERRIDES_KEY)
+    if session_value is not None:
+        raise ToolError(
+            f"{CLIENT_CONFIG_OVERRIDES_KEY} must be request-scoped; middleware must call "
+            "Context.set_state(..., serializable=False)"
+        )
+    return None
 
 
 def _apply_client_config_overrides(
@@ -1461,7 +2024,7 @@ class _ResolvedClientConfig(dict):
 def _resolve_client_config(
     client_config_overrides: Any = _CLIENT_CONFIG_OVERRIDES_UNSET,
 ) -> _ResolvedClientConfig:
-    """Resolve the client config on the active request thread."""
+    """Resolve a client config from environment settings and explicit overrides."""
     if client_config_overrides is _CLIENT_CONFIG_OVERRIDES_UNSET:
         overrides = _get_client_config_overrides()
     else:
@@ -1735,6 +2298,7 @@ def _clear_client_cache():
 def _shutdown():
     # Drain every worker before closing the clients they may hold.
     QUERY_EXECUTOR.shutdown(wait=True)
+    METADATA_EXECUTOR.shutdown(wait=True)
     CANCELLATION_EXECUTOR.shutdown(wait=True)
     HEALTH_EXECUTOR.shutdown(wait=True)
     _clear_client_cache()
@@ -1993,8 +2557,8 @@ def _register_chdb_tools():
 
 
 if os.getenv("CLICKHOUSE_ENABLED", "true").lower() == "true":
-    mcp.add_tool(Tool.from_function(list_databases))
-    mcp.add_tool(Tool.from_function(list_tables))
+    mcp.add_tool(Tool.from_function(list_databases_async, name="list_databases"))
+    mcp.add_tool(Tool.from_function(list_tables_async, name="list_tables"))
     mcp.add_tool(
         Tool.from_function(
             run_query_async,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "mcp-clickhouse"
-version = "0.5.0"
+version = "0.6.0"
 description = "An MCP server for ClickHouse."
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-     "fastmcp>=2.12.3,<3.0.0",
+     "fastmcp>=4.0.0,<4.1.0",
      "python-dotenv>=1.0.1",
      "clickhouse-connect>=0.8.16",
      "truststore>=0.10",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.ClickHouse/mcp-clickhouse",
   "title": "ClickHouse",
   "description": "Official ClickHouse MCP server for querying and exploring ClickHouse clusters and chDB.",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "repository": {
     "url": "https://github.com/ClickHouse/mcp-clickhouse",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-clickhouse",
-      "version": "0.4.0",
+      "version": "0.6.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -96,7 +96,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/clickhouse/mcp-clickhouse:0.4.0",
+      "identifier": "ghcr.io/clickhouse/mcp-clickhouse:0.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -73,7 +73,7 @@
         },
         {
           "name": "CLICKHOUSE_ALLOW_DROP",
-          "description": "Allow destructive operations (DROP, TRUNCATE) when write access is also enabled",
+          "description": "Allow destructive operations (DROP, TRUNCATE, DELETE, UPDATE, REPLACE, CLEAR, and DETACH PERMANENTLY) when write access is also enabled",
           "format": "boolean",
           "default": "false",
           "isRequired": false
@@ -155,7 +155,7 @@
         },
         {
           "name": "CLICKHOUSE_ALLOW_DROP",
-          "description": "Allow destructive operations (DROP, TRUNCATE) when write access is also enabled",
+          "description": "Allow destructive operations (DROP, TRUNCATE, DELETE, UPDATE, REPLACE, CLEAR, and DETACH PERMANENTLY) when write access is also enabled",
           "format": "boolean",
           "default": "false",
           "isRequired": false

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -1,7 +1,47 @@
-import pytest
+import inspect
+import os
+import shutil
+import subprocess
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
+import pytest
+from fastmcp.server.auth import AuthProvider
+from fastmcp.server.auth.providers.azure import AzureProvider
+
+import mcp_clickhouse.mcp_server as mcp_server_module
 from mcp_clickhouse.mcp_env import MCPServerConfig
-from mcp_clickhouse.mcp_server import _resolve_auth
+from mcp_clickhouse.mcp_server import _load_fastmcp_auth_provider, _resolve_auth
+from mcp_clickhouse.mcp_server import (
+    _LEGACY_AUTH_PROVIDER_ENV,
+    _get_case_insensitive_value,
+    _load_default_dotenv,
+    _parse_auth_provider_env_value,
+)
+
+
+class RecordingAuthProvider(AuthProvider):
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+_EXPECTED_LEGACY_AUTH_PROVIDER_PATHS = {
+    "fastmcp.server.auth.providers.auth0.Auth0Provider",
+    "fastmcp.server.auth.providers.aws.AWSCognitoProvider",
+    "fastmcp.server.auth.providers.azure.AzureProvider",
+    "fastmcp.server.auth.providers.descope.DescopeProvider",
+    "fastmcp.server.auth.providers.discord.DiscordProvider",
+    "fastmcp.server.auth.providers.github.GitHubProvider",
+    "fastmcp.server.auth.providers.google.GoogleProvider",
+    "fastmcp.server.auth.providers.introspection.IntrospectionTokenVerifier",
+    "fastmcp.server.auth.providers.jwt.JWTVerifier",
+    "fastmcp.server.auth.providers.oci.OCIProvider",
+    "fastmcp.server.auth.providers.scalekit.ScalekitProvider",
+    "fastmcp.server.auth.providers.supabase.SupabaseProvider",
+    "fastmcp.server.auth.providers.workos.WorkOSProvider",
+    "fastmcp.server.auth.providers.workos.AuthKitProvider",
+}
 
 
 def test_auth_token_configuration(monkeypatch: pytest.MonkeyPatch):
@@ -72,21 +112,984 @@ def test_auth_token_with_sse_transport(monkeypatch: pytest.MonkeyPatch):
 
 
 def _clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    for var in (
+    auth_names = {
+        name
+        for name in mcp_server_module.os.environ
+        if name.casefold().startswith("fastmcp_server_auth")
+        or name.casefold() == "fastmcp_env_file"
+    }
+    auth_names.update(
+        {
+            "FASTMCP_SERVER_AUTH",
+            "fastmcp_server_auth",
+            "FASTMCP_ENV_FILE",
+            "fastmcp_env_file",
+        }
+    )
+    for prefix, fields in _LEGACY_AUTH_PROVIDER_ENV.values():
+        for field_name in fields:
+            env_name = f"FASTMCP_SERVER_AUTH_{prefix}{field_name.upper()}"
+            auth_names.update({env_name, env_name.lower()})
+    for var in auth_names | {
         "CLICKHOUSE_MCP_AUTH_TOKEN",
         "CLICKHOUSE_MCP_AUTH_DISABLED",
-        "FASTMCP_SERVER_AUTH",
-    ):
+    }:
         monkeypatch.delenv(var, raising=False)
 
 
-def test_resolve_auth_oauth_omits_auth_kwarg(monkeypatch: pytest.MonkeyPatch):
-    """FASTMCP_SERVER_AUTH alone returns empty kwargs (no `auth` key)."""
+def _delete_loaded_auth_env() -> None:
+    for name in tuple(mcp_server_module.os.environ):
+        if name.casefold().startswith("fastmcp_server_auth") or (
+            name.casefold() == "fastmcp_env_file"
+        ):
+            del mcp_server_module.os.environ[name]
+
+
+def test_resolve_auth_loads_oauth_provider(monkeypatch: pytest.MonkeyPatch):
     _clear_auth_env(monkeypatch)
     monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
     monkeypatch.setenv("FASTMCP_SERVER_AUTH", "fastmcp.server.auth.providers.jwt.JWTVerifier")
+    provider = RecordingAuthProvider()
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_load_fastmcp_auth_provider",
+        lambda _provider_path, **_kwargs: provider,
+    )
 
-    assert _resolve_auth(MCPServerConfig()) == {}
+    assert _resolve_auth(MCPServerConfig()) == {"auth": provider}
+
+
+@pytest.mark.parametrize(
+    ("env_file_name", "selector_name"),
+    [
+        ("FASTMCP_ENV_FILE", "FASTMCP_SERVER_AUTH"),
+        ("fastmcp_env_file", "fastmcp_server_auth"),
+    ],
+)
+def test_resolve_auth_loads_provider_selector_from_explicit_env_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    env_file_name,
+    selector_name,
+):
+    _clear_auth_env(monkeypatch)
+    provider_path = "fastmcp.server.auth.providers.jwt.JWTVerifier"
+    env_file = tmp_path / "fastmcp.env"
+    field_name = (
+        "fastmcp_server_auth_jwt_jwks_uri"
+        if selector_name.islower()
+        else "FASTMCP_SERVER_AUTH_JWT_JWKS_URI"
+    )
+    env_file.write_text(
+        f"{selector_name}={provider_path}\n"
+        f"{field_name}=https://explicit.example/jwks.json\n"
+    )
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    monkeypatch.setenv(env_file_name, str(env_file))
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(JWTVerifier=RecordingAuthProvider),
+    )
+
+    resolved = _resolve_auth(MCPServerConfig())
+
+    assert resolved["auth"].kwargs["jwks_uri"] == "https://explicit.example/jwks.json"
+
+
+def test_resolve_auth_loads_lowercase_provider_selector(monkeypatch: pytest.MonkeyPatch):
+    _clear_auth_env(monkeypatch)
+    provider_path = "example.auth.CustomProvider"
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    monkeypatch.setenv("fastmcp_server_auth", provider_path)
+    provider = RecordingAuthProvider()
+    load_provider = MagicMock(return_value=provider)
+    monkeypatch.setattr(mcp_server_module, "_load_fastmcp_auth_provider", load_provider)
+
+    assert _resolve_auth(MCPServerConfig()) == {"auth": provider}
+    assert load_provider.call_args.args == (provider_path,)
+
+
+def test_explicit_auth_file_does_not_pollute_clickhouse_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    _clear_auth_env(monkeypatch)
+    env_file = tmp_path / "fastmcp.env"
+    env_file.write_text(
+        "FASTMCP_SERVER_AUTH=example.auth.CustomProvider\n"
+        "CLICKHOUSE_MCP_AUTH_DISABLED=true\n"
+    )
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    monkeypatch.setenv("FASTMCP_ENV_FILE", str(env_file))
+    provider = RecordingAuthProvider()
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_load_fastmcp_auth_provider",
+        MagicMock(return_value=provider),
+    )
+
+    assert _resolve_auth(MCPServerConfig()) == {"auth": provider}
+    assert "CLICKHOUSE_MCP_AUTH_DISABLED" not in mcp_server_module.os.environ
+
+
+def test_default_dotenv_preserves_process_auth_and_loads_noncolliding_auth(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("fastmcp_server_auth", "process.Provider")
+    monkeypatch.setenv("fastmcp_server_auth_jwt_jwks_uri", "process-jwks")
+    monkeypatch.setenv("FASTMCP_ENV_FILE", "process.env")
+
+    def load_values(**_kwargs):
+        monkeypatch.setenv("FASTMCP_SERVER_AUTH", "file.Provider")
+        monkeypatch.setenv("FASTMCP_SERVER_AUTH_JWT_JWKS_URI", "file-jwks")
+        monkeypatch.setenv("FASTMCP_SERVER_AUTH_JWT_AUDIENCE", "file-audience")
+        monkeypatch.setenv("fastmcp_env_file", "file.env")
+        monkeypatch.setenv("CLICKHOUSE_HOST", "file-host")
+
+    load_default = MagicMock(side_effect=load_values)
+    monkeypatch.setattr(mcp_server_module, "load_dotenv", load_default)
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_find_default_dotenv",
+        lambda: "/package/.env",
+    )
+
+    _load_default_dotenv()
+
+    load_default.assert_called_once_with(dotenv_path="/package/.env")
+    assert mcp_server_module.os.environ["fastmcp_server_auth"] == "process.Provider"
+    assert (
+        mcp_server_module.os.environ["fastmcp_server_auth_jwt_jwks_uri"]
+        == "process-jwks"
+    )
+    assert mcp_server_module.os.environ["FASTMCP_ENV_FILE"] == "process.env"
+    assert "FASTMCP_SERVER_AUTH" not in mcp_server_module.os.environ
+    assert "FASTMCP_SERVER_AUTH_JWT_JWKS_URI" not in mcp_server_module.os.environ
+    assert mcp_server_module.os.environ["FASTMCP_SERVER_AUTH_JWT_AUDIENCE"] == "file-audience"
+    assert "fastmcp_env_file" not in mcp_server_module.os.environ
+    assert mcp_server_module.os.environ["CLICKHOUSE_HOST"] == "file-host"
+
+
+def test_default_dotenv_delegates_python_dotenv_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    _clear_auth_env(monkeypatch)
+    env_file = tmp_path / ".env"
+    env_file.write_text("CLICKHOUSE_HOST=file-host\n")
+    monkeypatch.delenv("CLICKHOUSE_HOST", raising=False)
+    monkeypatch.setenv("PYTHON_DOTENV_DISABLED", "true")
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_find_default_dotenv",
+        lambda: str(env_file),
+    )
+
+    _load_default_dotenv()
+
+    assert "CLICKHOUSE_HOST" not in mcp_server_module.os.environ
+
+
+def test_default_dotenv_discovery_walks_up_from_resolved_package_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    package_dir = tmp_path / "source" / "mcp_clickhouse"
+    package_dir.mkdir(parents=True)
+    (package_dir / ".env").mkdir()
+    env_file = package_dir.parent / ".env"
+    env_file.write_text("CLICKHOUSE_HOST=package-host\n")
+    monkeypatch.setattr(
+        mcp_server_module,
+        "__file__",
+        str(package_dir / "mcp_server.py"),
+    )
+
+    assert mcp_server_module._find_default_dotenv() == str(env_file)
+
+
+def test_default_dotenv_discovery_returns_empty_path_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(mcp_server_module.os.path, "isfile", lambda _path: False)
+
+    assert mcp_server_module._find_default_dotenv() == ""
+
+
+def _copy_isolated_package(tmp_path):
+    source_root = tmp_path / "source"
+    package_dir = source_root / "mcp_clickhouse"
+    shutil.copytree(
+        os.path.dirname(mcp_server_module.__file__),
+        package_dir,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+    return source_root
+
+
+def _isolated_launch_env(source_root):
+    child_env = {}
+    for name, value in os.environ.items():
+        normalized_name = name.casefold()
+        if normalized_name.startswith("fastmcp_") or normalized_name.startswith(
+            "python_dotenv"
+        ):
+            continue
+        if normalized_name in {
+            "clickhouse_mcp_auth_token",
+            "clickhouse_mcp_auth_disabled",
+        }:
+            continue
+        child_env[name] = value
+    child_env.update(
+        {
+            "PYTHONPATH": str(source_root),
+            "CLICKHOUSE_MCP_SERVER_TRANSPORT": "http",
+            "MCP_CLICKHOUSE_TRUSTSTORE_DISABLE": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    return child_env
+
+
+_IMPORT_COMMANDS = (
+    ("-m", "mcp_clickhouse.main"),
+    (
+        "-c",
+        "import os; import mcp_clickhouse.mcp_server; "
+        "print(os.getenv('FASTMCP_SERVER_AUTH'))",
+    ),
+)
+
+
+@pytest.mark.parametrize("import_command", _IMPORT_COMMANDS, ids=("module", "command"))
+def test_import_modes_ignore_hostile_cwd_dotenv_and_use_package_discovery(
+    tmp_path,
+    import_command,
+):
+    source_root = _copy_isolated_package(tmp_path)
+    trusted_provider = "trusted.example.MissingProvider"
+    hostile_provider = "hostile.example.MissingProvider"
+    (source_root / ".env").write_text(f"FASTMCP_SERVER_AUTH={trusted_provider}\n")
+    hostile_dir = tmp_path / "hostile"
+    hostile_dir.mkdir()
+    (hostile_dir / ".env").write_text(
+        f"FASTMCP_SERVER_AUTH={hostile_provider}\n"
+        "FASTMCP_SERVER_AUTH_JWT_PUBLIC_KEY=hostile-key\n"
+    )
+
+    result = subprocess.run(
+        [sys.executable, *import_command],
+        cwd=hostile_dir,
+        env=_isolated_launch_env(source_root),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+
+    if import_command[0] == "-m":
+        assert result.returncode != 0
+    else:
+        assert result.returncode == 0
+    assert trusted_provider in output
+    assert hostile_provider not in output
+
+
+@pytest.mark.parametrize("import_command", _IMPORT_COMMANDS, ids=("module", "command"))
+def test_import_modes_without_package_dotenv_fail_closed_from_hostile_cwd(
+    tmp_path,
+    import_command,
+):
+    source_root = _copy_isolated_package(tmp_path)
+    hostile_provider = "hostile.example.MissingProvider"
+    hostile_dir = tmp_path / "hostile"
+    hostile_dir.mkdir()
+    (hostile_dir / ".env").write_text(
+        f"FASTMCP_SERVER_AUTH={hostile_provider}\n"
+        "FASTMCP_SERVER_AUTH_JWT_PUBLIC_KEY=hostile-key\n"
+    )
+
+    result = subprocess.run(
+        [sys.executable, *import_command],
+        cwd=hostile_dir,
+        env=_isolated_launch_env(source_root),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+
+    if import_command[0] == "-m":
+        assert result.returncode != 0
+        assert "Authentication is required for HTTP/SSE transports" in output
+    else:
+        assert result.returncode == 0
+        assert result.stdout.strip() == "None"
+    assert hostile_provider not in output
+
+
+def test_module_dotenv_auth_loads_from_foreign_working_directory_without_redirect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    _clear_auth_env(monkeypatch)
+    provider_path = "fastmcp.server.auth.providers.jwt.JWTVerifier"
+    launch_dir = tmp_path / "launch"
+    launch_dir.mkdir()
+    redirected_file = tmp_path / "redirected.env"
+    redirected_file.write_text(
+        f"FASTMCP_SERVER_AUTH={provider_path}\n"
+        "FASTMCP_SERVER_AUTH_JWT_JWKS_URI=https://redirected.example/jwks.json\n"
+    )
+    module_file = tmp_path / "module.env"
+    module_file.write_text(
+        f"FASTMCP_ENV_FILE={redirected_file}\n"
+        f"FASTMCP_SERVER_AUTH={provider_path}\n"
+        "FASTMCP_SERVER_AUTH_JWT_JWKS_URI=https://first.example/jwks.json\n"
+        "fastmcp_server_auth_jwt_jwks_uri=https://module.example/jwks.json\n"
+    )
+    monkeypatch.chdir(launch_dir)
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_find_default_dotenv",
+        lambda: str(module_file),
+    )
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(JWTVerifier=RecordingAuthProvider),
+    )
+
+    try:
+        _load_default_dotenv()
+        resolved = _resolve_auth(MCPServerConfig())
+
+        assert "FASTMCP_ENV_FILE" not in mcp_server_module.os.environ
+        assert mcp_server_module.os.environ["FASTMCP_SERVER_AUTH"] == provider_path
+        assert resolved["auth"].kwargs["jwks_uri"] == "https://module.example/jwks.json"
+    finally:
+        _delete_loaded_auth_env()
+
+
+@pytest.mark.parametrize("explicit", [False, True])
+def test_lowercase_process_auth_value_wins_over_uppercase_file_value(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    explicit,
+):
+    _clear_auth_env(monkeypatch)
+    provider_path = "fastmcp.server.auth.providers.jwt.JWTVerifier"
+    env_file = tmp_path / ("fastmcp.env" if explicit else ".env")
+    env_file.write_text(
+        "FASTMCP_SERVER_AUTH_JWT_JWKS_URI=https://file.example/jwks.json\n"
+    )
+    if explicit:
+        monkeypatch.setenv("FASTMCP_ENV_FILE", str(env_file))
+    else:
+        monkeypatch.delenv("FASTMCP_ENV_FILE", raising=False)
+        monkeypatch.setattr(
+            mcp_server_module,
+            "_find_default_dotenv",
+            lambda: str(env_file),
+        )
+    monkeypatch.setenv(
+        "fastmcp_server_auth_jwt_jwks_uri",
+        "https://process.example/jwks.json",
+    )
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(JWTVerifier=RecordingAuthProvider),
+    )
+    try:
+        if not explicit:
+            _load_default_dotenv()
+
+        provider = _load_fastmcp_auth_provider(provider_path)
+
+        assert provider.kwargs["jwks_uri"] == "https://process.example/jwks.json"
+        assert "FASTMCP_SERVER_AUTH_JWT_JWKS_URI" not in mcp_server_module.os.environ
+    finally:
+        _delete_loaded_auth_env()
+
+
+def test_cwd_dotenv_provider_selector_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    _clear_auth_env(monkeypatch)
+    provider_path = "fastmcp.server.auth.providers.jwt.JWTVerifier"
+    (tmp_path / ".env").write_text(
+        f"FASTMCP_SERVER_AUTH={provider_path}\n"
+        "FASTMCP_SERVER_AUTH_JWT_JWKS_URI=https://implicit.example/jwks.json\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    with pytest.raises(ValueError, match="Authentication is required") as exc_info:
+        _resolve_auth(MCPServerConfig())
+
+    assert "https://implicit.example/jwks.json" not in str(exc_info.value)
+    assert "FASTMCP_SERVER_AUTH" not in mcp_server_module.os.environ
+
+
+@pytest.mark.parametrize("selector_source", ["process", "module"])
+def test_trusted_selector_uses_cwd_dotenv_provider_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    selector_source,
+):
+    _clear_auth_env(monkeypatch)
+    provider_path = "fastmcp.server.auth.providers.jwt.JWTVerifier"
+    launch_dir = tmp_path / "launch"
+    launch_dir.mkdir()
+    (launch_dir / ".env").write_text(
+        "FASTMCP_SERVER_AUTH_JWT_JWKS_URI=https://cwd.example/jwks.json\n"
+    )
+    monkeypatch.chdir(launch_dir)
+    monkeypatch.setenv("CLICKHOUSE_MCP_SERVER_TRANSPORT", "http")
+    try:
+        if selector_source == "process":
+            monkeypatch.setenv("FASTMCP_SERVER_AUTH", provider_path)
+        else:
+            module_file = tmp_path / "module.env"
+            module_file.write_text(f"FASTMCP_SERVER_AUTH={provider_path}\n")
+            monkeypatch.setattr(
+                mcp_server_module,
+                "_find_default_dotenv",
+                lambda: str(module_file),
+            )
+            _load_default_dotenv()
+        monkeypatch.setattr(
+            mcp_server_module.importlib,
+            "import_module",
+            lambda _module_name: SimpleNamespace(JWTVerifier=RecordingAuthProvider),
+        )
+
+        resolved = _resolve_auth(MCPServerConfig())
+
+        assert resolved["auth"].kwargs["jwks_uri"] == "https://cwd.example/jwks.json"
+    finally:
+        _delete_loaded_auth_env()
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"FASTMCP_SERVER_AUTH": "first", "fastmcp_server_auth": "second"},
+        {"fastmcp_server_auth": "first", "FASTMCP_SERVER_AUTH": "second"},
+    ],
+)
+def test_case_insensitive_auth_lookup_uses_last_matching_key(values):
+    assert _get_case_insensitive_value(values, "FASTMCP_SERVER_AUTH") == "second"
+
+
+def test_load_auth_provider_preserves_legacy_azure_environment(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    provider_path = "fastmcp.server.auth.providers.azure.AzureProvider"
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(AzureProvider=RecordingAuthProvider),
+    )
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_AZURE_CLIENT_ID", "client-id")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_AZURE_CLIENT_SECRET", "secret-value")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_AZURE_TENANT_ID", "tenant-id")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_AZURE_BASE_URL", "https://mcp.example.com")
+    monkeypatch.setenv(
+        "FASTMCP_SERVER_AUTH_AZURE_REQUIRED_SCOPES",
+        "read access_as_user",
+    )
+    monkeypatch.setenv(
+        "FASTMCP_SERVER_AUTH_AZURE_ADDITIONAL_AUTHORIZE_SCOPES",
+        '["openid", "profile"]',
+    )
+    monkeypatch.setenv(
+        "FASTMCP_SERVER_AUTH_AZURE_ALLOWED_CLIENT_REDIRECT_URIS",
+        '["https://client.example/callback"]',
+    )
+
+    provider = _load_fastmcp_auth_provider(provider_path)
+
+    assert provider.kwargs == {
+        "client_id": "client-id",
+        "client_secret": "secret-value",
+        "tenant_id": "tenant-id",
+        "base_url": "https://mcp.example.com",
+        "required_scopes": ["read", "access_as_user"],
+        "additional_authorize_scopes": ["openid", "profile"],
+        "allowed_client_redirect_uris": ["https://client.example/callback"],
+    }
+
+
+def test_documented_azure_environment_constructs_real_provider(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    for field_name in _LEGACY_AUTH_PROVIDER_ENV[
+        "fastmcp.server.auth.providers.azure.AzureProvider"
+    ][1]:
+        monkeypatch.delenv(f"FASTMCP_SERVER_AUTH_AZURE_{field_name.upper()}", raising=False)
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_AZURE_CLIENT_ID", "client-id")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_AZURE_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_AZURE_TENANT_ID", "tenant-id")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_AZURE_BASE_URL", "https://mcp.example.com")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_AZURE_REQUIRED_SCOPES", "read access_as_user")
+
+    provider = _load_fastmcp_auth_provider(
+        "fastmcp.server.auth.providers.azure.AzureProvider"
+    )
+
+    assert isinstance(provider, AzureProvider)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("null", None),
+        ('"openid profile"', ["openid", "profile"]),
+        ('["openid", "profile"]', ["openid", "profile"]),
+        ("openid,profile", ["openid", "profile"]),
+        ("openid profile", ["openid", "profile"]),
+    ],
+)
+def test_legacy_scope_value_conversion(value, expected):
+    assert (
+        _parse_auth_provider_env_value(
+            "fastmcp.server.auth.providers.azure.AzureProvider",
+            "required_scopes",
+            "FASTMCP_SERVER_AUTH_AZURE_REQUIRED_SCOPES",
+            value,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("value", ["true", "10", "{}", '["openid", true]'])
+def test_legacy_scope_value_rejects_non_string_json_without_exposing_value(value):
+    with pytest.raises(ValueError) as exc_info:
+        _parse_auth_provider_env_value(
+            "fastmcp.server.auth.providers.azure.AzureProvider",
+            "required_scopes",
+            "FASTMCP_SERVER_AUTH_AZURE_REQUIRED_SCOPES",
+            value,
+        )
+
+    assert value not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("null", None), ('["https://client.example/callback"]', ["https://client.example/callback"])],
+)
+def test_legacy_redirect_uri_value_conversion(value, expected):
+    assert (
+        _parse_auth_provider_env_value(
+            "fastmcp.server.auth.providers.github.GitHubProvider",
+            "allowed_client_redirect_uris",
+            "FASTMCP_SERVER_AUTH_GITHUB_ALLOWED_CLIENT_REDIRECT_URIS",
+            value,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("value", ["true", "10", "{}", '"https://client.example"'])
+def test_legacy_redirect_uri_value_rejects_non_list_json(value):
+    with pytest.raises(ValueError) as exc_info:
+        _parse_auth_provider_env_value(
+            "fastmcp.server.auth.providers.github.GitHubProvider",
+            "allowed_client_redirect_uris",
+            "FASTMCP_SERVER_AUTH_GITHUB_ALLOWED_CLIENT_REDIRECT_URIS",
+            value,
+        )
+
+    assert value not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("https://issuer.example", "https://issuer.example"),
+        ('"https://issuer.example"', "https://issuer.example"),
+        ('["issuer-a", "issuer-b"]', ["issuer-a", "issuer-b"]),
+        ("null", None),
+    ],
+)
+def test_legacy_jwt_issuer_value_conversion(value, expected):
+    assert (
+        _parse_auth_provider_env_value(
+            "fastmcp.server.auth.providers.jwt.JWTVerifier",
+            "issuer",
+            "FASTMCP_SERVER_AUTH_JWT_ISSUER",
+            value,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("value", ["true", "10", "{}", '["issuer", false]'])
+def test_legacy_jwt_issuer_rejects_non_string_json(value):
+    with pytest.raises(ValueError) as exc_info:
+        _parse_auth_provider_env_value(
+            "fastmcp.server.auth.providers.jwt.JWTVerifier",
+            "issuer",
+            "FASTMCP_SERVER_AUTH_JWT_ISSUER",
+            value,
+        )
+
+    assert value not in str(exc_info.value)
+
+
+def test_legacy_timeout_accepts_integral_decimal_string():
+    assert (
+        _parse_auth_provider_env_value(
+            "fastmcp.server.auth.providers.github.GitHubProvider",
+            "timeout_seconds",
+            "FASTMCP_SERVER_AUTH_GITHUB_TIMEOUT_SECONDS",
+            "10.0",
+        )
+        == 10
+    )
+
+
+def test_legacy_timeout_rejects_fractional_decimal_without_exposing_value():
+    value = "10.5"
+    with pytest.raises(ValueError) as exc_info:
+        _parse_auth_provider_env_value(
+            "fastmcp.server.auth.providers.github.GitHubProvider",
+            "timeout_seconds",
+            "FASTMCP_SERVER_AUTH_GITHUB_TIMEOUT_SECONDS",
+            value,
+        )
+
+    assert value not in str(exc_info.value)
+
+
+def test_legacy_auth_provider_map_matches_fastmcp4_signatures():
+    assert set(_LEGACY_AUTH_PROVIDER_ENV) == _EXPECTED_LEGACY_AUTH_PROVIDER_PATHS
+    assert sum(len(fields) for _, fields in _LEGACY_AUTH_PROVIDER_ENV.values()) == 110
+
+    for provider_path, (_, fields) in _LEGACY_AUTH_PROVIDER_ENV.items():
+        module_name, _, class_name = provider_path.rpartition(".")
+        provider_class = getattr(mcp_server_module.importlib.import_module(module_name), class_name)
+        assert issubclass(provider_class, AuthProvider)
+        assert set(fields) <= set(inspect.signature(provider_class).parameters)
+
+
+def test_legacy_auth_environment_is_case_insensitive(monkeypatch: pytest.MonkeyPatch):
+    provider_path = "fastmcp.server.auth.providers.jwt.JWTVerifier"
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(JWTVerifier=RecordingAuthProvider),
+    )
+    monkeypatch.setenv(
+        "fastmcp_server_auth_jwt_jwks_uri",
+        "https://lowercase.example/jwks.json",
+    )
+
+    provider = _load_fastmcp_auth_provider(provider_path)
+
+    assert provider.kwargs["jwks_uri"] == "https://lowercase.example/jwks.json"
+
+
+def test_process_auth_environment_uses_last_matching_case_variant(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _clear_auth_env(monkeypatch)
+    provider_path = "fastmcp.server.auth.providers.jwt.JWTVerifier"
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(JWTVerifier=RecordingAuthProvider),
+    )
+    monkeypatch.setenv(
+        "fastmcp_server_auth_jwt_jwks_uri",
+        "https://lowercase.example/jwks.json",
+    )
+    monkeypatch.setenv(
+        "FASTMCP_SERVER_AUTH_JWT_JWKS_URI",
+        "https://uppercase.example/jwks.json",
+    )
+
+    provider = _load_fastmcp_auth_provider(provider_path)
+
+    assert provider.kwargs["jwks_uri"] == "https://uppercase.example/jwks.json"
+
+
+def test_legacy_auth_provider_loads_explicit_fastmcp_env_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    provider_path = "fastmcp.server.auth.providers.jwt.JWTVerifier"
+    env_name = "FASTMCP_SERVER_AUTH_JWT_JWKS_URI"
+    env_file = tmp_path / "fastmcp.env"
+    env_file.write_text(f"{env_name}=https://env-file.example/jwks.json\n")
+    monkeypatch.delenv(env_name, raising=False)
+    monkeypatch.setenv("FASTMCP_ENV_FILE", str(env_file))
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(JWTVerifier=RecordingAuthProvider),
+    )
+
+    provider = _load_fastmcp_auth_provider(provider_path)
+
+    assert provider.kwargs["jwks_uri"] == "https://env-file.example/jwks.json"
+
+
+def test_auth_provider_constructor_error_reports_type_without_secret(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class ProviderConfigurationError(Exception):
+        pass
+
+    class RejectingProvider(AuthProvider):
+        def __init__(self, **kwargs):
+            raise ProviderConfigurationError(kwargs["client_secret"])
+
+    provider_path = "fastmcp.server.auth.providers.github.GitHubProvider"
+    secret = "constructor-secret-value"
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_GITHUB_CLIENT_SECRET", secret)
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(GitHubProvider=RejectingProvider),
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        _load_fastmcp_auth_provider(provider_path)
+
+    assert "ProviderConfigurationError" in str(exc_info.value)
+    assert secret not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+
+
+@pytest.mark.parametrize(
+    ("provider_path", "class_name", "env_prefix", "default_scopes"),
+    [
+        (
+            "fastmcp.server.auth.providers.auth0.Auth0Provider",
+            "Auth0Provider",
+            "AUTH0",
+            ["openid"],
+        ),
+        (
+            "fastmcp.server.auth.providers.aws.AWSCognitoProvider",
+            "AWSCognitoProvider",
+            "AWS_COGNITO",
+            ["openid"],
+        ),
+        (
+            "fastmcp.server.auth.providers.discord.DiscordProvider",
+            "DiscordProvider",
+            "DISCORD",
+            ["identify"],
+        ),
+        (
+            "fastmcp.server.auth.providers.github.GitHubProvider",
+            "GitHubProvider",
+            "GITHUB",
+            ["user"],
+        ),
+        (
+            "fastmcp.server.auth.providers.google.GoogleProvider",
+            "GoogleProvider",
+            "GOOGLE",
+            ["openid"],
+        ),
+        (
+            "fastmcp.server.auth.providers.oci.OCIProvider",
+            "OCIProvider",
+            "OCI",
+            ["openid"],
+        ),
+    ],
+)
+@pytest.mark.parametrize("configured_scopes", ["", "[]", "null"])
+def test_legacy_empty_scopes_restore_provider_defaults(
+    monkeypatch,
+    provider_path,
+    class_name,
+    env_prefix,
+    default_scopes,
+    configured_scopes,
+):
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(**{class_name: RecordingAuthProvider}),
+    )
+    monkeypatch.setenv(
+        f"FASTMCP_SERVER_AUTH_{env_prefix}_REQUIRED_SCOPES",
+        configured_scopes,
+    )
+
+    provider = _load_fastmcp_auth_provider(provider_path)
+
+    assert provider.kwargs["required_scopes"] == default_scopes
+
+
+@pytest.mark.parametrize(
+    ("provider_path", "class_name", "env_prefix"),
+    [
+        (
+            "fastmcp.server.auth.providers.discord.DiscordProvider",
+            "DiscordProvider",
+            "DISCORD",
+        ),
+        (
+            "fastmcp.server.auth.providers.github.GitHubProvider",
+            "GitHubProvider",
+            "GITHUB",
+        ),
+        (
+            "fastmcp.server.auth.providers.google.GoogleProvider",
+            "GoogleProvider",
+            "GOOGLE",
+        ),
+        (
+            "fastmcp.server.auth.providers.workos.WorkOSProvider",
+            "WorkOSProvider",
+            "WORKOS",
+        ),
+    ],
+)
+def test_legacy_zero_timeout_restores_provider_default(
+    monkeypatch,
+    provider_path,
+    class_name,
+    env_prefix,
+):
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(**{class_name: RecordingAuthProvider}),
+    )
+    monkeypatch.setenv(f"FASTMCP_SERVER_AUTH_{env_prefix}_TIMEOUT_SECONDS", "0")
+
+    provider = _load_fastmcp_auth_provider(provider_path)
+
+    assert provider.kwargs["timeout_seconds"] == 10
+
+
+def test_legacy_introspection_keeps_zero_timeout(monkeypatch):
+    provider_path = "fastmcp.server.auth.providers.introspection.IntrospectionTokenVerifier"
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(
+            IntrospectionTokenVerifier=RecordingAuthProvider
+        ),
+    )
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_INTROSPECTION_INTROSPECTION_URL", "https://idp")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_INTROSPECTION_CLIENT_ID", "client")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_INTROSPECTION_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_INTROSPECTION_TIMEOUT_SECONDS", "0")
+
+    provider = _load_fastmcp_auth_provider(provider_path)
+
+    assert provider.kwargs["timeout_seconds"] == 0
+
+
+def test_legacy_empty_aws_region_restores_default(monkeypatch):
+    provider_path = "fastmcp.server.auth.providers.aws.AWSCognitoProvider"
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(AWSCognitoProvider=RecordingAuthProvider),
+    )
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_AWS_COGNITO_AWS_REGION", "")
+
+    provider = _load_fastmcp_auth_provider(provider_path)
+
+    assert provider.kwargs["aws_region"] == "eu-central-1"
+
+
+@pytest.mark.parametrize("required_field", ["introspection_url", "client_id", "client_secret"])
+def test_legacy_introspection_rejects_empty_required_fields_without_values(
+    monkeypatch,
+    required_field,
+):
+    provider_path = "fastmcp.server.auth.providers.introspection.IntrospectionTokenVerifier"
+    values = {
+        "introspection_url": "https://idp.example/introspect",
+        "client_id": "client",
+        "client_secret": "secret-value",
+    }
+    values[required_field] = ""
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(
+            IntrospectionTokenVerifier=RecordingAuthProvider
+        ),
+    )
+    for name, value in values.items():
+        monkeypatch.setenv(f"FASTMCP_SERVER_AUTH_INTROSPECTION_{name.upper()}", value)
+
+    with pytest.raises(ValueError) as exc_info:
+        _load_fastmcp_auth_provider(provider_path)
+
+    assert required_field.upper() in str(exc_info.value)
+    assert "secret-value" not in str(exc_info.value)
+
+
+def test_load_auth_provider_supports_no_arg_custom_provider(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(CustomProvider=RecordingAuthProvider),
+    )
+
+    provider = _load_fastmcp_auth_provider("example.auth.CustomProvider")
+
+    assert provider.kwargs == {}
+
+
+def test_load_auth_provider_rejects_invalid_json_without_secret_value(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    provider_path = "fastmcp.server.auth.providers.github.GitHubProvider"
+    invalid_value = "secret-invalid-value"
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(GitHubProvider=RecordingAuthProvider),
+    )
+    monkeypatch.setenv(
+        "FASTMCP_SERVER_AUTH_GITHUB_ALLOWED_CLIENT_REDIRECT_URIS",
+        invalid_value,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        _load_fastmcp_auth_provider(provider_path)
+
+    assert "FASTMCP_SERVER_AUTH_GITHUB_ALLOWED_CLIENT_REDIRECT_URIS" in str(exc_info.value)
+    assert invalid_value not in str(exc_info.value)
+
+
+def test_load_auth_provider_rejects_removed_supabase_hs256(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    provider_path = "fastmcp.server.auth.providers.supabase.SupabaseProvider"
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        lambda _module_name: SimpleNamespace(SupabaseProvider=RecordingAuthProvider),
+    )
+    monkeypatch.setenv("FASTMCP_SERVER_AUTH_SUPABASE_ALGORITHM", "HS256")
+
+    with pytest.raises(ValueError, match="not supported by FastMCP 4"):
+        _load_fastmcp_auth_provider(provider_path)
 
 
 def test_resolve_auth_disabled_passes_explicit_none(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_client_cache.py
+++ b/tests/test_client_cache.py
@@ -84,26 +84,19 @@ class TestClientCaching:
         assert mock_cc.get_client.call_count == 1
 
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
-    @patch("mcp_clickhouse.mcp_server.get_context")
-    def test_different_config_creates_new_client(self, mock_get_context, mock_cc):
-        """Different session configs should produce different cached clients."""
+    def test_different_config_creates_new_client(self, mock_cc):
+        """Different request configs should produce different cached clients."""
         mock_client_a = MagicMock(server_version="24.1")
         mock_client_b = MagicMock(server_version="24.1")
         mock_cc.get_client.side_effect = [mock_client_a, mock_client_b]
 
         # First call: no overrides
-        mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = None
-        mock_get_context.return_value = mock_ctx
         config1 = _resolve_client_config()
         entry1 = _acquire_clickhouse_client(config1)
         _release_client_entry(entry1)
 
         # Second call: with override that changes the config key
-        mock_ctx2 = MagicMock()
-        mock_ctx2.get_state.return_value = {"connect_timeout": 99}
-        mock_get_context.return_value = mock_ctx2
-        config2 = _resolve_client_config()
+        config2 = _resolve_client_config({"connect_timeout": 99})
         entry2 = _acquire_clickhouse_client(config2)
         _release_client_entry(entry2)
 
@@ -240,14 +233,9 @@ class TestResolveClientConfig:
         config = _resolve_client_config()
         assert config["send_receive_timeout"] == 200
 
-    @patch("mcp_clickhouse.mcp_server.get_context")
-    def test_session_override_timeout_not_capped(self, mock_get_context):
-        """Session override of send_receive_timeout should bypass the auto-cap."""
-        mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = {"send_receive_timeout": 300}
-        mock_get_context.return_value = mock_ctx
-
-        config = _resolve_client_config()
+    def test_request_override_timeout_not_capped(self):
+        """Request override of send_receive_timeout should bypass the auto-cap."""
+        config = _resolve_client_config({"send_receive_timeout": 300})
         assert config["send_receive_timeout"] == 300
 
 
@@ -509,13 +497,20 @@ class TestShutdownOrdering:
     @patch("mcp_clickhouse.mcp_server._clear_client_cache")
     @patch("mcp_clickhouse.mcp_server.HEALTH_EXECUTOR")
     @patch("mcp_clickhouse.mcp_server.CANCELLATION_EXECUTOR")
+    @patch("mcp_clickhouse.mcp_server.METADATA_EXECUTOR")
     @patch("mcp_clickhouse.mcp_server.QUERY_EXECUTOR")
     def test_executor_shutdown_runs_before_cache_clear(
-        self, mock_query_executor, mock_cancellation_executor, mock_health_executor, mock_clear
+        self,
+        mock_query_executor,
+        mock_metadata_executor,
+        mock_cancellation_executor,
+        mock_health_executor,
+        mock_clear,
     ):
         """Shutdown drains all executors before clearing the client cache."""
         call_order = []
         mock_query_executor.shutdown.side_effect = lambda wait: call_order.append("query")
+        mock_metadata_executor.shutdown.side_effect = lambda wait: call_order.append("metadata")
         mock_cancellation_executor.shutdown.side_effect = lambda wait: call_order.append(
             "cancel"
         )
@@ -524,8 +519,9 @@ class TestShutdownOrdering:
 
         _shutdown()
 
-        assert call_order == ["query", "cancel", "health", "cache"]
+        assert call_order == ["query", "metadata", "cancel", "health", "cache"]
         mock_query_executor.shutdown.assert_called_once_with(wait=True)
+        mock_metadata_executor.shutdown.assert_called_once_with(wait=True)
         mock_cancellation_executor.shutdown.assert_called_once_with(wait=True)
         mock_health_executor.shutdown.assert_called_once_with(wait=True)
         mock_clear.assert_called_once_with()

--- a/tests/test_context_config_override.py
+++ b/tests/test_context_config_override.py
@@ -3,8 +3,10 @@
 import asyncio
 import json
 import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp import Client
@@ -14,9 +16,13 @@ from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 
 from mcp_clickhouse.mcp_server import (
     CLIENT_CONFIG_OVERRIDES_KEY,
+    _active_queries,
+    _active_queries_lock,
     _clear_client_cache,
     _get_client_config_overrides,
+    _remove_active_query,
     create_clickhouse_client,
+    list_tables_async,
     mcp,
     run_query,
     run_query_async,
@@ -54,7 +60,11 @@ class ConfigOverrideMiddleware(Middleware):
 
     async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
         ctx = get_context()
-        ctx.set_state(CLIENT_CONFIG_OVERRIDES_KEY, self.overrides)
+        await ctx.set_state(
+            CLIENT_CONFIG_OVERRIDES_KEY,
+            self.overrides,
+            serializable=False,
+        )
         return await call_next(context)
 
 
@@ -64,7 +74,25 @@ class QueryOverrideMiddleware(Middleware):
     async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
         query = context.message.arguments["query"]
         ctx = get_context()
-        ctx.set_state(CLIENT_CONFIG_OVERRIDES_KEY, {"connect_timeout": int(query.split()[-1])})
+        await ctx.set_state(
+            CLIENT_CONFIG_OVERRIDES_KEY,
+            {"connect_timeout": int(query.split()[-1])},
+            serializable=False,
+        )
+        return await call_next(context)
+
+
+class OneShotSessionOverrideMiddleware(Middleware):
+    """Set a session-scoped override on the first tool call only."""
+
+    def __init__(self):
+        self.call_count = 0
+
+    async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
+        self.call_count += 1
+        if self.call_count == 1:
+            ctx = get_context()
+            await ctx.set_state(CLIENT_CONFIG_OVERRIDES_KEY, {"connect_timeout": 99})
         return await call_next(context)
 
 
@@ -94,42 +122,30 @@ class TestConfigOverrideUnit:
         _clear_client_cache()
 
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
-    @patch("mcp_clickhouse.mcp_server.get_context")
-    def test_overrides_merged_into_client_config(self, mock_get_context, mock_cc):
-        mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = {"connect_timeout": 99, "send_receive_timeout": 199}
-        mock_get_context.return_value = mock_ctx
+    def test_overrides_merged_into_client_config(self, mock_cc):
         mock_cc.get_client.return_value = MagicMock(server_version="24.1")
 
-        create_clickhouse_client()
+        create_clickhouse_client({"connect_timeout": 99, "send_receive_timeout": 199})
 
         call_kwargs = mock_cc.get_client.call_args.kwargs
         assert call_kwargs["connect_timeout"] == 99
         assert call_kwargs["send_receive_timeout"] == 199
 
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
-    @patch("mcp_clickhouse.mcp_server.get_context")
-    def test_empty_overrides_no_change(self, mock_get_context, mock_cc):
-        mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = {}
-        mock_get_context.return_value = mock_ctx
+    def test_empty_overrides_no_change(self, mock_cc):
         mock_cc.get_client.return_value = MagicMock(server_version="24.1")
 
-        create_clickhouse_client()
+        create_clickhouse_client({})
 
         call_kwargs = mock_cc.get_client.call_args.kwargs
         assert "host" in call_kwargs
         assert "username" in call_kwargs
 
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
-    @patch("mcp_clickhouse.mcp_server.get_context")
-    def test_none_overrides_no_change(self, mock_get_context, mock_cc):
-        mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = None
-        mock_get_context.return_value = mock_ctx
+    def test_none_overrides_no_change(self, mock_cc):
         mock_cc.get_client.return_value = MagicMock(server_version="24.1")
 
-        create_clickhouse_client()
+        create_clickhouse_client(None)
 
         assert "host" in mock_cc.get_client.call_args.kwargs
 
@@ -143,16 +159,9 @@ class TestConfigOverrideUnit:
 
     @pytest.mark.parametrize("invalid_overrides", [[], "", 0, False])
     @patch("mcp_clickhouse.mcp_server.clickhouse_connect")
-    @patch("mcp_clickhouse.mcp_server.get_context")
-    def test_invalid_context_state_fails_before_client_creation(
-        self, mock_get_context, mock_cc, invalid_overrides
-    ):
-        mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = invalid_overrides
-        mock_get_context.return_value = mock_ctx
-
+    def test_invalid_context_state_fails_before_client_creation(self, mock_cc, invalid_overrides):
         with pytest.raises(ToolError) as exc_info:
-            create_clickhouse_client()
+            create_clickhouse_client(invalid_overrides)
 
         assert repr(invalid_overrides) not in str(exc_info.value)
         assert CLIENT_CONFIG_OVERRIDES_KEY in str(exc_info.value)
@@ -262,7 +271,8 @@ class TestConfigOverrideUnit:
             "pool_mgr": pool_manager,
         }
         mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = state
+        mock_ctx._request_state = {"request-key": state}
+        mock_ctx._make_state_key.return_value = "request-key"
         mock_get_context.return_value = mock_ctx
 
         snapshot = _get_client_config_overrides()
@@ -273,12 +283,32 @@ class TestConfigOverrideUnit:
         assert snapshot["settings"] == {"max_threads": 2}
         assert snapshot["pool_mgr"] is pool_manager
 
-    @patch("mcp_clickhouse.mcp_server.execute_query", return_value="result")
-    @patch("mcp_clickhouse.mcp_server._get_client_config_overrides")
-    def test_sync_run_query_passes_resolved_config(self, mock_get_overrides, mock_execute):
-        overrides = {"connect_timeout": 41}
-        mock_get_overrides.return_value = overrides
+    @patch("mcp_clickhouse.mcp_server.get_context")
+    def test_capture_does_not_fall_back_to_session_state(self, mock_get_context):
+        mock_ctx = MagicMock()
+        mock_ctx._request_state = {}
+        mock_ctx._make_state_key.return_value = "request-key"
+        mock_ctx.get_state = AsyncMock(side_effect=AssertionError("must not read session state"))
+        mock_get_context.return_value = mock_ctx
 
+        assert _get_client_config_overrides() is None
+
+        mock_ctx.get_state.assert_not_awaited()
+
+    @patch("mcp_clickhouse.mcp_server.get_context", return_value=SimpleNamespace())
+    def test_capture_fails_loudly_when_fastmcp_private_state_api_drifts(
+        self,
+        _mock_get_context,
+    ):
+        with pytest.raises(RuntimeError, match="request-local state API is unavailable"):
+            _get_client_config_overrides()
+
+    @patch("mcp_clickhouse.mcp_server.execute_query", return_value="result")
+    @patch(
+        "mcp_clickhouse.mcp_server._get_client_config_overrides",
+        return_value={"connect_timeout": 41},
+    )
+    def test_sync_run_query_passes_resolved_config(self, _mock_get_overrides, mock_execute):
         assert run_query("SELECT 1") == "result"
 
         query, query_id, config = mock_execute.call_args.args
@@ -288,7 +318,7 @@ class TestConfigOverrideUnit:
 
     @pytest.mark.asyncio
     @patch("mcp_clickhouse.mcp_server.execute_query", return_value="result")
-    @patch("mcp_clickhouse.mcp_server._get_client_config_overrides")
+    @patch("mcp_clickhouse.mcp_server._get_client_config_overrides_for_tool")
     async def test_async_run_query_passes_resolved_config(
         self, mock_get_overrides, mock_execute
     ):
@@ -333,6 +363,121 @@ class TestConfigOverrideMcpBoundary:
             mcp_server.middleware.remove(middleware)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("tool_name", "arguments", "helper_name"),
+        [
+            ("list_databases", {}, "_list_databases_with_config"),
+            ("list_tables", {"database": "system"}, "_list_tables_with_config"),
+        ],
+    )
+    async def test_registered_metadata_tools_receive_request_overrides(
+        self,
+        mcp_server,
+        tool_name,
+        arguments,
+        helper_name,
+    ):
+        middleware = ConfigOverrideMiddleware({"connect_timeout": 99})
+        mcp_server.add_middleware(middleware)
+
+        def capture_config(config, *_args):
+            return json.dumps({"connect_timeout": config["connect_timeout"]})
+
+        try:
+            with patch(
+                f"mcp_clickhouse.mcp_server.{helper_name}",
+                side_effect=capture_config,
+            ) as helper:
+                async with Client(mcp_server) as client:
+                    result = await client.call_tool(tool_name, arguments)
+
+            assert json.loads(result.content[0].text) == {"connect_timeout": 99}
+            assert helper.call_args.args[0]["connect_timeout"] == 99
+        finally:
+            mcp_server.middleware.remove(middleware)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("tool_name", "arguments", "helper_name"),
+        [
+            ("list_databases", {}, "_list_databases_with_config"),
+            ("list_tables", {"database": "system"}, "_list_tables_with_config"),
+        ],
+    )
+    async def test_metadata_tools_do_not_block_event_loop(
+        self,
+        mcp_server,
+        tool_name,
+        arguments,
+        helper_name,
+    ):
+        def slow_metadata_call(_config, *_args):
+            time.sleep(0.5)
+            return json.dumps({"status": "ok"})
+
+        with patch(
+            f"mcp_clickhouse.mcp_server.{helper_name}",
+            side_effect=slow_metadata_call,
+        ):
+            async with Client(mcp_server) as client:
+                slow_task = asyncio.create_task(client.call_tool(tool_name, arguments))
+                await asyncio.sleep(0.05)
+
+                start = time.perf_counter()
+                tools = await client.list_tools()
+                elapsed = time.perf_counter() - start
+
+                await slow_task
+
+        assert len(tools) >= 1
+        assert elapsed < 0.3
+
+    @pytest.mark.asyncio
+    async def test_metadata_saturation_does_not_starve_query_executor(self):
+        metadata_started = threading.Event()
+        release_metadata = threading.Event()
+        metadata_executor = ThreadPoolExecutor(max_workers=1)
+        query_executor = ThreadPoolExecutor(max_workers=1)
+
+        def blocked_metadata_call(_config, *_args):
+            metadata_started.set()
+            assert release_metadata.wait(timeout=2)
+            return json.dumps({"status": "ok"})
+
+        def completed_query(_query, query_id, _config):
+            with _active_queries_lock:
+                state = _active_queries[query_id]
+            _remove_active_query(query_id, state)
+            return '{"columns":["value"],"rows":[[1]]}'
+
+        metadata_task = None
+        try:
+            with (
+                patch("mcp_clickhouse.mcp_server.METADATA_EXECUTOR", metadata_executor),
+                patch("mcp_clickhouse.mcp_server.QUERY_EXECUTOR", query_executor),
+                patch(
+                    "mcp_clickhouse.mcp_server._list_tables_with_config",
+                    side_effect=blocked_metadata_call,
+                ),
+                patch(
+                    "mcp_clickhouse.mcp_server.execute_query",
+                    side_effect=completed_query,
+                ),
+            ):
+                metadata_task = asyncio.create_task(list_tables_async("system"))
+                assert await asyncio.to_thread(metadata_started.wait, 1)
+
+                result = await asyncio.wait_for(run_query_async("SELECT 1"), timeout=1)
+
+            assert json.loads(result)["rows"] == [[1]]
+        finally:
+            release_metadata.set()
+            if metadata_task is not None:
+                await asyncio.gather(metadata_task, return_exceptions=True)
+            metadata_executor.shutdown(wait=True)
+            query_executor.shutdown(wait=True)
+
+    @pytest.mark.asyncio
     async def test_concurrent_run_queries_keep_overrides_isolated(self, mcp_server):
         barrier = threading.Barrier(2)
         middleware = QueryOverrideMiddleware()
@@ -369,6 +514,45 @@ class TestConfigOverrideMcpBoundary:
             get_client.assert_not_called()
         finally:
             mcp_server.middleware.remove(middleware)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["auto", "legacy"])
+    async def test_session_scoped_override_fails_with_middleware_guidance(
+        self,
+        mcp_server,
+        mode,
+    ):
+        middleware = OneShotSessionOverrideMiddleware()
+        mcp_server.add_middleware(middleware)
+        try:
+            with patch("mcp_clickhouse.mcp_server.clickhouse_connect.get_client") as get_client:
+                get_client.side_effect = lambda **kwargs: FakeQueryClient(
+                    kwargs["connect_timeout"]
+                )
+                async with Client(mcp_server, mode=mode) as client:
+                    with pytest.raises(ToolError) as exc_info:
+                        await client.call_tool("run_query", {"query": "SELECT 1"})
+
+            assert "serializable=False" in str(exc_info.value)
+            assert CLIENT_CONFIG_OVERRIDES_KEY in str(exc_info.value)
+            get_client.assert_not_called()
+        finally:
+            mcp_server.middleware.remove(middleware)
+
+    @pytest.mark.asyncio
+    async def test_private_request_state_drift_fails_at_mcp_boundary(self, mcp_server):
+        with (
+            patch(
+                "mcp_clickhouse.mcp_server._request_client_config_overrides",
+                side_effect=RuntimeError("FastMCP request-local state API is unavailable"),
+            ),
+            patch("mcp_clickhouse.mcp_server.clickhouse_connect.get_client") as get_client,
+        ):
+            async with Client(mcp_server) as client:
+                with pytest.raises(ToolError, match="request-local state API is unavailable"):
+                    await client.call_tool("run_query", {"query": "SELECT 1"})
+
+        get_client.assert_not_called()
 
 
 @pytest.mark.skipif(

--- a/tests/test_grants_advisory.py
+++ b/tests/test_grants_advisory.py
@@ -130,17 +130,14 @@ def test_advisory_runs_in_write_mode_without_drop(caplog):
     assert any("DROP" in r.getMessage() for r in _warnings(caplog))
 
 
-def test_advisory_skipped_for_session_override_client(caplog):
+def test_advisory_skipped_for_request_override_client(caplog):
     """An override client may connect as a different user. The advisory must
     neither inspect it nor consume the one-shot for the base user."""
     client = _client_with_grants([("GRANT DROP ON *.* TO u",)])
     config = _config(allow_write_access=True, allow_drop=False)
-    ctx = MagicMock()
-    ctx.get_state.return_value = {"username": "other"}
     with patch("mcp_clickhouse.mcp_server.get_config", return_value=config):
         with patch("mcp_clickhouse.mcp_server.clickhouse_connect.get_client", return_value=client):
-            with patch("mcp_clickhouse.mcp_server.get_context", return_value=ctx):
-                assert create_clickhouse_client() is client
+            assert create_clickhouse_client({"username": "other"}) is client
             client.query.assert_not_called()
             assert mcp_server._grants_advisory_done is False
 

--- a/tests/test_http_security_boundary.py
+++ b/tests/test_http_security_boundary.py
@@ -2,9 +2,11 @@ import asyncio
 import warnings
 from pathlib import Path
 
+import fastmcp
 import pytest
-from fastmcp import FastMCP
+from fastmcp import FastMCP, settings as fastmcp_settings
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+from fastmcp.settings import Settings as FastMCPSettings
 from fastmcp.utilities.mcp_server_config import MCPServerConfig as FastMCPFileConfig
 from starlette.applications import Starlette
 from starlette.exceptions import StarletteDeprecationWarning
@@ -46,6 +48,9 @@ def _clear_http_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "CLICKHOUSE_MCP_BIND_HOST",
         "CLICKHOUSE_MCP_BIND_PORT",
         "FASTMCP_SERVER_AUTH",
+        "FASTMCP_HTTP_HOST_ORIGIN_PROTECTION",
+        "FASTMCP_HTTP_ALLOWED_HOSTS",
+        "FASTMCP_HTTP_ALLOWED_ORIGINS",
     ):
         monkeypatch.delenv(name, raising=False)
 
@@ -103,6 +108,40 @@ def test_static_auth_is_enforced_on_sse(monkeypatch: pytest.MonkeyPatch):
     response = TestClient(app).get("/sse")
 
     assert response.status_code == 401
+
+
+def test_rebuilt_sse_app_enforces_static_auth_and_host(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _clear_http_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_TOKEN", "secret-token")
+    monkeypatch.setenv("CLICKHOUSE_MCP_ALLOWED_HOSTS", "testserver")
+    app = ClickHouseFastMCP("test").sse_app()
+
+    with TestClient(app) as client:
+        unauthorized = client.post(
+            "/messages/?session_id=missing",
+            json={"jsonrpc": "2.0"},
+        )
+        authorized = client.post(
+            "/messages/?session_id=missing",
+            headers={"authorization": "Bearer secret-token"},
+            json={"jsonrpc": "2.0"},
+        )
+        invalid_host = client.post(
+            "/messages/?session_id=missing",
+            headers={
+                "authorization": "Bearer secret-token",
+                "host": "attacker.example",
+            },
+            json={"jsonrpc": "2.0"},
+        )
+
+    assert unauthorized.status_code == 401
+    assert authorized.status_code == 400
+    assert authorized.text == "Invalid session ID"
+    assert invalid_host.status_code == 421
+    assert invalid_host.text == "Invalid Host header"
 
 
 def test_http_app_allows_configured_request_with_auth_disabled(
@@ -318,32 +357,87 @@ def test_legacy_app_builders_respect_the_trusted_proxy_embedding_guard(
     assert len(_proxy_headers_entries(app)) == 1
 
 
-def test_sse_app_applies_and_restores_message_path(monkeypatch: pytest.MonkeyPatch):
-    _clear_http_env(monkeypatch)
-    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
-    server = ClickHouseFastMCP("test")
-    original_message_path = server._deprecated_settings.message_path
-
-    app = server.sse_app(message_path="/custom-messages/")
-
-    assert server._deprecated_settings.message_path == original_message_path
-    assert any(getattr(route, "path", None) == "/custom-messages" for route in app.routes)
-
-
-def test_sse_app_restores_message_path_when_the_embedding_guard_raises(
+def test_sse_app_uses_custom_message_route_without_mutating_settings(
     monkeypatch: pytest.MonkeyPatch,
 ):
     _clear_http_env(monkeypatch)
     monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
-    monkeypatch.setenv("CLICKHOUSE_MCP_ALLOWED_HOSTS", "mcp.example.com")
-    monkeypatch.setenv("CLICKHOUSE_MCP_TRUSTED_PROXIES", "10.0.0.0/24")
     server = ClickHouseFastMCP("test")
-    original_message_path = server._deprecated_settings.message_path
+    original_message_path = fastmcp_settings.message_path
 
-    with pytest.raises(ValueError, match="raw ASGI client address"):
-        server.sse_app(message_path="/custom-messages/")
+    app = server.sse_app(message_path="/custom-messages/")
 
-    assert server._deprecated_settings.message_path == original_message_path
+    assert fastmcp_settings.message_path == original_message_path
+    assert any(getattr(route, "path", None) == "/custom-messages" for route in app.routes)
+
+
+def test_sse_app_custom_message_route_does_not_change_later_default_app(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _clear_http_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
+    server = ClickHouseFastMCP("test")
+    original_message_path = fastmcp_settings.message_path
+
+    custom_app = server.sse_app(message_path="/custom-messages/")
+    default_app = server.sse_app()
+
+    assert fastmcp_settings.message_path == original_message_path
+    assert any(getattr(route, "path", None) == "/custom-messages" for route in custom_app.routes)
+    assert not any(
+        getattr(route, "path", None) == "/custom-messages" for route in default_app.routes
+    )
+    assert any(
+        getattr(route, "path", None) == original_message_path.rstrip("/")
+        for route in default_app.routes
+    )
+
+
+@pytest.mark.parametrize("protection", ["true", "auto"])
+def test_repo_host_guard_overrides_fastmcp_host_origin_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    protection,
+):
+    _clear_http_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
+    monkeypatch.setenv("CLICKHOUSE_MCP_ALLOWED_HOSTS", "repo.example")
+    monkeypatch.setenv("FASTMCP_HTTP_HOST_ORIGIN_PROTECTION", protection)
+    monkeypatch.setenv("FASTMCP_HTTP_ALLOWED_HOSTS", '["fastmcp.example"]')
+    monkeypatch.setenv("FASTMCP_HTTP_ALLOWED_ORIGINS", '["https://fastmcp.example"]')
+    configured_settings = FastMCPSettings()
+    monkeypatch.setattr(fastmcp, "settings", configured_settings)
+    monkeypatch.setattr(mcp_server_module, "fastmcp_settings", configured_settings)
+    app = ClickHouseFastMCP("test").http_app(transport="http")
+
+    with TestClient(app, base_url="http://repo.example") as client:
+        allowed = client.post("/mcp", json=_INITIALIZE_REQUEST, headers=_MCP_HEADERS)
+        rejected = client.post(
+            "/mcp",
+            json=_INITIALIZE_REQUEST,
+            headers={**_MCP_HEADERS, "host": "fastmcp.example"},
+        )
+
+    assert configured_settings.http_host_origin_protection in {True, "auto"}
+    assert allowed.status_code == 200
+    assert rejected.status_code == 421
+    assert rejected.text == "Invalid Host header"
+
+
+def test_sse_app_keeps_registered_health_route(monkeypatch: pytest.MonkeyPatch):
+    _clear_http_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
+
+    app = mcp_server_module.mcp.sse_app()
+
+    assert any(getattr(route, "path", None) == "/health" for route in app.routes)
+
+
+def test_sse_app_rejects_health_message_path(monkeypatch: pytest.MonkeyPatch):
+    _clear_http_env(monkeypatch)
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
+
+    with pytest.raises(ValueError, match="MCP transport path cannot be /health"):
+        ClickHouseFastMCP("test").sse_app(message_path="/health")
 
 
 def test_direct_http_app_requires_raw_client_address_assertion(
@@ -395,6 +489,11 @@ def test_http_app_restores_auth_between_static_and_oauth_construction(
     assert server.auth is oauth_provider
     monkeypatch.delenv("CLICKHOUSE_MCP_AUTH_TOKEN")
     monkeypatch.setenv("FASTMCP_SERVER_AUTH", "example.OAuthProvider")
+    monkeypatch.setattr(
+        mcp_server_module,
+        "_load_fastmcp_auth_provider",
+        lambda _provider_path, **_kwargs: oauth_provider,
+    )
     oauth_app = server.http_app(transport="http")
     assert server.auth is oauth_provider
 
@@ -419,7 +518,7 @@ def test_oauth_cannot_reuse_temporary_static_provider(monkeypatch: pytest.Monkey
     assert server.auth is None
     monkeypatch.delenv("CLICKHOUSE_MCP_AUTH_TOKEN")
     monkeypatch.setenv("FASTMCP_SERVER_AUTH", "example.OAuthProvider")
-    with pytest.raises(ValueError, match="did not create an authentication provider"):
+    with pytest.raises(ValueError, match="Could not import FASTMCP_SERVER_AUTH provider"):
         server.http_app(transport="http")
 
 
@@ -475,9 +574,8 @@ def test_http_app_rejects_health_transport_path_from_fastmcp_settings(
 ):
     _clear_http_env(monkeypatch)
     monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        server = ClickHouseFastMCP("test", **{setting_name: "/health"})
+    monkeypatch.setattr(fastmcp_settings, setting_name, "/health")
+    server = ClickHouseFastMCP("test")
 
     with pytest.raises(ValueError, match="MCP transport path cannot be /health"):
         server.http_app(transport=transport)

--- a/tests/test_pagination_validation.py
+++ b/tests/test_pagination_validation.py
@@ -1,5 +1,6 @@
 """Tests for list_tables input validation."""
 
+import asyncio
 import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -11,7 +12,7 @@ from fastmcp import Client
 from fastmcp.exceptions import ToolError
 
 from mcp_clickhouse.mcp_server import (
-    _claim_page_token,
+    _claim_page_token_for_request,
     _list_tables_with_config,
     _restore_page_token,
     _table_pagination_cache_lock,
@@ -112,16 +113,18 @@ def test_duplicate_page_token_has_only_one_concurrent_claim():
 
 
 @pytest.mark.parametrize(
-    ("database", "like", "include_detailed_columns"),
+    ("database", "like", "not_like", "include_detailed_columns"),
     [
-        ("other_database", None, True),
-        ("database", "other%", True),
-        ("database", None, False),
+        ("other_database", None, None, True),
+        ("database", "other%", None, True),
+        ("database", None, "other%", True),
+        ("database", None, None, False),
     ],
 )
 def test_page_token_mismatch_retains_original_token(
     database,
     like,
+    not_like,
     include_detailed_columns,
 ):
     with _table_pagination_cache_lock:
@@ -153,13 +156,17 @@ def test_page_token_mismatch_retains_original_token(
                 "mcp_clickhouse.mcp_server.get_paginated_table_data",
                 return_value=([], 0, False),
             ),
+            patch(
+                "mcp_clickhouse.mcp_server._restore_page_token",
+                wraps=_restore_page_token,
+            ) as restore_page_token,
         ):
             result = json.loads(
                 _list_tables_with_config(
                     {},
                     database,
                     like,
-                    None,
+                    not_like,
                     token,
                     1,
                     include_detailed_columns,
@@ -171,6 +178,7 @@ def test_page_token_mismatch_retains_original_token(
             "next_page_token": None,
             "total_tables": 0,
         }
+        restore_page_token.assert_not_called()
         with _table_pagination_cache_lock:
             assert table_pagination_cache[token] == original_state
     finally:
@@ -224,6 +232,10 @@ def test_mismatch_failure_cannot_restore_token_after_valid_caller_consumes_it():
                 "mcp_clickhouse.mcp_server.get_paginated_table_data",
                 side_effect=paginated_data,
             ),
+            patch(
+                "mcp_clickhouse.mcp_server._restore_page_token",
+                wraps=_restore_page_token,
+            ) as restore_page_token,
             ThreadPoolExecutor(max_workers=1) as executor,
         ):
             mismatch = executor.submit(
@@ -258,6 +270,7 @@ def test_mismatch_failure_cannot_restore_token_after_valid_caller_consumes_it():
         assert valid_result["total_tables"] == 3
         assert third_result["total_tables"] == 3
         assert saved_indexes == [2, 0]
+        restore_page_token.assert_not_called()
         with _table_pagination_cache_lock:
             assert token not in table_pagination_cache
     finally:
@@ -280,14 +293,29 @@ def test_restored_page_token_keeps_original_expiration_deadline():
             True,
         )
         current_time[0] = 109.9
-        state = _claim_page_token(token)
+        state = _claim_page_token_for_request(
+            token,
+            "database",
+            None,
+            None,
+            True,
+        )
         assert state is not None
         _restore_page_token(token, state)
         assert token in cache
 
         current_time[0] = 110.1
         assert token in cache
-        assert _claim_page_token(token) is None
+        assert (
+            _claim_page_token_for_request(
+                token,
+                "database",
+                None,
+                None,
+                True,
+            )
+            is None
+        )
         assert token not in cache
 
         _restore_page_token(token, state)
@@ -396,6 +424,84 @@ def test_page_token_is_restored_after_final_page_fetch_failure():
         with _table_pagination_cache_lock:
             assert table_pagination_cache[token] == original_state
     finally:
+        with _table_pagination_cache_lock:
+            table_pagination_cache.clear()
+
+
+@pytest.mark.parametrize("resume_from_token", [False, True])
+@pytest.mark.asyncio
+async def test_cancelled_mcp_call_does_not_commit_page_cursor(resume_from_token):
+    page_started = threading.Event()
+    release_page = threading.Event()
+    page_finished = threading.Event()
+    with _table_pagination_cache_lock:
+        table_pagination_cache.clear()
+
+    page_token = None
+    original_state = None
+    if resume_from_token:
+        page_token = create_page_token(
+            "database",
+            None,
+            None,
+            ["first", "second", "third"],
+            1,
+            True,
+        )
+        with _table_pagination_cache_lock:
+            original_state = dict(table_pagination_cache[page_token])
+
+    def blocked_page(_client, _database, _table_names, start_idx, _page_size, _details):
+        page_started.set()
+        try:
+            assert release_page.wait(timeout=2)
+            return [], start_idx + 1, True
+        finally:
+            page_finished.set()
+
+    entry = MagicMock(client=MagicMock())
+    try:
+        with (
+            patch(
+                "mcp_clickhouse.mcp_server._acquire_clickhouse_client",
+                return_value=entry,
+            ),
+            patch("mcp_clickhouse.mcp_server._release_client_entry"),
+            patch(
+                "mcp_clickhouse.mcp_server.fetch_table_names_from_system",
+                return_value=["first", "second", "third"],
+            ),
+            patch(
+                "mcp_clickhouse.mcp_server.get_paginated_table_data",
+                side_effect=blocked_page,
+            ),
+        ):
+            async with Client(mcp) as client:
+                call = asyncio.create_task(
+                    client.call_tool(
+                        "list_tables",
+                        {
+                            "database": "database",
+                            "page_token": page_token,
+                            "page_size": 1,
+                        },
+                    )
+                )
+                assert await asyncio.to_thread(page_started.wait, 2)
+                call.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await call
+
+            release_page.set()
+            assert await asyncio.to_thread(page_finished.wait, 2)
+
+        with _table_pagination_cache_lock:
+            if resume_from_token:
+                assert dict(table_pagination_cache) == {page_token: original_state}
+            else:
+                assert not table_pagination_cache
+    finally:
+        release_page.set()
         with _table_pagination_cache_lock:
             table_pagination_cache.clear()
 

--- a/tests/test_pagination_validation.py
+++ b/tests/test_pagination_validation.py
@@ -1,12 +1,24 @@
 """Tests for list_tables input validation."""
 
-from unittest.mock import patch
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
 
 import pytest
+from cachetools import TTLCache
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
 
-from mcp_clickhouse.mcp_server import mcp
+from mcp_clickhouse.mcp_server import (
+    _claim_page_token,
+    _list_tables_with_config,
+    _restore_page_token,
+    _table_pagination_cache_lock,
+    create_page_token,
+    mcp,
+    table_pagination_cache,
+)
 
 
 @pytest.mark.parametrize("page_size", [0, -1])
@@ -31,6 +43,375 @@ async def test_list_tables_page_size_schema_requires_positive_value():
         tools = await client.list_tools()
 
     list_tables_tool = next(tool for tool in tools if tool.name == "list_tables")
-    page_size_schema = list_tables_tool.inputSchema["properties"]["page_size"]
+    page_size_schema = list_tables_tool.input_schema["properties"]["page_size"]
 
     assert page_size_schema["exclusiveMinimum"] == 0
+    assert "one hour" in list_tables_tool.description
+
+
+def test_duplicate_page_token_has_only_one_concurrent_claim():
+    barrier = threading.Barrier(2)
+    start_indexes = []
+    start_indexes_lock = threading.Lock()
+    with _table_pagination_cache_lock:
+        table_pagination_cache.clear()
+    token = create_page_token(
+        "database",
+        None,
+        None,
+        ["first", "second"],
+        1,
+        True,
+    )
+
+    def paginated_data(_client, _database, _table_names, start_idx, _page_size, _details):
+        with start_indexes_lock:
+            start_indexes.append(start_idx)
+        barrier.wait(timeout=1)
+        return [], start_idx, False
+
+    entries = [MagicMock(client=MagicMock()), MagicMock(client=MagicMock())]
+    try:
+        with (
+            patch(
+                "mcp_clickhouse.mcp_server._acquire_clickhouse_client",
+                side_effect=entries,
+            ),
+            patch("mcp_clickhouse.mcp_server._release_client_entry"),
+            patch(
+                "mcp_clickhouse.mcp_server.fetch_table_names_from_system",
+                return_value=["first", "second"],
+            ),
+            patch(
+                "mcp_clickhouse.mcp_server.get_paginated_table_data",
+                side_effect=paginated_data,
+            ),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            futures = [
+                executor.submit(
+                    _list_tables_with_config,
+                    {},
+                    "database",
+                    None,
+                    None,
+                    token,
+                    1,
+                    True,
+                )
+                for _ in range(2)
+            ]
+            results = [json.loads(future.result(timeout=2)) for future in futures]
+
+        assert start_indexes.count(1) == 1
+        assert start_indexes.count(0) == 1
+        assert all(result["tables"] == [] for result in results)
+    finally:
+        with _table_pagination_cache_lock:
+            table_pagination_cache.clear()
+
+
+@pytest.mark.parametrize(
+    ("database", "like", "include_detailed_columns"),
+    [
+        ("other_database", None, True),
+        ("database", "other%", True),
+        ("database", None, False),
+    ],
+)
+def test_page_token_mismatch_retains_original_token(
+    database,
+    like,
+    include_detailed_columns,
+):
+    with _table_pagination_cache_lock:
+        table_pagination_cache.clear()
+    token = create_page_token(
+        "database",
+        None,
+        None,
+        ["first", "second"],
+        1,
+        True,
+    )
+    with _table_pagination_cache_lock:
+        original_state = dict(table_pagination_cache[token])
+
+    entry = MagicMock(client=MagicMock())
+    try:
+        with (
+            patch(
+                "mcp_clickhouse.mcp_server._acquire_clickhouse_client",
+                return_value=entry,
+            ),
+            patch("mcp_clickhouse.mcp_server._release_client_entry"),
+            patch(
+                "mcp_clickhouse.mcp_server.fetch_table_names_from_system",
+                return_value=[],
+            ),
+            patch(
+                "mcp_clickhouse.mcp_server.get_paginated_table_data",
+                return_value=([], 0, False),
+            ),
+        ):
+            result = json.loads(
+                _list_tables_with_config(
+                    {},
+                    database,
+                    like,
+                    None,
+                    token,
+                    1,
+                    include_detailed_columns,
+                )
+            )
+
+        assert result == {
+            "tables": [],
+            "next_page_token": None,
+            "total_tables": 0,
+        }
+        with _table_pagination_cache_lock:
+            assert table_pagination_cache[token] == original_state
+    finally:
+        with _table_pagination_cache_lock:
+            table_pagination_cache.clear()
+
+
+def test_mismatch_failure_cannot_restore_token_after_valid_caller_consumes_it():
+    mismatch_page_started = threading.Event()
+    valid_call_finished = threading.Event()
+    saved_indexes = []
+    saved_indexes_lock = threading.Lock()
+    with _table_pagination_cache_lock:
+        table_pagination_cache.clear()
+    token = create_page_token(
+        "database",
+        None,
+        None,
+        ["first", "second", "third"],
+        2,
+        True,
+    )
+    entries = [
+        MagicMock(client=MagicMock()),
+        MagicMock(client=MagicMock()),
+        MagicMock(client=MagicMock()),
+    ]
+
+    def paginated_data(_client, database, _table_names, start_idx, _page_size, _details):
+        if database == "wrong_database":
+            assert start_idx == 0
+            mismatch_page_started.set()
+            assert valid_call_finished.wait(timeout=2)
+            raise RuntimeError("mismatched request failed")
+        with saved_indexes_lock:
+            saved_indexes.append(start_idx)
+        return [], start_idx, False
+
+    try:
+        with (
+            patch(
+                "mcp_clickhouse.mcp_server._acquire_clickhouse_client",
+                side_effect=entries,
+            ),
+            patch("mcp_clickhouse.mcp_server._release_client_entry"),
+            patch(
+                "mcp_clickhouse.mcp_server.fetch_table_names_from_system",
+                return_value=["first", "second", "third"],
+            ),
+            patch(
+                "mcp_clickhouse.mcp_server.get_paginated_table_data",
+                side_effect=paginated_data,
+            ),
+            ThreadPoolExecutor(max_workers=1) as executor,
+        ):
+            mismatch = executor.submit(
+                _list_tables_with_config,
+                {},
+                "wrong_database",
+                None,
+                None,
+                token,
+                1,
+                True,
+            )
+            assert mismatch_page_started.wait(timeout=2)
+            try:
+                valid_result = json.loads(
+                    _list_tables_with_config(
+                        {}, "database", None, None, token, 1, True
+                    )
+                )
+            finally:
+                valid_call_finished.set()
+
+            with pytest.raises(RuntimeError, match="mismatched request failed"):
+                mismatch.result(timeout=2)
+
+            third_result = json.loads(
+                _list_tables_with_config(
+                    {}, "database", None, None, token, 1, True
+                )
+            )
+
+        assert valid_result["total_tables"] == 3
+        assert third_result["total_tables"] == 3
+        assert saved_indexes == [2, 0]
+        with _table_pagination_cache_lock:
+            assert token not in table_pagination_cache
+    finally:
+        valid_call_finished.set()
+        with _table_pagination_cache_lock:
+            table_pagination_cache.clear()
+
+
+def test_restored_page_token_keeps_original_expiration_deadline():
+    current_time = [100.0]
+    cache = TTLCache(maxsize=100, ttl=10, timer=lambda: current_time[0])
+
+    with patch("mcp_clickhouse.mcp_server.table_pagination_cache", cache):
+        token = create_page_token(
+            "database",
+            None,
+            None,
+            ["first", "second"],
+            1,
+            True,
+        )
+        current_time[0] = 109.9
+        state = _claim_page_token(token)
+        assert state is not None
+        _restore_page_token(token, state)
+        assert token in cache
+
+        current_time[0] = 110.1
+        assert token in cache
+        assert _claim_page_token(token) is None
+        assert token not in cache
+
+        _restore_page_token(token, state)
+        assert token not in cache
+
+
+def test_page_token_cursor_survives_connection_retry():
+    with _table_pagination_cache_lock:
+        table_pagination_cache.clear()
+    token = create_page_token(
+        "database",
+        None,
+        None,
+        ["first", "second", "third"],
+        2,
+        True,
+    )
+    clients = [MagicMock(), MagicMock()]
+    entries = [MagicMock(client=client) for client in clients]
+    start_indexes = []
+
+    def paginated_data(_client, _database, _table_names, start_idx, _page_size, _details):
+        start_indexes.append(start_idx)
+        if len(start_indexes) == 1:
+            raise ConnectionError("connection failed")
+        return [], start_idx, False
+
+    try:
+        with (
+            patch(
+                "mcp_clickhouse.mcp_server._acquire_clickhouse_client",
+                side_effect=entries,
+            ),
+            patch("mcp_clickhouse.mcp_server._release_client_entry"),
+            patch("mcp_clickhouse.mcp_server._evict_cached_client"),
+            patch(
+                "mcp_clickhouse.mcp_server.fetch_table_names_from_system"
+            ) as fetch_names,
+            patch(
+                "mcp_clickhouse.mcp_server.get_paginated_table_data",
+                side_effect=paginated_data,
+            ),
+        ):
+            result = json.loads(
+                _list_tables_with_config(
+                    {}, "database", None, None, token, 1, True
+                )
+            )
+
+        assert start_indexes == [2, 2]
+        assert result == {
+            "tables": [],
+            "next_page_token": None,
+            "total_tables": 3,
+        }
+        fetch_names.assert_not_called()
+    finally:
+        with _table_pagination_cache_lock:
+            table_pagination_cache.clear()
+
+
+def test_page_token_is_restored_after_final_page_fetch_failure():
+    with _table_pagination_cache_lock:
+        table_pagination_cache.clear()
+    token = create_page_token(
+        "database",
+        None,
+        None,
+        ["first", "second", "third"],
+        2,
+        True,
+    )
+    with _table_pagination_cache_lock:
+        original_state = dict(table_pagination_cache[token])
+    clients = [MagicMock(), MagicMock()]
+    entries = [MagicMock(client=client) for client in clients]
+    start_indexes = []
+
+    def fail_page_fetch(_client, _database, _table_names, start_idx, _page_size, _details):
+        start_indexes.append(start_idx)
+        raise ConnectionError("connection failed")
+
+    try:
+        with (
+            patch(
+                "mcp_clickhouse.mcp_server._acquire_clickhouse_client",
+                side_effect=entries,
+            ),
+            patch("mcp_clickhouse.mcp_server._release_client_entry"),
+            patch("mcp_clickhouse.mcp_server._evict_cached_client"),
+            patch(
+                "mcp_clickhouse.mcp_server.fetch_table_names_from_system"
+            ) as fetch_names,
+            patch(
+                "mcp_clickhouse.mcp_server.get_paginated_table_data",
+                side_effect=fail_page_fetch,
+            ),
+        ):
+            with pytest.raises(ConnectionError, match="connection failed"):
+                _list_tables_with_config(
+                    {}, "database", None, None, token, 1, True
+                )
+
+        assert start_indexes == [2, 2]
+        fetch_names.assert_not_called()
+        with _table_pagination_cache_lock:
+            assert table_pagination_cache[token] == original_state
+    finally:
+        with _table_pagination_cache_lock:
+            table_pagination_cache.clear()
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        ("list_databases", {"unexpected": True}),
+        ("list_tables", {"database": "database", "page_size": 0}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_registered_validation_errors_keep_public_tool_names(tool_name, arguments):
+    async with Client(mcp) as client:
+        with pytest.raises(ToolError) as exc_info:
+            await client.call_tool(tool_name, arguments)
+
+    assert f"call[{tool_name}]" in str(exc_info.value)
+    assert "_async" not in str(exc_info.value)

--- a/tests/test_protocol_compat.py
+++ b/tests/test_protocol_compat.py
@@ -178,7 +178,14 @@ def test_modern_http_discover_list_and_tool_error_without_initialize(
     assert "mcp-session-id" not in tool_success.headers
 
 
-def test_legacy_http_initialize_and_list_tools(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize(
+    "protocol_version",
+    ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"],
+)
+def test_legacy_http_initialize_and_list_tools(
+    monkeypatch: pytest.MonkeyPatch,
+    protocol_version: str,
+):
     monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
     monkeypatch.setenv("CLICKHOUSE_MCP_ALLOWED_HOSTS", "testserver")
     app = mcp.http_app(transport="http")
@@ -187,7 +194,7 @@ def test_legacy_http_initialize_and_list_tools(monkeypatch: pytest.MonkeyPatch):
         "id": 1,
         "method": "initialize",
         "params": {
-            "protocolVersion": _LEGACY_VERSION,
+            "protocolVersion": protocol_version,
             "capabilities": {},
             "clientInfo": {"name": "raw-test-client", "version": "1"},
         },
@@ -202,9 +209,10 @@ def test_legacy_http_initialize_and_list_tools(monkeypatch: pytest.MonkeyPatch):
         session_id = initialize.headers["mcp-session-id"]
         session_headers = {
             **_CONTENT_HEADERS,
-            "MCP-Protocol-Version": _LEGACY_VERSION,
             "Mcp-Session-Id": session_id,
         }
+        if protocol_version in {"2025-06-18", "2025-11-25"}:
+            session_headers["MCP-Protocol-Version"] = protocol_version
         initialized = client.post(
             "/mcp",
             headers=session_headers,
@@ -218,7 +226,7 @@ def test_legacy_http_initialize_and_list_tools(monkeypatch: pytest.MonkeyPatch):
 
     assert initialize.status_code == 200
     initialize_result = _sse_data(initialize)["result"]
-    assert initialize_result["protocolVersion"] == _LEGACY_VERSION
+    assert initialize_result["protocolVersion"] == protocol_version
     assert initialize_result["serverInfo"]["name"] == "mcp-clickhouse"
     assert initialize_result["serverInfo"]["version"] == package_version("mcp-clickhouse")
     assert initialized.status_code == 202

--- a/tests/test_protocol_compat.py
+++ b/tests/test_protocol_compat.py
@@ -1,0 +1,454 @@
+"""MCP 2026-07-28 and legacy protocol compatibility tests."""
+
+import asyncio
+import json
+import socket
+from importlib.metadata import PackageNotFoundError, version as package_version
+from unittest.mock import patch
+
+import pytest
+import uvicorn
+from fastmcp import Client, FastMCP
+from fastmcp.client.transports import SSETransport
+from fastmcp.exceptions import ToolError
+from starlette.testclient import TestClient
+
+from mcp_clickhouse.mcp_server import (
+    _active_queries,
+    _active_queries_lock,
+    _get_mcp_server_version,
+    _remove_active_query,
+    mcp,
+)
+
+_MODERN_VERSION = "2026-07-28"
+_LEGACY_VERSION = "2025-11-25"
+_CONTENT_HEADERS = {
+    "accept": "application/json, text/event-stream",
+    "content-type": "application/json",
+}
+_CLICKHOUSE_TOOL_NAMES = ["list_databases", "list_tables", "run_query"]
+
+
+def _assert_registered_tool_names(tool_names: list[str]) -> None:
+    expected = list(_CLICKHOUSE_TOOL_NAMES)
+    if "run_chdb_select_query" in tool_names:
+        expected.append("run_chdb_select_query")
+    assert tool_names == expected
+
+
+def _modern_request(method: str, *, params: dict | None = None, request_id: int = 1) -> dict:
+    request_params = dict(params or {})
+    request_params["_meta"] = {
+        "io.modelcontextprotocol/protocolVersion": _MODERN_VERSION,
+        "io.modelcontextprotocol/clientCapabilities": {},
+    }
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": request_params,
+    }
+
+
+def _modern_headers(method: str, *, name: str | None = None) -> dict[str, str]:
+    headers = {
+        **_CONTENT_HEADERS,
+        "MCP-Protocol-Version": _MODERN_VERSION,
+        "Mcp-Method": method,
+    }
+    if name is not None:
+        headers["Mcp-Name"] = name
+    return headers
+
+
+def _sse_data(response) -> dict:
+    data_line = next(line for line in response.text.splitlines() if line.startswith("data: "))
+    return json.loads(data_line.removeprefix("data: "))
+
+
+def _completed_query(_query, query_id, _config):
+    with _active_queries_lock:
+        state = _active_queries[query_id]
+    _remove_active_query(query_id, state)
+    return '{"columns":["value"],"rows":[[1]]}'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "expected_version"),
+    [("auto", _MODERN_VERSION), ("legacy", _LEGACY_VERSION)],
+)
+async def test_in_memory_client_supports_modern_and_legacy_eras(mode, expected_version):
+    async with Client(mcp, mode=mode) as client:
+        assert client.session.protocol_version == expected_version
+        tools = await client.list_tools()
+        with pytest.raises(ToolError, match="page_size"):
+            await client.call_tool(
+                "list_tables",
+                {"database": "system", "page_size": 0},
+            )
+
+    _assert_registered_tool_names([tool.name for tool in tools])
+
+
+def test_modern_http_discover_list_and_tool_error_without_initialize(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
+    monkeypatch.delenv("CLICKHOUSE_MCP_AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("CLICKHOUSE_MCP_ALLOWED_HOSTS", "testserver")
+    app = mcp.http_app(transport="http")
+
+    with TestClient(app) as client:
+        discover = client.post(
+            "/mcp",
+            headers=_modern_headers("server/discover"),
+            json=_modern_request("server/discover"),
+        )
+        tools_list = client.post(
+            "/mcp",
+            headers=_modern_headers("tools/list"),
+            json=_modern_request("tools/list", request_id=2),
+        )
+        tool_error = client.post(
+            "/mcp",
+            headers=_modern_headers("tools/call", name="list_tables"),
+            json=_modern_request(
+                "tools/call",
+                params={
+                    "name": "list_tables",
+                    "arguments": {"database": "system", "page_size": 0},
+                },
+                request_id=3,
+            ),
+        )
+        with patch(
+            "mcp_clickhouse.mcp_server.execute_query",
+            side_effect=_completed_query,
+        ):
+            tool_success = client.post(
+                "/mcp",
+                headers=_modern_headers("tools/call", name="run_query"),
+                json=_modern_request(
+                    "tools/call",
+                    params={"name": "run_query", "arguments": {"query": "SELECT 1"}},
+                    request_id=4,
+                ),
+            )
+
+    assert discover.status_code == 200
+    discover_result = discover.json()["result"]
+    assert _MODERN_VERSION in discover_result["supportedVersions"]
+    assert discover_result["resultType"] == "complete"
+    assert isinstance(discover_result["ttlMs"], int)
+    assert discover_result["ttlMs"] >= 0
+    assert discover_result["cacheScope"] in {"public", "private"}
+    assert discover_result["capabilities"]["tools"] == {"listChanged": False}
+    assert discover_result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"] == (
+        "mcp-clickhouse"
+    )
+    assert discover_result["_meta"]["io.modelcontextprotocol/serverInfo"][
+        "version"
+    ] == package_version("mcp-clickhouse")
+    assert "https://github.com/ClickHouse/agent-skills" in discover_result["instructions"]
+    assert "mcp-session-id" not in discover.headers
+
+    assert tools_list.status_code == 200
+    tools_result = tools_list.json()["result"]
+    _assert_registered_tool_names([tool["name"] for tool in tools_result["tools"]])
+    assert tools_result["resultType"] == "complete"
+    assert isinstance(tools_result["ttlMs"], int)
+    assert tools_result["ttlMs"] >= 0
+    assert tools_result["cacheScope"] in {"public", "private"}
+    assert "mcp-session-id" not in tools_list.headers
+
+    assert tool_error.status_code == 200
+    tool_result = tool_error.json()["result"]
+    assert tool_result["isError"] is True
+    assert tool_result["resultType"] == "complete"
+    assert "page_size" in tool_result["content"][0]["text"]
+    assert "mcp-session-id" not in tool_error.headers
+
+    assert tool_success.status_code == 200
+    success_result = tool_success.json()["result"]
+    assert success_result["isError"] is False
+    assert success_result["resultType"] == "complete"
+    assert json.loads(success_result["content"][0]["text"])["rows"] == [[1]]
+    assert "mcp-session-id" not in tool_success.headers
+
+
+def test_legacy_http_initialize_and_list_tools(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
+    monkeypatch.setenv("CLICKHOUSE_MCP_ALLOWED_HOSTS", "testserver")
+    app = mcp.http_app(transport="http")
+    initialize_request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": _LEGACY_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "raw-test-client", "version": "1"},
+        },
+    }
+
+    with TestClient(app) as client:
+        initialize = client.post(
+            "/mcp",
+            headers=_CONTENT_HEADERS,
+            json=initialize_request,
+        )
+        session_id = initialize.headers["mcp-session-id"]
+        session_headers = {
+            **_CONTENT_HEADERS,
+            "MCP-Protocol-Version": _LEGACY_VERSION,
+            "Mcp-Session-Id": session_id,
+        }
+        initialized = client.post(
+            "/mcp",
+            headers=session_headers,
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        tools_list = client.post(
+            "/mcp",
+            headers=session_headers,
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        )
+
+    assert initialize.status_code == 200
+    initialize_result = _sse_data(initialize)["result"]
+    assert initialize_result["protocolVersion"] == _LEGACY_VERSION
+    assert initialize_result["serverInfo"]["name"] == "mcp-clickhouse"
+    assert initialize_result["serverInfo"]["version"] == package_version("mcp-clickhouse")
+    assert initialized.status_code == 202
+    assert tools_list.status_code == 200
+    _assert_registered_tool_names(
+        [tool["name"] for tool in _sse_data(tools_list)["result"]["tools"]]
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_sse_client_initialize_and_list_tools(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_socket.bind(("127.0.0.1", 0))
+    server_socket.listen()
+    port = server_socket.getsockname()[1]
+    monkeypatch.delenv("CLICKHOUSE_MCP_AUTH_DISABLED", raising=False)
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_TOKEN", "test-token")
+    monkeypatch.setenv("CLICKHOUSE_MCP_ALLOWED_HOSTS", f"127.0.0.1:{port}")
+    app = mcp.sse_app()
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app,
+            log_level="error",
+            lifespan="on",
+            proxy_headers=False,
+            ws="none",
+        )
+    )
+    server_task = asyncio.create_task(server.serve(sockets=[server_socket]))
+
+    try:
+        for _ in range(100):
+            if server.started:
+                break
+            await asyncio.sleep(0.01)
+        assert server.started
+
+        transport = SSETransport(
+            f"http://127.0.0.1:{port}/sse",
+            headers={"Authorization": "Bearer test-token"},
+        )
+        async with Client(transport, mode="legacy", timeout=5) as client:
+            assert client.session.protocol_version == _LEGACY_VERSION
+            tools = await client.list_tools()
+
+        _assert_registered_tool_names([tool.name for tool in tools])
+    finally:
+        server.should_exit = True
+        await server_task
+        server_socket.close()
+
+
+@pytest.mark.parametrize(
+    ("case", "headers", "request_body", "expected_status", "expected_code"),
+    [
+        (
+            "missing method header",
+            {**_CONTENT_HEADERS, "MCP-Protocol-Version": _MODERN_VERSION},
+            _modern_request("tools/list"),
+            400,
+            -32020,
+        ),
+        (
+            "version mismatch",
+            _modern_headers("tools/list"),
+            {
+                **_modern_request("tools/list"),
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": _LEGACY_VERSION,
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                    }
+                },
+            },
+            400,
+            -32020,
+        ),
+        (
+            "unsupported version",
+            {
+                **_CONTENT_HEADERS,
+                "MCP-Protocol-Version": "2099-01-01",
+                "Mcp-Method": "tools/list",
+            },
+            {
+                **_modern_request("tools/list"),
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": "2099-01-01",
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                    }
+                },
+            },
+            400,
+            -32022,
+        ),
+        (
+            "missing tool name header",
+            _modern_headers("tools/call"),
+            _modern_request(
+                "tools/call",
+                params={"name": "list_tables", "arguments": {"database": "system"}},
+            ),
+            400,
+            -32020,
+        ),
+        (
+            "unknown method",
+            _modern_headers("unknown/method"),
+            _modern_request("unknown/method"),
+            404,
+            -32601,
+        ),
+        (
+            "removed initialize method",
+            _modern_headers("initialize"),
+            _modern_request("initialize"),
+            404,
+            -32601,
+        ),
+    ],
+)
+def test_modern_http_header_and_method_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    case,
+    headers,
+    request_body,
+    expected_status,
+    expected_code,
+):
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
+    monkeypatch.setenv("CLICKHOUSE_MCP_ALLOWED_HOSTS", "testserver")
+    app = mcp.http_app(transport="http")
+
+    with TestClient(app) as client:
+        response = client.post("/mcp", headers=headers, json=request_body)
+
+    assert response.status_code == expected_status, case
+    response_body = response.json()
+    assert response_body["id"] == request_body["id"], case
+    assert response_body["error"]["code"] == expected_code, case
+    if case == "unsupported version":
+        assert response_body["error"]["data"]["supported"] == [_MODERN_VERSION]
+        assert response_body["error"]["data"]["requested"] == "2099-01-01"
+
+
+def test_modern_http_requires_request_metadata(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
+    monkeypatch.setenv("CLICKHOUSE_MCP_ALLOWED_HOSTS", "testserver")
+    app = mcp.http_app(transport="http")
+    request = _modern_request("tools/list")
+    request["params"]["_meta"] = {}
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp",
+            headers=_modern_headers("tools/list"),
+            json=request,
+        )
+
+    assert response.status_code == 400
+    response_body = response.json()
+    assert response_body["id"] == request["id"]
+    assert response_body["error"]["code"] == -32602
+
+
+def test_modern_http_decodes_mcp_name_base64_sentinel(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
+    monkeypatch.setenv("CLICKHOUSE_MCP_ALLOWED_HOSTS", "testserver")
+    app = mcp.http_app(transport="http")
+    request = _modern_request(
+        "tools/call",
+        params={"name": "run_query", "arguments": {"query": "SELECT 1"}},
+        request_id=91,
+    )
+    headers = _modern_headers("tools/call", name="=?base64?cnVuX3F1ZXJ5?=")
+
+    with (
+        patch(
+            "mcp_clickhouse.mcp_server.execute_query",
+            side_effect=_completed_query,
+        ),
+        TestClient(app) as client,
+    ):
+        response = client.post("/mcp", headers=headers, json=request)
+
+    assert response.status_code == 200
+    assert response.json()["id"] == 91
+    assert response.json()["result"]["isError"] is False
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "MCP Python SDK 2.1.1 uses header-first dual-era dispatch; body-first detection "
+        "would preserve the modern request and return HeaderMismatch"
+    ),
+)
+def test_modern_http_missing_protocol_header_is_header_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("CLICKHOUSE_MCP_AUTH_DISABLED", "true")
+    monkeypatch.setenv("CLICKHOUSE_MCP_ALLOWED_HOSTS", "testserver")
+    app = mcp.http_app(transport="http")
+    request = _modern_request("tools/list", request_id=92)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp",
+            headers={**_CONTENT_HEADERS, "Mcp-Method": "tools/list"},
+            json=request,
+        )
+
+    assert response.status_code == 400
+    response_body = response.json()
+    assert response_body["id"] == request["id"]
+    assert response_body["error"]["code"] == -32020
+
+
+def test_server_version_falls_back_when_distribution_metadata_is_missing():
+    with patch(
+        "mcp_clickhouse.mcp_server.package_version",
+        side_effect=PackageNotFoundError,
+    ):
+        fallback_version = _get_mcp_server_version()
+
+    assert fallback_version == "unknown"
+    assert FastMCP("test-server", version=fallback_version).version == "unknown"

--- a/uv.lock
+++ b/uv.lock
@@ -6,18 +6,46 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.4"
+name = "aiofile"
+version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "caio", version = "0.9.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
+name = "aiofile"
+version = "3.12.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "caio", version = "0.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/31/edb06aabd8f8f0b56d659f30800795f40b93cba96be946ce179f6931e3a5/aiofile-3.12.3.tar.gz", hash = "sha256:caa6aa746b5e47e2165f7abd741b6415e49cf4d44fddc0f61844612cc3924d41", size = 21600, upload-time = "2026-08-04T22:59:27.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/79/6e45e778c4c3cab39e0937b007b720c15f76c50c6453d153282d0fcc3588/aiofile-3.12.3-py3-none-any.whl", hash = "sha256:5c1bcc9e929c50834608e8cc1a4cc1d7503eb60c15a535b779fd39e2f372c017", size = 22122, upload-time = "2026-08-04T22:59:25.838Z" },
 ]
 
 [[package]]
@@ -41,15 +69,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
-]
-
-[[package]]
-name = "async-timeout"
-version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
 ]
 
 [[package]]
@@ -107,6 +126,87 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/dd/57fe3fdb6e65b25a5987fd2cdc7e22db0aef508b91634d2e57d22928d41b/cachetools-7.0.5.tar.gz", hash = "sha256:0cd042c24377200c1dcd225f8b7b12b0ca53cc2c961b43757e774ebe190fd990", size = 37367, upload-time = "2026-03-09T20:51:29.451Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/f3/39cf3367b8107baa44f861dc802cbf16263c945b62d8265d36034fc07bea/cachetools-7.0.5-py3-none-any.whl", hash = "sha256:46bc8ebefbe485407621d0a4264b23c080cedd913921bad7ac3ed2f26c183114", size = 13918, upload-time = "2026-03-09T20:51:27.33Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/36715c97c873649d1029001578f901b50250916295e3dddf20c865438865/caio-0.9.25-cp310-cp310-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db9b5681e4af8176159f0d6598e73b2279bb661e718c7ac23342c550bd78c241", size = 79695, upload-time = "2025-12-26T15:22:18.818Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/07080ecb1adb55a02cbd8ec0126aa8e43af343ffabb6a71125b42670e9a1/caio-0.9.25-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:bf61d7d0c4fd10ffdd98ca47f7e8db4d7408e74649ffaf4bef40b029ada3c21b", size = 79457, upload-time = "2026-03-04T22:08:16.024Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/dd55757bb671eb4c376e006c04e83beb413486821f517792ea603ef216e9/caio-0.9.25-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:ab52e5b643f8bbd64a0605d9412796cd3464cb8ca88593b13e95a0f0b10508ae", size = 77705, upload-time = "2026-03-04T22:08:17.202Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/c8/82b3c760141a1076408164b03e8789b51809add6aecd48aa9d7651cf6b59/caio-0.12.2.tar.gz", hash = "sha256:87a67c0dccc60e432888bd532ec504b66e124a5d8b391aab894583b55abd39ea", size = 80927, upload-time = "2026-08-04T14:43:33.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/db/2b780a0c859a0bc873683beb60d94215af5c082c76e11e632b4f122905a3/caio-0.12.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a294091062831970b702f10a7fb119c1b55a49db7b843deeb8939550531189ea", size = 77836, upload-time = "2026-08-04T14:42:49.581Z" },
+    { url = "https://files.pythonhosted.org/packages/72/cc/bc8c1f81dc00d4232a2f842eca38df6c86281f012026416873ebaea2f592/caio-0.12.2-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:af0c75b43f0cde52c758c000b797188e6d62579c4914173ca7afca382a47993d", size = 193718, upload-time = "2026-08-04T14:42:51.158Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ce/a7429564d74c7ed1cd7ed8c490e8ae9211d38786ac113a8e8eecba97f7c6/caio-0.12.2-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:c3922302878d17d6860ebe6b5e4dcc6821f7a9d162474a774b8534fedea80236", size = 190539, upload-time = "2026-08-04T14:42:52.521Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/43/43dc1bd7c961679267c2ca2c73fd5b732528bf719ba16d39cc1be0346a3c/caio-0.12.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e97f960ab7c84aaa7520367bf597222db4229054bc7aae70344cb7da7b19b6f1", size = 191334, upload-time = "2026-08-04T14:42:54.067Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b2/0ea4998968112f1211b1c057f1bd606f40f3efdab640f5e49529d2438707/caio-0.12.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a682783aef6eff8bc47cd5dd262081d7f746b8d3db1957c70a04017598a048d9", size = 190232, upload-time = "2026-08-04T14:42:55.551Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/e9/c346d656b2f3626ef726aaac1c5ea58a981757cbed62087a9e81eaa4b09f/caio-0.12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a2a7f0fa3b49f219f09705717c73a618eecbb3d697701e20abb4771d17e2bbcf", size = 84555, upload-time = "2026-08-04T14:42:56.84Z" },
+    { url = "https://files.pythonhosted.org/packages/84/60/0b99da0d1345c0c1f9bde58ae96527b54b4aae32c2b6e74dcef514f7fa9c/caio-0.12.2-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:1b04358ef65bd03d9c34d7b028efb422593b07485da82d6c5439f8c5dea35668", size = 196508, upload-time = "2026-08-04T14:42:58.074Z" },
+    { url = "https://files.pythonhosted.org/packages/92/7e/7eb5a9ab97cfa5500a2cff8444e16e183aab6473912ac37d8bf9de283337/caio-0.12.2-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:e1253743841b0864bfd6827e496fea4591bb3999ec1c003e57de65370e2d9031", size = 192985, upload-time = "2026-08-04T14:42:59.404Z" },
+    { url = "https://files.pythonhosted.org/packages/92/13/308773ae27f33bc141720ded63216c9a115f5838c1e341d2d37c2b051281/caio-0.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd94522714af3fd806093bdd10f3175f1c42c5ee72dda975b8b35b55c3400147", size = 194087, upload-time = "2026-08-04T14:43:00.645Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8b/08814adc89f2c7612da9c2f17d962626bf59eb3b4dd715ea8198ccecb66c/caio-0.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a857d06308dc4428b760f9430350b3847f4c62ad0e79e635215f7cc97f7adcc9", size = 192586, upload-time = "2026-08-04T14:43:02.388Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bc/b62bf048a6e11870291a24319ed027bdf658df9ba77d1ad762aa138e066b/caio-0.12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2097cc0d19fa95e8d55aad770597bb0f76e4f70ed48278c965aa7c5b0b8c3bf5", size = 84702, upload-time = "2026-08-04T14:43:03.946Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/be/b40d55d793afcfa5bcdb32ade9289d9588e14e3026c2c87522e303cc6e8c/caio-0.12.2-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:2122dccbd1959b922543fc9f8a9d2af47bd5b59190d1ece2445d3d1b4d1be45f", size = 198292, upload-time = "2026-08-04T14:43:05.238Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/02/9bd2bca72bfa478337618eae88942c43c891ae225e11baeae275e5e5c6ab/caio-0.12.2-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:107e56554c179749de9440e1b5e5a19813572eebf3166e9dc3e5228b16966beb", size = 196207, upload-time = "2026-08-04T14:43:06.494Z" },
+    { url = "https://files.pythonhosted.org/packages/48/9b/65f95efdd68b50b7a9f2555c93d9edc7da7aa5ae5e153163c41cf6fd5cd9/caio-0.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adc7785e61ff7cf372318f67ec65617eaa06975e20da177522665dca8be6ea5d", size = 195748, upload-time = "2026-08-04T14:43:07.893Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/16/6a5c010ca435a5184d11ca350874694ac19db249560126dc8df0f25791ce/caio-0.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:07942d3b5999127ecb96256c38d5dbf49ed2864c087ed2a80b783901d0aa3ba1", size = 195835, upload-time = "2026-08-04T14:43:09.19Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/9b/31f0b49a2542ffa2f9d6140267e2b568e722a1feeb05cfbffea97666c62b/caio-0.12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:40ebea9ebe3a3a66ae85fa00d4112d163654a33c82dcf9b26a99f7d30de13317", size = 84656, upload-time = "2026-08-04T14:43:10.513Z" },
+    { url = "https://files.pythonhosted.org/packages/99/bc/62568d688af9712a34fe3f958d7a98c53bb2017e263260cd5deae67a90e9/caio-0.12.2-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:6003ec389a68d5ec8f089df82b2dc8915293dd630a4d11322d7e3455045981fd", size = 198443, upload-time = "2026-08-04T14:43:11.767Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e4/5ed627860285612e5307f06c109913c5918c947fbc223b55599e484c64b0/caio-0.12.2-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:eee9376d0e2af25b6defc5bce39f6efa90521c803aaf12eba931bd898a397cfc", size = 196356, upload-time = "2026-08-04T14:43:13.206Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e2/2a8cfc6ba3ef3f19e7c778e9fb6f98600f0971cca78bbdfc23a413a66349/caio-0.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:78e3ccafc98e009fcb00a97ad441585551e52c0ae7ecc50427a3ccd9b11502fd", size = 195893, upload-time = "2026-08-04T14:43:14.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/87/77c40fb2301d0b5bb27c2e79ae42fce718ed75396d5fe3e1c09d8e1400b1/caio-0.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f2355db8917f5a0f3638bf332fe0d87549c80e978fca01db84a8a14b9df56a05", size = 195969, upload-time = "2026-08-04T14:43:15.946Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b5/0ceca97eb546fe6bbace3399c8b11dfc503efcc7509d708a7a3f09ab50e9/caio-0.12.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8054cba5e7ee623bea34946e2b59eb7c7c2be8872d0a5d12215d6ff564938d5f", size = 78621, upload-time = "2026-08-04T14:43:17.316Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/43/54d01cf9b643ffd6678aedee5ad5d6e7a1063bd169a203bfb6fb471e6887/caio-0.12.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:5d658212d585b8814b9caf766d8090acac05f01abfa2875d57fdc4a7e2af032e", size = 77834, upload-time = "2026-08-04T14:43:18.492Z" },
+    { url = "https://files.pythonhosted.org/packages/90/00/a0ca7394a0c3a234811b0c38b39aa0db9373663981c1cf446e26e7a7c198/caio-0.12.2-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:391a7cc1dbfc5885d7d54406c9a7a4ec19d514d526e67d240d32734eebde378e", size = 198993, upload-time = "2026-08-04T14:43:19.992Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b2/f8f1a5e57c16c86825f1f0648e76f7760f84452a41efee0d04fa53ef3e2d/caio-0.12.2-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:121f4de82e2a875aff468ef2af7491fbecfffe9e71b507f5073fe2a156bb78df", size = 196408, upload-time = "2026-08-04T14:43:21.3Z" },
+    { url = "https://files.pythonhosted.org/packages/01/db/5d94d1d58ef6f0acb39ab1a802793413a8b1e17108c05cf98cb4dc9e4b22/caio-0.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e0ba5f8c0dc7035c05817ca1399dd7d6121ea55c363a079c334a151a75094322", size = 196480, upload-time = "2026-08-04T14:43:22.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2a/366adf468d7654b895e232eeaa80d147df2ba293f708bd9cef78b95f92d0/caio-0.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0ad8d8f9f5ea47aee81aead563fe3aca5bb54c3fc21b62bd830eaf369eb04060", size = 196071, upload-time = "2026-08-04T14:43:24.187Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b1/4c0c989d2a24b8f3ba2e13b9115a107d9413b36aab8b299674b66da21c75/caio-0.12.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0b85f94819058a8f21c3dca26c5f006a0f003b8700483a326ec86d569d2bd1a3", size = 78627, upload-time = "2026-08-04T14:43:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/107cfe84199b9fb5a7317e1230d808944205fd91c7869641ac4e2ef5d603/caio-0.12.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a60459e42c680068a2a5286f15f54ccd887af34ad9ed1be1f0a7747ad6bd8820", size = 220217, upload-time = "2026-08-04T14:43:26.823Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1c/d6f03d3226519cd8f362081370326846348c442078e005753c57522a4190/caio-0.12.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:51bb86c0abce55d0b3467ba6671e95cd96356044e5abd58651ad0645cf37084b", size = 216293, upload-time = "2026-08-04T14:43:28.177Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a4/d53ed7e639b778b6f41a5e7c664b37f75830e38afa62dad62ec913674548/caio-0.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e33295963f5a4787355b8bfd754b4f0e7ac5d535138860748c1eb833ca10d620", size = 218220, upload-time = "2026-08-04T14:43:29.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d6/c353fd1dda371262995bba1b2f9aa42cc6cf7fc82c0853238510aa655bb9/caio-0.12.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15af6eb10d7705a92ee8143d8a4d89c2886ecb6b65ce1161d3dad1adb9b3cbec", size = 216106, upload-time = "2026-08-04T14:43:31.011Z" },
+    { url = "https://files.pythonhosted.org/packages/61/8a/71b0144f783468ba9f1bbf8a2f8e45c7d85ae31ec192f10650aa46f31702/caio-0.12.2-py3-none-any.whl", hash = "sha256:5233e797c9fe2b541914b1bc2e2df82677e2206b537e44e252188f3c2cbb0ea9", size = 62548, upload-time = "2026-08-04T14:43:32.394Z" },
 ]
 
 [[package]]
@@ -311,29 +411,12 @@ wheels = [
 ]
 
 [[package]]
-name = "cloudpickle"
-version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
-name = "cronsim"
-version = "2.7"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
 ]
 
 [[package]]
@@ -414,15 +497,6 @@ wheels = [
 ]
 
 [[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
-]
-
-[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -475,52 +549,76 @@ wheels = [
 ]
 
 [[package]]
-name = "fakeredis"
-version = "2.34.1"
+name = "fastmcp"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "redis" },
-    { name = "sortedcontainers" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/40/fd09efa66205eb32253d2b2ebc63537281384d2040f0a88bcd2289e120e4/fakeredis-2.34.1.tar.gz", hash = "sha256:4ff55606982972eecce3ab410e03d746c11fe5deda6381d913641fbd8865ea9b", size = 177315, upload-time = "2026-02-25T13:17:51.315Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/02/4f53258f4fb2b88675246a022d1ed9f653d9129c0ddcc40f88479abde455/fastmcp-4.0.0.tar.gz", hash = "sha256:613d925f687609973575039afc6bd8874e60ab373e4f5b8c60f7860897063598", size = 42300863, upload-time = "2026-08-31T18:20:33.564Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b5/82f89307d0d769cd9bf46a54fb9136be08e4e57c5570ae421db4c9a2ba62/fakeredis-2.34.1-py3-none-any.whl", hash = "sha256:0107ec99d48913e7eec2a5e3e2403d1bd5f8aa6489d1a634571b975289c48f12", size = 122160, upload-time = "2026-02-25T13:17:49.701Z" },
-]
-
-[package.optional-dependencies]
-lua = [
-    { name = "lupa" },
+    { url = "https://files.pythonhosted.org/packages/24/6a/03160d06bcf2957caf02555d296b343136895e07a1160a6f4b85d0f672af/fastmcp-4.0.0-py3-none-any.whl", hash = "sha256:b041d669971f2325ab41797961bb4e729d1195d0da38d213bfbbcc6ddd65ca75", size = 8077, upload-time = "2026-08-31T18:20:31.342Z" },
 ]
 
 [[package]]
-name = "fastmcp"
-version = "2.14.7"
+name = "fastmcp-slim"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "mcp-types" },
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/b1/8abb7c56159cf817718c1fc6b4547fd0f35cb91f05659ffc1d4f5cee1198/fastmcp_slim-4.0.0.tar.gz", hash = "sha256:b6f78c26e369b4c29b485d7d7b662838d9631e765dc496b4560274762f144e6a", size = 683960, upload-time = "2026-08-31T18:20:09.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/4b/7bc65d74cc93684ec8b10d49a51fa14c5e4aa3a08120c7001a85bd2a159a/fastmcp_slim-4.0.0-py3-none-any.whl", hash = "sha256:75259ad8033af011f926f4b99cda9ce080b7853f9831d38f2056a392908e11c2", size = 857981, upload-time = "2026-08-31T18:20:07.951Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx2" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
-    { name = "fakeredis", extra = ["lua"] },
-    { name = "httpx" },
+    { name = "griffelib" },
+    { name = "httpx2" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
-    { name = "pydocket" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
-    { name = "rich" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "starlette" },
+    { name = "uncalled-for" },
     { name = "uvicorn" },
+    { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/c7/6b5202e427b87b14a34ef8b65eba0f5c60a8fbc71919e98a13d646b4a641/fastmcp-2.14.7.tar.gz", hash = "sha256:0d2e83b9d1c5fe0af32036979de3bb99a38f05dc1476d60f1b3259168e139cd0", size = 8296810, upload-time = "2026-04-13T01:12:53.098Z" }
+
+[[package]]
+name = "griffelib"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/a767e91c606deefc447a96eaf59edd77397960b1d677dffd833ee8449831/griffelib-2.2.0.tar.gz", hash = "sha256:e1bc36fe9cd21d4b6b659b456346755e4cfdc5676c0a5214083126ee12612b3c", size = 227048, upload-time = "2026-08-16T14:04:58.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/f1/56310847b0bdd5b14c2af8f0a39082af078deff60d0dc43efef4e366a83e/fastmcp-2.14.7-py3-none-any.whl", hash = "sha256:e081a5222a6d302a148871d89fd714b13130cee6594f53a3e1afd7518f0096c0", size = 418162, upload-time = "2026-04-13T01:12:51.325Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b6/f65ac785d4ac90dcf7c831ac6256f5dd4a19780f4e1575b2c0d6eeebe319/griffelib-2.2.0-py3-none-any.whl", hash = "sha256:d71c3bc2bbed9f958488634fe788b843a9f705d6d2838ca32cd6c25eeb64dfc4", size = 166779, upload-time = "2026-08-16T14:04:54.365Z" },
 ]
 
 [[package]]
@@ -533,49 +631,51 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
+    { name = "h11", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
     { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2-jsfetch"
+version = "1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -645,6 +745,18 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.7.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/94/80fea1514b7c6d7d37804d3fe9ca81455f633347fc98731bd71ffe1faa17/joserfc-1.7.5.tar.gz", hash = "sha256:d5ff536e658e17664f8c1b1ab60dc4aa62aa973fcef1edd33cc44bda45d6f5ea", size = 234990, upload-time = "2026-08-29T13:05:42.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/c5/82addfd375e5ee6520644e0553e4aadde92d668c4fc99cc716d337fe7bb3/joserfc-1.7.5-py3-none-any.whl", hash = "sha256:add2c2c84e8373b084d526a8b53daba5d7a513a118cd2dcd9fc9f979d0922159", size = 71269, upload-time = "2026-08-29T13:05:40.718Z" },
+]
+
+[[package]]
 name = "jsonref"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -710,67 +822,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
-]
-
-[[package]]
-name = "lupa"
-version = "2.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/a0/327c40cdd59f0ce9dc6faaf73bf6e52b0b22188f1ee2366ef36d0e5c1b85/lupa-2.7.tar.gz", hash = "sha256:73a64ce5dc8cd95b75a330c1513e46e098d40fceed3fea516c09f6595eade889", size = 8121014, upload-time = "2026-04-07T08:54:54.179Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/b7/18f7e66df0245cee685b22f458e9c614fdff9406aaf77a2e81b452a56da6/lupa-2.7-cp310-abi3-win32.whl", hash = "sha256:9992c5afa5adddabb953685b205cfd42cb6cdaf44316f4e4e2cf1c5dc4815f74", size = 1594773, upload-time = "2026-04-07T08:52:36.557Z" },
-    { url = "https://files.pythonhosted.org/packages/29/e5/390470a09b8972772f547b51c29baafd1708b20c46f92ac8c251d1db2fbf/lupa-2.7-cp310-abi3-win_arm64.whl", hash = "sha256:e353bad751b55d48d1b909a6b48fb5b306a2d6cd8404981a1554b356da2cf050", size = 1371622, upload-time = "2026-04-07T08:52:38.976Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/0c/6a9f5a7ffd0c286550ea18b136e51bf9bf757f9d2b01245b4aa93e4f37d2/lupa-2.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3b441227447001e2e4059fbe5cd0b4067a9af60bc77979eb9bad1b143b299c57", size = 1202624, upload-time = "2026-04-07T08:52:40.772Z" },
-    { url = "https://files.pythonhosted.org/packages/33/6a/9fb6e8f0dca122090d82696c1758864eb409a822bb4d135993481b522553/lupa-2.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d986b406df775b6f092b91f57bbf26df17f02ad0da11b37e0f66d45c011b26ad", size = 1857338, upload-time = "2026-04-07T08:52:43.082Z" },
-    { url = "https://files.pythonhosted.org/packages/36/d2/cd90b3f126766523ac4ef535739f9ca8838a1232d0df030492cdba22c785/lupa-2.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:65f8b89da2f3c85b8f5e33855f07a8db8eb8a04264d020850d59e04f3f0a9615", size = 2408778, upload-time = "2026-04-07T08:52:45.675Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/90/8cc64d5e5d4ff314a747f44017b4423749e6027c3aa2612f19be0c690c05/lupa-2.7-cp310-cp310-win_amd64.whl", hash = "sha256:bd7e295c1f56f02786dc935cac2892fca6e6cde2ace0eac08915297306053779", size = 1910270, upload-time = "2026-04-07T08:52:47.8Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/69/db7099ef820fdaa532edbbadb24fe47f114f2f53252fdd9872683cdd2e42/lupa-2.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4eff5282d76f57dc27067d1cfe668a40dc63c8d052004ee96831d4d8b15057d0", size = 1202264, upload-time = "2026-04-07T08:52:49.943Z" },
-    { url = "https://files.pythonhosted.org/packages/29/89/f4b2fa7eaee9810c5280b8f18f6c5640b2f434242ffb4f050e16a01f0ca7/lupa-2.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c30332ff60c6587dd4177d286516316e4fe63ef09bf4c25249c7e0d98f6100ff", size = 1839154, upload-time = "2026-04-07T08:52:52.346Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/e0/207c641774016a1b200b30c50cbcfea332536b412daad14778bba7ceea10/lupa-2.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51bbd28c639088028cbfa10aa001ea77b890609ab364fbd85d3fc36d3e0a6b0d", size = 2376138, upload-time = "2026-04-07T08:52:54.833Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c3/5ffe67670e34aad6792b9daa6f6ae2aa1188ea9b6d4e9a947425b5152aa8/lupa-2.7-cp311-cp311-win_amd64.whl", hash = "sha256:87358e2bfd630a3cac05bd376aba6ce6a67acd0df44970be6c25b9134d400d2e", size = 1923368, upload-time = "2026-04-07T08:52:56.743Z" },
-    { url = "https://files.pythonhosted.org/packages/58/b3/83836d5f3d4af2c135b12dd4483592c4064339b075158cbcc8fbfe5e239b/lupa-2.7-cp312-abi3-macosx_10_13_x86_64.whl", hash = "sha256:5bb4461f6127293c866819a22f39a3878d49314f4463b4adf45d3bf968d15c92", size = 1193921, upload-time = "2026-04-07T08:52:59.073Z" },
-    { url = "https://files.pythonhosted.org/packages/81/22/9b3db3535ec25f3e091ffd111b39e25a16bd17bcddea5e5a269075ec104d/lupa-2.7-cp312-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:9de6c9263a82bc4f0db73d0c8534bdb8a3a1fd13f448c967d7f3e085dbc50c05", size = 1434166, upload-time = "2026-04-07T08:53:01.119Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/b7/a7b8561ceefca78c6b38fcd2edd624dbbd66818d6a7cacdb49155745f44c/lupa-2.7-cp312-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:23915808a2475705582e7c8adc17fac5ca9f3a803be184798e06cbd8c7350580", size = 1149951, upload-time = "2026-04-07T08:53:02.814Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/1d/ae4f7cc90eb3e42021e0ca7ef5f4ce5e9894a3f46b47d3dfa40d9b749c94/lupa-2.7-cp312-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5f720ce493fa9049917954ae1270a5d3c41987f792e34a633f725fa0fc85781e", size = 1409419, upload-time = "2026-04-07T08:53:04.706Z" },
-    { url = "https://files.pythonhosted.org/packages/40/17/bd577543997b3e0b9f49525b4a9966817808048e34a30ca3e15939d9de40/lupa-2.7-cp312-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8046dedc75cbd93ee4ec01d3088511079425d9438ffddd7c0de8bac54db6701d", size = 1242571, upload-time = "2026-04-07T08:53:06.427Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/68/3e3c32342dfa906c9c3ab2a88084688c1e22f77be1cc4da44669faa071d3/lupa-2.7-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:319c02f8e4ec2dbdccb47bb3676a139f8634b255efafbb433a2c705e315fbb76", size = 1855925, upload-time = "2026-04-07T08:53:08.573Z" },
-    { url = "https://files.pythonhosted.org/packages/30/f5/c8a7a80dc6f31216fdce524089cea475af7ae1e6b28952fecba076d8a166/lupa-2.7-cp312-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9545a538067f517330faa56d59ff08b0c74910711597dcccc24ad71a97c9cb8c", size = 1128866, upload-time = "2026-04-07T08:53:10.848Z" },
-    { url = "https://files.pythonhosted.org/packages/64/fa/a9fe2aaf0605b5556ebb8539c19c023fdd3bc78a0d07811ceba27d3f18c8/lupa-2.7-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:90c0adf6519cac6f2ab1fc094e6ea40650198571e9aace52b8a7e69e316a2b89", size = 1457480, upload-time = "2026-04-07T08:53:13.228Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/c0/dd451cb97c52bcb69b8ecc1e92c87426dd88cb51e79d128accfda2b66949/lupa-2.7-cp312-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:ab47477a37c562c6512a222c0acaddb11d9d69ec16e50913214bc15b2ab3d8bc", size = 1425606, upload-time = "2026-04-07T08:53:14.835Z" },
-    { url = "https://files.pythonhosted.org/packages/31/67/af8600ce0268e675f7d23e970bb2a5f6c68a3686884ef2518c9d24c75379/lupa-2.7-cp312-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:4615785072c1185b0ed1caf0dea188abd7890667e730c6d6717d84b317d10e78", size = 1253143, upload-time = "2026-04-07T08:53:17.078Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/ec/5ba9bad40d46baebc2f85d22c21b44c1afa38363e00cf8f75ca2add07267/lupa-2.7-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d0bf6bd82d639d6cd527983ecff76450bc8878a75e4434c0fbde5edf16aa2bb4", size = 2395157, upload-time = "2026-04-07T08:53:19.409Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/84/69bbd0cba804e33761709775b769db54187003f98000350ae2807793821a/lupa-2.7-cp312-abi3-win32.whl", hash = "sha256:093e03d520d294a372f2521e5948b5660874c889f189f23b538d59fa1841c365", size = 1606024, upload-time = "2026-04-07T08:53:22.219Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/a1/4eee20d28e7170fb50e7b2389946e9b385b9e23c079391648ef7a7b3db10/lupa-2.7-cp312-abi3-win_arm64.whl", hash = "sha256:5b4630d86f3d97613f08cb0cb302ecb2a5266e67fbb2d50eb69ba69f259b5ee0", size = 1364378, upload-time = "2026-04-07T08:53:24.858Z" },
-    { url = "https://files.pythonhosted.org/packages/19/c0/8e70d5084e3b79f360df71251c61b9f46959c676131d93da25f67037b8e9/lupa-2.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7b9c1340029815952fd7ed1f788274659298a73aabd3573a4753d14b1a9162db", size = 1190006, upload-time = "2026-04-07T08:53:26.961Z" },
-    { url = "https://files.pythonhosted.org/packages/12/12/54642ea2fab032a6aba57317fb1087c144f2ddd56d671fc0c9140afbbd25/lupa-2.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ec34c94e25f1c4bd66c9be714ff72376e3da6d7918a8a037fc6ba82fb9822cb", size = 1812882, upload-time = "2026-04-07T08:53:29.151Z" },
-    { url = "https://files.pythonhosted.org/packages/34/ee/19eca26ea53a8b747560479db61837ea9b2c88d43ebde1112a2eff6edec4/lupa-2.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d1b05ef0c8075a1d5378f11998ddaa0f3af53b06970a337f3eb312ff837b7d94", size = 2368616, upload-time = "2026-04-07T08:53:32.351Z" },
-    { url = "https://files.pythonhosted.org/packages/90/51/974e7a2b40d331157f4102ed427f1ff64b95cbef6d91a65e3c01aca44681/lupa-2.7-cp312-cp312-win_amd64.whl", hash = "sha256:97376dbfaeecd8ee13ae08eaa18749c0e2142557552838d1da25c5102b22a504", size = 1941683, upload-time = "2026-04-07T08:53:35.292Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/1f/278709766ded94736d011239d6ece9f52e6621827f7d28f195f2a0574126/lupa-2.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d4d3cd6100dad6664992b60397a3d0731ffce663b966eaa0fdcb5cfcac26550b", size = 1201091, upload-time = "2026-04-07T08:53:38.075Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ac/b6b45ba0c5200f569c9571936e980a35d92aca878017e3a0dc9e48263084/lupa-2.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b1c56c56e8ce7dd5f4daf1e926942983c1b419ef81da2a51f5e5dc717f1b8da7", size = 1806093, upload-time = "2026-04-07T08:53:40.677Z" },
-    { url = "https://files.pythonhosted.org/packages/65/53/c20eda14f95f8a96123d627e06f7926fb4cc919c14b248a287f050eb242c/lupa-2.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:446b2245b2b6265d8340c13c4d80eb2f0bfd0d918d399aea1590d3f57f867a7e", size = 2358889, upload-time = "2026-04-07T08:53:43.625Z" },
-    { url = "https://files.pythonhosted.org/packages/de/1f/fe20ad87f791240f936d6ec762e3ce81ec8f0e71d1c2b2789e20b949eaab/lupa-2.7-cp313-cp313-win_amd64.whl", hash = "sha256:2a7ae5b9bd275221311c7993c8c8f4d21eafa4502826130e2bb85d46f6d9224e", size = 1936625, upload-time = "2026-04-07T08:53:46.089Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/01/198d43e8abee9febca7bbed5cbd2bbe471f4a08fd20860f5544fb5fcf782/lupa-2.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e1d832452975b2251bda891a12e5fc239151f347802fd2f6e2224b3adf5caf49", size = 1209249, upload-time = "2026-04-07T08:53:48.153Z" },
-    { url = "https://files.pythonhosted.org/packages/32/c4/433da832d0d1b551f8d699a23f63ee02203b13522e9956a18b19a4770b89/lupa-2.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4fbc5dfabab4ef6da94284db04132da1702696cbdb39b57e83e7e577c30d12e3", size = 1826708, upload-time = "2026-04-07T08:53:50.641Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/96/060b5e32c70af7a8b47c1ac8b497ade1817fada345f904edaafb28928894/lupa-2.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c8b7012f1389e7b8399edf7520e6f3aba1ff99d192b269ccd0a1c452d1fc2064", size = 2366778, upload-time = "2026-04-07T08:53:53.493Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/eb/05a4169973a4e9498268f66fcc778a56331b4fce94feb15b9b41a3f831ed/lupa-2.7-cp314-cp314-win_amd64.whl", hash = "sha256:a2de0c293cb0c67c38963b676017ed2e38c5b76254316e956451ca21589b44fe", size = 1994579, upload-time = "2026-04-07T08:54:05.849Z" },
-    { url = "https://files.pythonhosted.org/packages/13/f7/651916ffd568ac4261298fdcb64dd8213603ed22ebaab8541bb8114c73d9/lupa-2.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8e0fd2c9895e8a456f583ac05b210b406924cf25921a675c42b00806cb14a8f4", size = 1251117, upload-time = "2026-04-07T08:53:55.59Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e5/3b9aea6bad4141c9379f0612c94e7c465204d64738eca25fb03c688fab35/lupa-2.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4abb197d3adb7607651df03853c0f7656d23a8f6d91f43b72d8d7a1032c6e82", size = 1814587, upload-time = "2026-04-07T08:53:57.711Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/5d/6c31a442643ad5b3fb0fd74236fc4bdf835162e22686213ead92600c560e/lupa-2.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2dc4956154e0fb556f1b4d37f97ee83f8ab4288151172ebb869209fb1732070e", size = 2348299, upload-time = "2026-04-07T08:54:00.782Z" },
-    { url = "https://files.pythonhosted.org/packages/41/b2/2a18c34abf3e63daa539c29dcbf595de4c1fa482aa632b0045555df333c1/lupa-2.7-cp314-cp314t-win_amd64.whl", hash = "sha256:8e01cefd60857ab39a9fd648c594d9a77872f768d9411e3ba0d84373dafae8fc", size = 2209127, upload-time = "2026-04-07T08:54:03.795Z" },
-    { url = "https://files.pythonhosted.org/packages/78/c1/9976b81671b339196a69f4ee96a885864b96cf9541c6c1c76ce00cb08df4/lupa-2.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:10d679932e759d628cd9df56590d6e90dd81040d10552172d01b2419e8f16565", size = 1185876, upload-time = "2026-04-07T08:54:18.172Z" },
-    { url = "https://files.pythonhosted.org/packages/08/3e/17109c4f7e333205a08f01c2d3d4222c76ce6f8b6c72791a739b11c6f43a/lupa-2.7-cp39-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:aa5d3f540fed4534cac696d0a5ee6cb267180b45241501a43db5ca1699d46746", size = 1468828, upload-time = "2026-04-07T08:54:20.621Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/25/9bcbd18a5742d0b1b80b783548007dcc57d4159075ff35fd833bf53548a5/lupa-2.7-cp39-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:07f2cd100f7278888f23f79d7ad49f3544835501543fa65be74bc5bfd2369aea", size = 1172884, upload-time = "2026-04-07T08:54:22.544Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/3f/7e0a6660a84ae3b6d8f9834ff183d0522b123b3b2329f0343f52d469fd1a/lupa-2.7-cp39-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c98d4d085e438d5fcee10e555baf67bc84553417efbe1d163fcc152466696a69", size = 1449860, upload-time = "2026-04-07T08:54:24.954Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/18/66e5289a6d086235723fa7516049313eb994a5d6ead9eb8f7f7eb8523172/lupa-2.7-cp39-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3cd273b4fa9c0fcdaed0a541e37ced22117c7aeab8af14d75ece213ce4c37506", size = 1281828, upload-time = "2026-04-07T08:54:27.633Z" },
-    { url = "https://files.pythonhosted.org/packages/32/8f/5499f13dac1329a9759fd9344622656b3f00c52ea70f9be94de9fb273256/lupa-2.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:14b26aaa7f600c670eec2afeb5cf312cc398c0a1bd958f97f5328e8162d11f78", size = 1910337, upload-time = "2026-04-07T08:54:30.047Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/de/cb2dca1f39ada99f311e54f4ede0235ec47398b712482528fc64737df407/lupa-2.7-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:02e24aaf1bc55242fdd4dd6c6b556f927f1c2a7a669deb902d4d1e73d2c9d1d6", size = 1155434, upload-time = "2026-04-07T08:54:31.929Z" },
-    { url = "https://files.pythonhosted.org/packages/37/2a/8cfc3ae8ec1d474beaa07839b3e200ef0710f0439959cc91a97ef4e432f9/lupa-2.7-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:f810b920787dfb46b3bf3f54d370f2e3c78ea37db214954fc025d2d1e760eff7", size = 1489117, upload-time = "2026-04-07T08:54:33.901Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/28/4e4cbc45a36000a37a1109ce4c375a8621e9fa195e86ec1e228138e88a39/lupa-2.7-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:1129d12951c221941c471251ea478db6faa34175ffafadd3dca1f75c9d83e84a", size = 1466206, upload-time = "2026-04-07T08:54:35.865Z" },
-    { url = "https://files.pythonhosted.org/packages/42/89/6ed7cb2441213569d5732b9d2b955c4fb0484c94dbb875f3af502e083650/lupa-2.7-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:6dcf4cba4bb5936859a675bb22f0d9291914f3e2840366653eb829b7d8b3035d", size = 1288464, upload-time = "2026-04-07T08:54:37.763Z" },
-    { url = "https://files.pythonhosted.org/packages/14/77/5df2e2296eac345c6d391632b50138615cabc4834742acf82d318fe2f89b/lupa-2.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8f899ceacf2d38bdd4c54aa777cec4deafcc7a6b02a0aa65dbca96e57e11d260", size = 2444753, upload-time = "2026-04-07T08:54:39.785Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/25/d579f7a7c72c771845c886600915e96be31c7ce676258d2555fa46bfb372/lupa-2.7-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5e441dc3b09875d38a75cd9a98a6da5378a6fe6307a58b2307c1de33d481b5f", size = 1778393, upload-time = "2026-04-07T09:06:49.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/7d/fdb7d7c4e68e50f48031bbcd7b81114f62d7781c5fce7854f637142bb9b7/lupa-2.7-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00bfc3d78479d2ee16babba46c9566fbd942203fe7212538cf4412fd6c857cf7", size = 2300366, upload-time = "2026-04-07T09:06:52.466Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/7b/9c5e08bc09a10102f12d032e4c8f1d9bbb9c07a442866ed5ea0915ad4f96/lupa-2.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d794357fba342f3e2fb9145d0a21677a55f0d8dc285f629752942bd437d9f3ab", size = 1847339, upload-time = "2026-04-07T09:06:54.76Z" },
 ]
 
 [[package]]
@@ -843,15 +894,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -861,14 +912,14 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
 ]
 
 [[package]]
 name = "mcp-clickhouse"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
@@ -895,7 +946,7 @@ requires-dist = [
     { name = "cachetools", specifier = ">=5.5.0" },
     { name = "chdb", marker = "extra == 'chdb'", specifier = ">=3.3.0" },
     { name = "clickhouse-connect", specifier = ">=0.8.16" },
-    { name = "fastmcp", specifier = ">=2.12.3,<3.0.0" },
+    { name = "fastmcp", specifier = ">=4.0.0,<4.1.0" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -905,6 +956,19 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.31.0" },
 ]
 provides-extras = ["chdb", "dev"]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
+]
 
 [[package]]
 name = "mdurl"
@@ -998,7 +1062,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
@@ -1183,7 +1248,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -1252,15 +1318,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathvalidate"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1279,53 +1336,29 @@ wheels = [
 ]
 
 [[package]]
-name = "prometheus-client"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
-]
-
-[[package]]
 name = "py-key-value-aio"
-version = "0.3.0"
+version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
-    { name = "py-key-value-shared" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/ce/3136b771dddf5ac905cc193b461eb67967cf3979688c6696e1f2cdcde7ea/py_key_value_aio-0.3.0.tar.gz", hash = "sha256:858e852fcf6d696d231266da66042d3355a7f9871650415feef9fca7a6cd4155", size = 50801, upload-time = "2025-11-17T16:50:04.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e2/d689d922894a7ecde73b6daeaf9b13dab5aae06fe6aaaf7514722644d382/py_key_value_aio-0.4.5.tar.gz", hash = "sha256:c6563a2c6abe5da5e20f4f9e875c2a9b425a2244a54fadbf46cf140a9eea45d7", size = 107547, upload-time = "2026-05-27T16:37:08.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/10/72f6f213b8f0bce36eff21fda0a13271834e9eeff7f9609b01afdc253c79/py_key_value_aio-0.3.0-py3-none-any.whl", hash = "sha256:1c781915766078bfd608daa769fefb97e65d1d73746a3dfb640460e322071b64", size = 96342, upload-time = "2025-11-17T16:50:03.801Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/95/b8ba862968712caa12a19666175334fa979e1f198b896a430adb3bacfe87/py_key_value_aio-0.4.5-py3-none-any.whl", hash = "sha256:ab862adbcb8c72547d1c57821f22cbbb71ab86509039c96f36e914e0336c8dd7", size = 170005, upload-time = "2026-05-27T16:37:06.629Z" },
 ]
 
 [package.optional-dependencies]
-disk = [
-    { name = "diskcache" },
-    { name = "pathvalidate" },
+filetree = [
+    { name = "aiofile", version = "3.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "aiofile", version = "3.12.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "anyio" },
 ]
 keyring = [
     { name = "keyring" },
 ]
 memory = [
     { name = "cachetools" },
-]
-redis = [
-    { name = "redis" },
-]
-
-[[package]]
-name = "py-key-value-shared"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
 ]
 
 [[package]]
@@ -1545,32 +1578,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydocket"
-version = "0.18.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cloudpickle" },
-    { name = "cronsim" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "fakeredis", extra = ["lua"] },
-    { name = "opentelemetry-api" },
-    { name = "prometheus-client" },
-    { name = "py-key-value-aio", extra = ["memory", "redis"] },
-    { name = "python-json-logger" },
-    { name = "redis" },
-    { name = "rich" },
-    { name = "taskgroup", marker = "python_full_version < '3.11'" },
-    { name = "typer" },
-    { name = "typing-extensions" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-    { name = "uncalled-for" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/5f/82dde9fb6099b960a4203596d3b755d1bd2c0d0210fea104d015d6515d7f/pydocket-0.18.2.tar.gz", hash = "sha256:cc2051d15557f83bb164a83b0743fa9c12c2bfe9a9145cff3a5922b4935ce4f5", size = 354762, upload-time = "2026-03-10T13:09:22.52Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/cf/8c1b6340baf81d7f6c97fe0181bda7cfd500d5e33bf469fbffbdae07b3c9/pydocket-0.18.2-py3-none-any.whl", hash = "sha256:19e48de15e83370f750e362610b777533ff9c0fa48bf36766ed581f91d266556", size = 99041, upload-time = "2026-03-10T13:09:20.598Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1656,15 +1663,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
-name = "python-json-logger"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
 ]
 
 [[package]]
@@ -1778,18 +1776,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
-name = "redis"
-version = "7.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
 ]
 
 [[package]]
@@ -1993,15 +1979,6 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
 name = "simplejson"
 version = "4.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2086,15 +2063,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
-]
-
-[[package]]
 name = "sse-starlette"
 version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2118,19 +2086,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
-]
-
-[[package]]
-name = "taskgroup"
-version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b1/74babcc824a57904e919f3af16d86c08b524c0691504baf038ef2d7f655c/taskgroup-0.2.2-py2.py3-none-any.whl", hash = "sha256:e2c53121609f4ae97303e9ea1524304b4de6faf9eb2c9280c7f87976479a52fb", size = 14237, upload-time = "2025-01-03T09:24:11.41Z" },
 ]
 
 [[package]]
@@ -2197,21 +2152,6 @@ wheels = [
 ]
 
 [[package]]
-name = "typer"
-version = "0.24.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2243,11 +2183,11 @@ wheels = [
 
 [[package]]
 name = "uncalled-for"
-version = "0.3.1"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/68/35c1d87e608940badbcfeb630347aa0509897284684f61fab6423d02b253/uncalled_for-0.3.1.tar.gz", hash = "sha256:5e412ac6708f04b56bef5867b5dcf6690ebce4eb7316058d9c50787492bb4bca", size = 49693, upload-time = "2026-04-07T13:05:06.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5a/92ce0b3ea5481915f55da994c2c2c5f7a3c09949afde196ee89f8ab961aa/uncalled_for-0.4.0.tar.gz", hash = "sha256:335b95bd2422332ec210d518f314a16e4c640921c39fc8bf2ad095bd3538f4af", size = 56979, upload-time = "2026-08-10T14:51:46.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/e1/7ec67882ad8fc9f86384bef6421fa252c9cbe5744f8df6ce77afc9eca1f5/uncalled_for-0.3.1-py3-none-any.whl", hash = "sha256:074cdc92da8356278f93d0ded6f2a66dd883dbecaf9bc89437646ee2289cc200", size = 11361, upload-time = "2026-04-07T13:05:05.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/40/97cec87c077eb3291fc7905e6633e08b7ca593c57d30238444bcb6bb3d53/uncalled_for-0.4.0-py3-none-any.whl", hash = "sha256:16c4bb3337532e4bd5569adc192285976f3ad5305402256d34c67a12b5c968bd", size = 15502, upload-time = "2026-08-10T14:51:45.068Z" },
 ]
 
 [[package]]
@@ -2271,6 +2211,123 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/5a/2bf22ecb24916983bf1cc0095e7dea2741d14d6553b0d6a2ac8bc96eca93/watchfiles-1.2.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:bb68bf4df85abebe5efddc53cf2075520f243a59868d9b3973278b23e76962a9", size = 400471, upload-time = "2026-05-18T04:31:08.908Z" },
+    { url = "https://files.pythonhosted.org/packages/55/70/dea1f6a0e76607841a60fb51af150e70124864673f61704abb62b90cdcc7/watchfiles-1.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c16cb06dd17d43b9d185094268459eac92c9538356f050e55b54e82cf700e1d4", size = 394599, upload-time = "2026-05-18T04:30:19.845Z" },
+    { url = "https://files.pythonhosted.org/packages/18/52/752dcc7dc817baef5e89518732925795ce52e36a683a9a3c9fb68b21504e/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a0feab9af4c021c581f695258c642b3d10c5fd4c676e33a0d8606425d82631", size = 455458, upload-time = "2026-05-18T04:30:29.126Z" },
+    { url = "https://files.pythonhosted.org/packages/12/48/366ebbb22fcc504c2f72b45f0b7e72f40a18795cc01752c16066d597b67a/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a16ffe19bf5cf9f5edaa1ad1dd830c5a816e8feec430c522302ab55483a4b994", size = 460513, upload-time = "2026-05-18T04:31:40.85Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/44/1f9e1b15e7a729062e0d0c3d0d7225ea4ab98b2267ef87287153be2495fc/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:204f299afcbd65918ab78dbc52626b0ae45e9d8cef403fdbf33ecf9e40eac66e", size = 493616, upload-time = "2026-05-18T04:30:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/55/8b1086dcc8a1d6a697a62767bd7ea368e74c61c6fd171683cfe24a3fe5d2/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:11743adfa510bfffebe97659fb280182b5c9b238708f667e866f308c3430dc19", size = 573154, upload-time = "2026-05-18T04:30:37.903Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7a/242f400cc77fafa7b18d53d19d9cb64fc6a6f61f28c55913bae7c674d92a/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb72919d93e3a16fc451d3aa3d4b1698423daca1b382d3d959c9ac51297c12a8", size = 467046, upload-time = "2026-05-18T04:30:41.869Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c8/79eee650c62d2c186598489814468e389b5def0ebe755399ff645b35b1b2/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62f042afde2dde21ec1d2c1a74361e804673df86f51e418a999c9acfe671b07", size = 457100, upload-time = "2026-05-18T04:31:13.064Z" },
+    { url = "https://files.pythonhosted.org/packages/81/36/519f6dbb7a95e4fe7c1513ed25b1520295ef9905a27f1f2226a73892bfb7/watchfiles-1.2.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:027ae72bfdfd254862065d8b3e2a815c6ab9b1853ce41e6648ece84afd34a551", size = 467038, upload-time = "2026-05-18T04:30:32.915Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/12/951af6b9f89097e02511122258402cb3578443021930b70cf968d6310dc0/watchfiles-1.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e1cfd51e97e13ff3bd047c140764d277fc9b95b7cb5da59e46a47d167adab310", size = 632563, upload-time = "2026-05-18T04:30:11.539Z" },
+    { url = "https://files.pythonhosted.org/packages/28/cc/0cba1f0a6117b7ec117271bdc3cb3a5a252005959755a2c09a745e0942cc/watchfiles-1.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:24b2405c0a46738dd9e1cf7135aa5dbdb9d42d024628651b3b13d5117e99f8df", size = 660851, upload-time = "2026-05-18T04:31:53.186Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/26347558cc8bf6877845e66b315f644d03c173906aa09e233a3f4fd23928/watchfiles-1.2.0-cp310-cp310-win32.whl", hash = "sha256:8c520725602756229f045b032a1ff33d7ef0f7404189d62f6c2438cb6d8ef6a1", size = 277023, upload-time = "2026-05-18T04:30:18.825Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/68/a5e67b6b68e94f4c1511d61c46c55eba0737583620b6febf194c7b9cc23f/watchfiles-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:03b14855c6f35539e2d95c442ae9530a75762f1e26567152b9ed05f96534a74d", size = 290107, upload-time = "2026-05-18T04:32:09.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/3d/8024c801df84d1587740d0359e7fdd80afeae3d159011f3d5376dd82f18e/watchfiles-1.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:704fd259e332e01f9b9c178f4bce9e49027e5587cc2600eeeaf8e76e1c846201", size = 400242, upload-time = "2026-05-18T04:31:19.014Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/f4dfd45323e949984a3a7f9dc31d1cbb049921e7d98253488dda72ccdaa9/watchfiles-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6543cf55d170003296d185c0af981f3e1311564907e1f4e08671fc7693a890a5", size = 394562, upload-time = "2026-05-18T04:30:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d8/19483ef075d601c409bce8bcbb5c0f81a10876fff870400568f08ce484a1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d8c2394a065ca86f5d2910ff263ae67c127e1376ccc4f9fc35c71db879f80a", size = 456611, upload-time = "2026-05-18T04:30:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6a/cc81fbe7ee42f2f22e661a6e12def7807e01b14b2f39e0ff83fd373fd307/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:772b80df316480d894a0e3165fdd19cf77f5d17f9a787f94029465ad0e3529d1", size = 461379, upload-time = "2026-05-18T04:31:29.292Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/57/7e669002082c0a0f4fb5113bb70125f7110124b846b0a11bc5ae8e90eac1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d158cd89df6053823533e06fb1d73c549133bff5f0396170c0e53d9559340717", size = 493556, upload-time = "2026-05-18T04:30:05.44Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/f60a2b19807b21fe8281f3a8da4f59eef0d5f96825ac4680ba2d4f2ebf91/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d516b3283a758e087841aedb8031549fb41ced08f3db10aa6d2bf32dc042525b", size = 575255, upload-time = "2026-05-18T04:30:40.568Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/49/77f5b5e6efbcd57482f74948ebb1b97e5c0046d6b61475042d830c84b3ff/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53b2290c92e0506d102cd448fbc610d87079553f86caa39d67440856a8b8bba5", size = 467052, upload-time = "2026-05-18T04:31:17.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5a/73e2959af1b97fd5d556f9a8bdba017be23ceeef731869d5eaa0a753d5a3/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a711b51aec4370d0dcda5b6c09463206f133a5759341d7744b953a7b62e1100e", size = 456858, upload-time = "2026-05-18T04:30:30.182Z" },
+    { url = "https://files.pythonhosted.org/packages/50/57/1bc8c27fad7e6c19bddee15d276dbb6ab72480ec01c127afff1673aee417/watchfiles-1.2.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:e2ca07fa7d89195ec0865d3d285666286740bfa83d83e5cee204043a31ecc165", size = 467579, upload-time = "2026-05-18T04:32:15.897Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6c/3c2e44edba3553c5e3c3b8c8a2a6dee6b9e12ae2cf4bd2378bebf9dc3038/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e0618518f282c4ebff60f5e5b1247b6d91bb8b9f4476947563a1e74acc66f3c6", size = 633253, upload-time = "2026-05-18T04:31:37.123Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c2/d8c84a882ab39bbefcc4915ab3e91830b7a7e990c5570b0b69075aba3faf/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0d191c054d0715c3c95c99df9b8dbf6fd096d8c1e021e8f212e1bd8bc444ccb5", size = 660713, upload-time = "2026-05-18T04:31:24.62Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/07/f97736a5fc605364fe67b25e9fa4a6965dfd4840d50c406ada507e9d735f/watchfiles-1.2.0-cp311-cp311-win32.whl", hash = "sha256:9342472aff9b093c5acd4f6d8f70ae0937964ab56542502bcf5579782da69ae8", size = 277222, upload-time = "2026-05-18T04:31:21.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/99/2b04981977fc2608afd60360d928c6aecf6b950292ca221d98f4005f6694/watchfiles-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:dbd6c97045dad81227c8d040173da044c1de08de64a5ea8b555da4aee1d5fa22", size = 290274, upload-time = "2026-05-18T04:31:45.966Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/74/f7f58a7075ee9cf612b0cfcddb78b8cd8234f0742d6f0075cf0da2dde1c6/watchfiles-1.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:57a2d9fa4fb4c2ecae57b13dfff2c7ab53e21a2ba674fe9f05506680fcdcc0d7", size = 283460, upload-time = "2026-05-18T04:31:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f4/7513ef1e85fc4c6331b59479d6d72661fc391fbe543678052ac72c8b6c19/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4674d49eb94706dfe666c069fc0a1b646ffcf920473492e209f6d5f60d3f0cc2", size = 403050, upload-time = "2026-05-18T04:30:36.753Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0b/a54103cfd732bb703c7a749222011a0483ef3705948dae3b203158601119/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:094b9b70103d4e963499bdea001ee3c2697b144cd9ae6218a62c0f89ec9e31db", size = 396629, upload-time = "2026-05-18T04:32:03.268Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2c/73f31a3b893886206c3f54d73e8ad8dee58cdb2f69ad2622e0a8a9e07f4e/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0ef001f8c25ad0fa9529f914c1600647ecd0f542d11c19b7894768c67b6acb7", size = 457318, upload-time = "2026-05-18T04:31:01.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/45d021e4a5cc7b9dd567f7cbb06d3b75f751a690063fb6cc7ec60f4e46b7/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a88fc94e647bc4eec523f1caa540258eb71d14278b9daf72fa1e2658a98df0f0", size = 457771, upload-time = "2026-05-18T04:30:56.331Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Upgrade to FastMCP 4 and MCP SDK 2.1.1, adding MCP 2026-07-28 support but still retains legacy clients and deprecated SSE
- Preserve tool contracts, authentication, Host/Origin protection, and request-scoped configuration overrides
- Add FastMCP 2-compatible provider config with process-first, launch-independent `.env` handling
- Move metadata work off the event loop and strengthen pagination concurrency and retries
- Expand protocol, auth, SSE, security, state, and pagination coverage
- Update migration and security docs

Closes #218